### PR TITLE
Fix use of unsupported string templates

### DIFF
--- a/key.util/src/main/java/org/key_project/util/helper/FindResources.java
+++ b/key.util/src/main/java/org/key_project/util/helper/FindResources.java
@@ -56,7 +56,7 @@ public final class FindResources {
             Path dir = fs.getPath(path);
             return Files.list(dir).collect(Collectors.toList());
         }
-        throw new UnsupportedOperationException("Cannot list files for URL $dirURL");
+        throw new UnsupportedOperationException("Cannot list files for URL \"" + dirURL + "\"");
     }
 
     public static <T> List<Path> getResources(String path) throws URISyntaxException, IOException {
@@ -90,7 +90,7 @@ public final class FindResources {
             Path dir = fs.getPath(path);
             return dir;
         }
-        throw new UnsupportedOperationException("Cannot list files for URL $dirURL");
+        throw new UnsupportedOperationException("Cannot list files for URL \"" + dirURL + "\"");
     }
 
     public static <T> Path getResource(String path) throws URISyntaxException, IOException {

--- a/key.util/src/main/java/org/key_project/util/lookup/Lookup.java
+++ b/key.util/src/main/java/org/key_project/util/lookup/Lookup.java
@@ -86,7 +86,7 @@ public class Lookup {
             if (parent != null)
                 return parent.get(service);
             else
-                throw new IllegalStateException("Service $service not registered");
+                throw new IllegalStateException("Service \"" + service + "\" not registered");
         } else {
             return t.get(0);
         }


### PR DESCRIPTION
Java (as opposed to Groovy and Kotlin) does not support string templates of the form "$variable". Attempting to use the feature anyway results in a string which literally contains the text "$variable".

See JEP 430: https://openjdk.org/jeps/430