### PR TITLE
Issues misconfigured

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: FAQ
-    url: https://key-project.org/docs/faq
+    url: https://www.key-project.org/docs/user/FAQ/
     about: Documentation 
   - name: KeY Discussions
     url: https://github.com/keyproject/key/discussions


### PR DESCRIPTION
Due to missing issue templates and misconfiguration, nobody can currently create an issue. 

This commit fixes this, and also repairs the link to the FAQs.