### PR TITLE
Install SMT solvers for CI testing

### DIFF
--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/sh
+
+# https://docs.github.com/en/actions/creating-actions/developing-a-third-party-cli-action
+#
+
+echo "Install Z3"
+mkdir smt-solvers
+cd smt-solvers
+
+gh release download --skip-existing -p 'z3-*-x64-glibc-*.zip' -R Z3Prover/z3
+unzip -n z3*.zip
+
+Z3=$(readlink -f */bin/z3)
+chmod u+x $Z3
+echo "Z3 installed and added to path: $Z3"
+echo $(dirname $Z3) >> $GITHUB_PATH
+
+
+echo "Install CVC5"
+gh release download --skip-existing -p 'cvc5-Linux' -R cvc5/cvc5
+CVC5=$(readlink -f cvc5-Linux)
+chmod u+x $CVC5
+echo "CVC5 installed and added to path: CVC5"
+echo $(dirname $CVC5) >> $GITHUB_PATH
+
+echo "Check installation!"
+
+$Z3 --version
+
+$CVC5 --version

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -1,30 +1,73 @@
 #!/usr/bin/sh
 
-# https://docs.github.com/en/actions/creating-actions/developing-a-third-party-cli-action
-#
+## Weigl's little helper to download SMT-solvers. 
+# SPDX-License-Identifier: GPL-2.0-or-later
 
-echo "Install Z3"
+# This script is meant to be executed inside an Github Action to download the SMT-solver. 
+# It uses the Github cli tool "gh", which allows an easy access to the releases of a
+# repository, and to download it artifacts. 
+#
+# This script will always the latest uploaded artifact.
+#
+#
+# For performance, you should consider caching. This script skips downloading if files are present.
+
+
+## Github workflow commands
+#  Please have a look at https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+#  which explains a lot of workflow commands and special files in Github Actions. 
+
+
+## TODO 
+# It would be nice to convert it into a real! Github action, which can also exploit 
+# the API library of Github. A manual/tutorial is here:
+#
+# https://docs.github.com/en/actions/creating-actions/developing-a-third-party-cli-action
+
 mkdir smt-solvers
 cd smt-solvers
 
-gh release download --skip-existing -p 'z3-*-x64-glibc-*.zip' -R Z3Prover/z3
-unzip -n z3*.zip
+
+#################################################
+echo "::group::{install z3}"
+echo "Check for Z3, if present skip installation"
+
+if readlink -f */bin/z3; then 
+  echo "::notice::{Z3 found. Caching works! Skip installation}"
+else 
+  echo "Download Z3"
+  gh release download --skip-existing -p 'z3-*-x64-glibc-*.zip' -R Z3Prover/z3
+  unzip -n z3*.zip
+  rm z3-*-x64-glibc-*.zip  
+fi
 
 Z3=$(readlink -f */bin/z3)
 chmod u+x $Z3
-echo "Z3 installed and added to path: $Z3"
+echo "Z3 added to path: $Z3"
 echo $(dirname $Z3) >> $GITHUB_PATH
 
+echo "::endgroup::"
+#################################################
 
-echo "Install CVC5"
-gh release download --skip-existing -p 'cvc5-Linux' -R cvc5/cvc5
+#################################################
+echo "::group::{install cvc5}"
+if -f cvc5-Linux; then 
+  echo "::notice::{Z3 found. Caching works! Skip installation}"
+else 
+  echo "Install CVC5"
+  gh release download --skip-existing -p 'cvc5-Linux' -R cvc5/cvc5  
+fi 
+
 CVC5=$(readlink -f cvc5-Linux)
-chmod u+x $CVC5
 echo "CVC5 installed and added to path: CVC5"
+chmod u+x $CVC5
 echo $(dirname $CVC5) >> $GITHUB_PATH
 
-echo "Check installation!"
+echo "::endgroup::"
+#################################################
 
+echo "::group::{check installation/versions}"
 $Z3 --version
 
 $CVC5 --version
+echo "::endgroup::"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.os }}
     env:
-      SONAR_SCANNER_OPTS: -Xmx12G
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
@@ -32,6 +32,16 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+
+      - name: Cache SMT-Solvers
+        id: smt-solvers
+        uses: actions/cache@v3
+        with:
+          path: smt-solvers
+          key: ${{ runner.os }}-smt-solvers
+
+      - name: Install SMT-Solvers
+        run: .github/dlsmt.sh
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.3.3
@@ -46,6 +56,8 @@ jobs:
           path: "**/build/test-results/*/*.xml"
 
   integration-tests:
+    env:
+      GH_TOKEN: ${{ github.token }}
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -61,6 +73,16 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+
+      - name: Cache SMT-Solvers
+        id: smt-solvers
+        uses: actions/cache@v3
+        with:
+          path: smt-solvers
+          key: ${{ runner.os }}-smt-solvers
+
+      - name: Install SMT-Solvers
+        run: .github/dlsmt.sh
 
       - name: "Running tests: ${{ matrix.test }}"
         uses: gradle/gradle-build-action@v2.3.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,16 +33,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
-      - name: Cache SMT-Solvers
-        id: smt-solvers
-        uses: actions/cache@v3
-        with:
-          path: smt-solvers
-          key: ${{ runner.os }}-smt-solvers
-
-      - name: Install SMT-Solvers
-        run: .github/dlsmt.sh
-
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.3.3
         with:


### PR DESCRIPTION
Currently, no SMT-solver is available during the CI build and test. 

This MR brings a small bash scripts, which download and "install" z3 and CVC5. Both SMT-solvers should be available via `$PATH`. Caching is activated. 

The script uses the `gh`, the cli application for/from Github, to download the latest releases.
