### PR TITLE
Proof tree view: Multiple small changes for readability

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/PrettyPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/PrettyPrinter.java
@@ -2914,7 +2914,10 @@ public class PrettyPrinter {
 
     public void printCatch(Catch x) throws java.io.IOException {
         printHeader(x);
+        boolean oldLineFeed = noLinefeed;
+        noLinefeed = true;
         writeToken("catch", x);
+        noLinefeed = oldLineFeed;
         write(" (");
         if (x.getParameterDeclaration() != null) {
             noLinefeed = true;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/statement/JmlAssert.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/statement/JmlAssert.java
@@ -90,7 +90,7 @@ public class JmlAssert extends JavaStatement {
      */
     public String getConditionText() {
         if (cond != null) {
-            return LogicPrinter.quickPrintTerm(cond, services);
+            return LogicPrinter.quickPrintTerm(cond, services).trim();
         }
         // this will lose whitespace, so e.g. \forall will not be printed correctly
         // but normally the term form should get printed.

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -134,8 +134,9 @@ public class IntermediateProofReplayer {
         // initialize progress monitoring
         int stepIndex = 0;
         int reportInterval = 1;
+        int max = 0;
         if (listener != null && progressMonitor != null) {
-            int max = !queue.isEmpty() && queue.peekFirst().second != null
+            max = !queue.isEmpty() && queue.peekFirst().second != null
                     ? queue.peekFirst().second.countAllChildren()
                     : 1;
             listener.reportStatus(this, "Replaying proof", max);
@@ -343,6 +344,9 @@ public class IntermediateProofReplayer {
             }
         }
 
+        if (listener != null && progressMonitor != null) {
+            progressMonitor.setProgress(max);
+        }
         return new Result(status, errors, currGoal);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
@@ -241,10 +241,6 @@ public final class ExampleChooser extends JDialog {
         exampleList.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                // select closest tree entry to ensure that double clicks
-                // always open the entry the double click was performed on
-                TreePath closest = exampleList.getClosestPathForLocation(e.getX(), e.getY());
-                exampleList.setSelectionPath(closest);
                 if (e.getClickCount() == 2) {
                     loadButton.doClick();
                 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
@@ -241,9 +241,14 @@ public final class ExampleChooser extends JDialog {
         exampleList.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2) {
-                    loadButton.doClick();
+                // row is -1 when the user does not click on an entry but on the background
+                int row = exampleList.getRowForLocation(e.getX(), e.getY());
+
+                // Check that it is a double click on an item, not a folder or the background
+                if (e.getClickCount() != 2 || row == -1 || selectedExample == null) {
+                    return;
                 }
+                loadButton.doClick();
             }
         });
         final JScrollPane exampleScrollPane = new JScrollPane(exampleList);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
@@ -10,6 +10,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 
+import javax.annotation.Nonnull;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -133,11 +134,11 @@ public abstract class SearchBar extends JPanel {
     /*
      * The boolean return value of this function indicates, whether search was successful or not.
      */
-    public abstract boolean search(String s);
+    public abstract boolean search(@Nonnull String s);
 
     public void search() {
-        boolean b = search(searchField.getText());
-        if (b) {
+        boolean match = search(searchField.getText());
+        if (match) {
             searchField.setBackground(Color.WHITE);
         } else {
             searchField.setBackground(ALERT_COLOR.get());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -294,8 +294,8 @@ public final class IconFactory {
         return scaleIcon(keyHole, x, y);
     }
 
-    public static Icon keyHoleClosed(int x) {
-        return GOAL_CLOSED.load(x);
+    public static Icon keyHoleClosed(int height) {
+        return GOAL_CLOSED.load(height);
         // return scaleIcon(GOAL_CLOSED, x, y);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentViewSearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentViewSearchBar.java
@@ -6,6 +6,7 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.pp.*;
 import de.uka.ilkd.key.util.Pair;
 
+import javax.annotation.Nonnull;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ItemEvent;
@@ -171,7 +172,7 @@ public class SequentViewSearchBar extends SearchBar {
      * searches for the occurrence of the specified string
      */
     @Override
-    public boolean search(String search) {
+    public boolean search(@Nonnull String search) {
         clearSearchResults();
 
         if (sequentView.getFilter() instanceof SearchSequentPrintFilter) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIAbstractTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIAbstractTreeNode.java
@@ -5,6 +5,7 @@ import java.lang.ref.WeakReference;
 import java.util.Enumeration;
 import java.util.LinkedList;
 
+import javax.annotation.Nonnull;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.proof.Node;
@@ -36,6 +37,8 @@ public abstract class GUIAbstractTreeNode implements TreeNode {
     public abstract boolean isLeaf();
 
     public abstract void flushCache();
+
+    public abstract @Nonnull String getSearchString();
 
     public int getIndex(TreeNode node) {
         for (int i = 0; i < getChildCount(); i++) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
@@ -3,6 +3,7 @@ package de.uka.ilkd.key.gui.prooftree;
  * this class implements a TreeModel that can be displayed using the JTree class framework
  */
 
+import javax.annotation.Nonnull;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.proof.Node;
@@ -70,6 +71,12 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
     @Override
     public void flushCache() {
         childrenCache = null;
+    }
+
+    @Nonnull
+    @Override
+    public String getSearchString() {
+        return toString();
     }
 
     public int getChildCount() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
@@ -1,5 +1,6 @@
 package de.uka.ilkd.key.gui.prooftree;
 
+import javax.annotation.Nonnull;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.java.Services;
@@ -56,5 +57,11 @@ public class GUIOneStepChildTreeNode extends GUIAbstractTreeNode {
     @Override
     public void flushCache() {
         // nothing to do
+    }
+
+    @Nonnull
+    @Override
+    public String getSearchString() {
+        return toString();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
@@ -1,11 +1,11 @@
 package de.uka.ilkd.key.gui.prooftree;
 
-import javax.annotation.Nonnull;
-import javax.swing.tree.TreeNode;
-
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.rule.RuleApp;
+
+import javax.annotation.Nonnull;
+import javax.swing.tree.TreeNode;
 
 /**
  * A special kind of gui proof tree node to show intermediate intermediate steps of the
@@ -52,6 +52,10 @@ public class GUIOneStepChildTreeNode extends GUIAbstractTreeNode {
         String prettySubTerm =
             LogicPrinter.quickPrintTerm(app.posInOccurrence().subTerm(), services);
         return app.rule().name() + " ON " + prettySubTerm;
+    }
+
+    public RuleApp getRuleApp() {
+        return app;
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeNode.java
@@ -3,6 +3,7 @@ package de.uka.ilkd.key.gui.prooftree;
  * this class implements a TreeModel that can be displayed using the JTree class framework
  */
 
+import javax.annotation.Nonnull;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.proof.Node;
@@ -82,5 +83,11 @@ class GUIProofTreeNode extends GUIAbstractTreeNode {
     @Override
     public void flushCache() {
         children = null;
+    }
+
+    @Nonnull
+    @Override
+    public String getSearchString() {
+        return toString();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
@@ -1,15 +1,14 @@
 package de.uka.ilkd.key.gui.prooftree;
 
-import java.util.Vector;
+import de.uka.ilkd.key.gui.SearchBar;
+import de.uka.ilkd.key.util.Pair;
 
-import javax.swing.event.DocumentEvent;
+import javax.annotation.Nonnull;
 import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 import javax.swing.text.Position;
 import javax.swing.tree.TreePath;
-
-import de.uka.ilkd.key.gui.SearchBar;
-import de.uka.ilkd.key.util.Pair;
+import java.util.Vector;
 
 class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
 
@@ -44,7 +43,8 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
         search(searchField.getText(), Position.Bias.Backward);
     }
 
-    public boolean search(String searchString) {
+    public boolean search(@Nonnull String searchString) {
+        fillCache();
         return search(searchString, Position.Bias.Forward);
     }
 
@@ -65,7 +65,7 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
             this.proofTreeView.delegateView.scrollPathToVisible(tp);
             this.proofTreeView.delegateView.setSelectionPath(tp);
         }
-        return (currentRow != -1);
+        return currentRow != -1;
     }
 
     public void treeNodesChanged(TreeModelEvent e) {
@@ -116,7 +116,7 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
         }
     }
 
-    private int getNextMatch(String searchString, int startingRow, Position.Bias bias) {
+    private int getNextMatch(@Nonnull String searchString, int startingRow, Position.Bias bias) {
         String s = searchString.toLowerCase();
 
         if (bias == Position.Bias.Forward) {
@@ -152,7 +152,7 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
      * @param searchString the String to be looked for
      * @return true if a match has been found
      */
-    private boolean nodeContainsString(int node, String searchString) {
+    private boolean nodeContainsString(int node, @Nonnull String searchString) {
         return cache.get(node).second.contains(searchString);
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -908,22 +908,18 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 if (goal == null || leaf.isClosed()) {
                     style.foreground = DARK_GREEN_COLOR.get();
                     style.icon = IconFactory.keyHoleClosed(iconHeight);
-                    ProofTreeView.this.setToolTipText("Closed Goal");
                     toolTipText = "A closed goal";
                 } else if (goal.isLinked()) {
                     style.foreground = PINK_COLOR.get();
                     style.icon = IconFactory.keyHoleLinked(20, 20);
-                    ProofTreeView.this.setToolTipText("Linked Goal");
                     toolTipText = "Linked goal - no automatic rule application";
                 } else if (!goal.isAutomatic()) {
                     style.foreground = ORANGE_COLOR.get();
                     style.icon = IconFactory.keyHoleInteractive(20, 20);
-                    ProofTreeView.this.setToolTipText("Disabled Goal");
                     toolTipText = "Interactive goal - no automatic rule application";
                 } else {
                     style.foreground = DARK_RED_COLOR.get();
                     style.icon = IconFactory.keyHole(20, 20);
-                    ProofTreeView.this.setToolTipText("Open Goal");
                     toolTipText = "An open goal";
                 }
                 if (notes != null) {
@@ -939,11 +935,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
             if (node.leaf() || treeNode instanceof GUIBranchNode)
                 return;
             style.foreground = Color.black;
-            String tooltipText = "An inner node of the proof";
+            String tooltipText = "";
             final String notes = node.getNodeInfo().getNotes();
 
             if (notes != null) {
-                tooltipText += ".\nNotes: " + notes;
+                tooltipText += "Notes: " + notes;
             }
 
             Icon defaultIcon;
@@ -961,7 +957,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             boolean isBranch = false;
             final Node child = treeNode.findChild(node);
-            if (child != null && child.getNodeInfo().getBranchLabel() != null) {
+            if (!(treeNode instanceof GUIOneStepChildTreeNode) && child != null && child.getNodeInfo().getBranchLabel() != null) {
                 isBranch = true;
                 style.text = style.text + ": " + child.getNodeInfo().getBranchLabel();
             }
@@ -970,7 +966,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 tooltipText = "A branch node with all children hidden";
             }
             style.icon = defaultIcon;
-            style.tooltip = tooltipText;
+            style.tooltip = tooltipText.isEmpty() ? null : tooltipText;
         }
 
         private void checkNotes(Style style, GUIAbstractTreeNode treeNode) {
@@ -990,7 +986,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
             if (node instanceof GUIOneStepChildTreeNode) {
                 style.foreground = GRAY_COLOR.get();
                 style.icon = IconFactory.oneStepSimplifier(16);
-                style.text = node.toString();
             }
         }
 
@@ -1008,8 +1003,9 @@ public class ProofTreeView extends JPanel implements TabPanel {
             Style style = new Style();
             style.foreground = getForeground();
             style.background = getBackground();
+            style.text = getText();
             style.border = null;
-            style.tooltip = "";
+            style.tooltip = null;
             style.icon = null;
 
             stylers.forEach(it -> it.style(style, (GUIAbstractTreeNode) value));
@@ -1026,6 +1022,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             setFont(getFont().deriveFont(Font.PLAIN));
             setToolTipText(style.tooltip);
+            setText(style.text);
             setIcon(style.icon);
 
             return this;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -5,7 +5,9 @@ import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.core.KeYSelectionEvent;
 import de.uka.ilkd.key.core.KeYSelectionListener;
-import de.uka.ilkd.key.gui.*;
+import de.uka.ilkd.key.gui.GUIListener;
+import de.uka.ilkd.key.gui.NodeInfoVisualizer;
+import de.uka.ilkd.key.gui.NodeInfoVisualizerListener;
 import de.uka.ilkd.key.gui.colors.ColorSettings;
 import de.uka.ilkd.key.gui.configuration.Config;
 import de.uka.ilkd.key.gui.configuration.ConfigChangeListener;
@@ -32,19 +34,13 @@ import java.awt.event.*;
 import java.util.List;
 import java.util.*;
 
-import static de.uka.ilkd.key.gui.prooftree.Style.*;
-
 public class ProofTreeView extends JPanel implements TabPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofTreeView.class);
 
     public static final ColorSettings.ColorProperty GRAY_COLOR =
         ColorSettings.define("[proofTree]gray", "", Color.DARK_GRAY);
-    public static final ColorSettings.ColorProperty BISQUE_COLOR =
-        ColorSettings.define("[proofTree]bisque", "", new Color(240, 228, 196));
     public static final ColorSettings.ColorProperty LIGHT_BLUE_COLOR =
         ColorSettings.define("[proofTree]lightBlue", "", new Color(230, 254, 255));
-    public static final ColorSettings.ColorProperty DARK_BLUE_COLOR =
-        ColorSettings.define("[proofTree]darkBlue", "", new Color(31, 77, 153));
     public static final ColorSettings.ColorProperty DARK_GREEN_COLOR =
         ColorSettings.define("[proofTree]darkGreen", "", new Color(0, 128, 51));
     public static final ColorSettings.ColorProperty DARK_RED_COLOR =
@@ -96,9 +92,9 @@ public class ProofTreeView extends JPanel implements TabPanel {
     /**
      * listener
      */
-    private GUIProofTreeProofListener proofListener;
-    private GUITreeSelectionListener treeSelectionListener;
-    private GUIProofTreeGUIListener guiListener;
+    private final GUIProofTreeProofListener proofListener;
+    private final GUITreeSelectionListener treeSelectionListener;
+    private final GUIProofTreeGUIListener guiListener;
 
     /**
      * Updates relevant nodes in the proof tree whenever a {@link NodeInfoVisualizer} is opened or
@@ -134,7 +130,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
     /**
      * the search dialog
      */
-    private ProofTreeSearchBar proofTreeSearchPanel;
+    private final ProofTreeSearchBar proofTreeSearchPanel;
 
     private int iconHeight = 12;
 
@@ -569,7 +565,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
     @Override
     public Icon getIcon() {
-        return IconFactory.PROOF_TREE.get(MainWindowTabbedPane.TAB_ICON_SIZE);
+        return IconFactory.PROOF_TREE.get(IconFactory.DEFAULT_SIZE);
     }
 
     @Nonnull
@@ -865,10 +861,10 @@ public class ProofTreeView extends JPanel implements TabPanel {
             try {
                 GUIBranchNode node = ((GUIBranchNode) treeNode);
 
-                style.set(KEY_ICON, getIcon());
+                style.icon = getIcon();
                 if (node.isClosed()) {
                     // all goals below this node are closed
-                    style.set(KEY_ICON, IconFactory.provedFolderIcon(iconHeight));
+                    style.icon = IconFactory.provedFolderIcon(iconHeight);
                 } else {
                     // Find leaf goal for node and check whether this is a linked goal.
 
@@ -893,7 +889,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                     FindGoalVisitor v = new FindGoalVisitor();
                     proof.breadthFirstSearch(node.getNode(), v);
                     if (v.isLinked()) {
-                        style.set(KEY_ICON, IconFactory.linkedFolderIcon(iconHeight));
+                        style.icon = IconFactory.linkedFolderIcon(iconHeight);
                     }
                 }
             } catch (ClassCastException ignored) {
@@ -910,30 +906,30 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 final String notes = leaf.getNodeInfo().getNotes();
 
                 if (goal == null || leaf.isClosed()) {
-                    style.setAndSeal(KEY_COLOR_FOREGROUND, DARK_GREEN_COLOR.get());
-                    style.set(KEY_ICON, IconFactory.keyHoleClosed(iconHeight));
+                    style.foreground = DARK_GREEN_COLOR.get();
+                    style.icon = IconFactory.keyHoleClosed(iconHeight);
                     ProofTreeView.this.setToolTipText("Closed Goal");
                     toolTipText = "A closed goal";
                 } else if (goal.isLinked()) {
-                    style.set(KEY_COLOR_FOREGROUND, PINK_COLOR.get());
-                    style.set(KEY_ICON, IconFactory.keyHoleLinked(20, 20));
+                    style.foreground = PINK_COLOR.get();
+                    style.icon = IconFactory.keyHoleLinked(20, 20);
                     ProofTreeView.this.setToolTipText("Linked Goal");
                     toolTipText = "Linked goal - no automatic rule application";
                 } else if (!goal.isAutomatic()) {
-                    style.set(KEY_COLOR_FOREGROUND, ORANGE_COLOR.get());
-                    style.set(KEY_ICON, IconFactory.keyHoleInteractive(20, 20));
+                    style.foreground = ORANGE_COLOR.get();
+                    style.icon = IconFactory.keyHoleInteractive(20, 20);
                     ProofTreeView.this.setToolTipText("Disabled Goal");
                     toolTipText = "Interactive goal - no automatic rule application";
                 } else {
-                    style.setAndSeal(KEY_COLOR_FOREGROUND, DARK_RED_COLOR.get());
-                    style.set(KEY_ICON, IconFactory.keyHole(20, 20));
+                    style.foreground = DARK_RED_COLOR.get();
+                    style.icon = IconFactory.keyHole(20, 20);
                     ProofTreeView.this.setToolTipText("Open Goal");
                     toolTipText = "An open goal";
                 }
                 if (notes != null) {
                     toolTipText += ".\nNotes: " + notes;
                 }
-                style.set(KEY_TOOLTIP, toolTipText);
+                style.tooltip = toolTipText;
             } catch (ClassCastException ignored) {
             }
         }
@@ -942,7 +938,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             Node node = treeNode.getNode();
             if (node.leaf() || treeNode instanceof GUIBranchNode)
                 return;
-            style.set(KEY_COLOR_FOREGROUND, Color.black);
+            style.foreground = Color.black;
             String tooltipText = "An inner node of the proof";
             final String notes = node.getNodeInfo().getNotes();
 
@@ -967,36 +963,34 @@ public class ProofTreeView extends JPanel implements TabPanel {
             final Node child = treeNode.findChild(node);
             if (child != null && child.getNodeInfo().getBranchLabel() != null) {
                 isBranch = true;
-                style.set(KEY_TEXT,
-                    style.get(KEY_TEXT) + ": " + child.getNodeInfo().getBranchLabel());
+                style.text = style.text + ": " + child.getNodeInfo().getBranchLabel();
             }
             if (isBranch && node.childrenCount() > 1) {
                 defaultIcon = getOpenIcon();
                 tooltipText = "A branch node with all children hidden";
             }
-            style.set(KEY_ICON, defaultIcon);
-            style.set(KEY_TOOLTIP, tooltipText);
+            style.icon = defaultIcon;
+            style.tooltip = tooltipText;
         }
 
         private void checkNotes(Style style, GUIAbstractTreeNode treeNode) {
             Node node = treeNode.getNode();
             if (node.getNodeInfo().getNotes() != null) {
-                style.set(Style.KEY_COLOR_BACKGROUND, ORANGE_COLOR.get());
+                style.background = ORANGE_COLOR.get();
             } else {
                 if (node.getNodeInfo().getActiveStatement() != null) {
-                    style.set(Style.KEY_COLOR_BACKGROUND, LIGHT_BLUE_COLOR.get());
+                    style.background = LIGHT_BLUE_COLOR.get();
                 } else {
-                    style.set(Style.KEY_COLOR_BACKGROUND, Color.white);
+                    style.background = Color.white;
                 }
             }
         }
 
-
         private void oneStepSimplification(Style style, GUIAbstractTreeNode node) {
             if (node instanceof GUIOneStepChildTreeNode) {
-                style.set(KEY_COLOR_FOREGROUND, GRAY_COLOR.get());
-                style.set(KEY_ICON, IconFactory.oneStepSimplifier(16));
-                style.set(KEY_TEXT, node.toString());
+                style.foreground = GRAY_COLOR.get();
+                style.icon = IconFactory.oneStepSimplifier(16);
+                style.text = node.toString();
             }
         }
 
@@ -1012,32 +1006,27 @@ public class ProofTreeView extends JPanel implements TabPanel {
             super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
 
             Style style = new Style();
-            style.set(KEY_COLOR_FOREGROUND, getForeground());
-            style.set(KEY_COLOR_BACKGROUND, getBackground());
-            style.set(KEY_COLOR_BORDER, Color.WHITE);
-            style.set(KEY_FONT_BOLD, false);
-            style.set(KEY_FONT_ITALIC, false);
-            style.set(KEY_TOOLTIP, "");
-            style.set(KEY_ICON, null);
+            style.foreground = getForeground();
+            style.background = getBackground();
+            style.border = null;
+            style.tooltip = "";
+            style.icon = null;
 
             stylers.forEach(it -> it.style(style, (GUIAbstractTreeNode) value));
 
-            setForeground(style.get(KEY_COLOR_FOREGROUND));
-            setBackground(style.get(KEY_COLOR_BACKGROUND));
+            setForeground(style.foreground);
+            setBackground(style.background);
 
-            if (style.get(KEY_COLOR_BORDER) != null) {
-                setBorder(BorderFactory.createLineBorder(style.get(KEY_COLOR_BORDER)));
+            if (style.border != null) {
+                setBorder(BorderFactory.createLineBorder(style.border));
             } else {
                 // set default
                 setBorder(BorderFactory.createLineBorder(Color.WHITE));
             }
 
-            int fontStyle = (style.getBoolean(KEY_FONT_BOLD) ? Font.BOLD : Font.PLAIN)
-                    | (style.getBoolean(KEY_FONT_ITALIC) ? Font.ITALIC : Font.PLAIN);
-
-            setFont(getFont().deriveFont(fontStyle));
-            setToolTipText(style.get(KEY_TOOLTIP));
-            setIcon(style.get(KEY_ICON));
+            setFont(getFont().deriveFont(Font.PLAIN));
+            setToolTipText(style.tooltip);
+            setIcon(style.icon);
 
             return this;
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -850,7 +850,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
     private static String renderTooltip(Style.Tooltip tooltip) {
         boolean titleEmpty = tooltip.title == null || tooltip.title.isEmpty();
         boolean notesEmpty = tooltip.notes == null || tooltip.notes.isEmpty();
-        boolean additionalInfoEmpty = tooltip.additionalInfo == null || tooltip.additionalInfo.isEmpty();
+        boolean additionalInfoEmpty =
+            tooltip.additionalInfo == null || tooltip.additionalInfo.isEmpty();
         if (titleEmpty && notesEmpty && additionalInfoEmpty) {
             return tooltip.title;
         }
@@ -984,7 +985,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             boolean isBranch = false;
             final Node child = treeNode.findChild(node);
-            if (!(treeNode instanceof GUIOneStepChildTreeNode) && child != null && child.getNodeInfo().getBranchLabel() != null) {
+            if (!(treeNode instanceof GUIOneStepChildTreeNode) && child != null
+                    && child.getNodeInfo().getBranchLabel() != null) {
                 isBranch = true;
                 style.text = style.text + ": " + child.getNodeInfo().getBranchLabel();
             }
@@ -997,7 +999,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
             var text = style.text;
             // Elide text and move it to additional info
             // This does not influence the search since it does not use the text
-            if (style.tooltip.additionalInfo.isEmpty() && text.length() > 60 && treeNode instanceof GUIProofTreeNode) {
+            if (style.tooltip.additionalInfo.isEmpty() && text.length() > 60
+                    && treeNode instanceof GUIProofTreeNode) {
                 style.text = text.substring(0, 60) + "...";
                 // This should only happen if node.name() uses the active statement
                 // Pretty print it to make it readable
@@ -1010,9 +1013,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
                     try {
                         active.prettyPrint(printer);
                         info = writer.toString().trim();
-                    } catch (IOException ignored) {}
+                    } catch (IOException ignored) {
+                    }
                 }
-                style.tooltip.additionalInfo = "Applied on:\n" + (info == null ? node.name() : info);
+                style.tooltip.additionalInfo =
+                    "Applied on:\n" + (info == null ? node.name() : info);
             }
         }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -12,7 +12,7 @@ public class Style {
     public String text;
 
     /** the tooltip */
-    public String tooltip;
+    public Tooltip tooltip;
 
     /** foreground color of the node */
     public Color foreground;
@@ -25,4 +25,10 @@ public class Style {
 
     /** icon of the node */
     public Icon icon;
+
+    public static class Tooltip {
+        public String title = "";
+        public String notes = "";
+        public String additionalInfo = "";
+    }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -1,67 +1,28 @@
 package de.uka.ilkd.key.gui.prooftree;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Alexander Weigl
  * @version 1 (20.05.19)
  */
 public class Style {
-    private final Map<Object, Object> styles = new HashMap<>();
-    private final Set<Object> sealed = new HashSet<>();
+    /** the text of this node */
+    public String text;
 
-    private static class Key<T> {
-        <T> Key(Class<T> clazz) {
-        }
-    }
+    /** the tooltip */
+    public String tooltip;
 
-    public static final Key<Color> KEY_COLOR_FOREGROUND = new Key<>(Color.class);
-    public static final Key<Color> KEY_COLOR_BACKGROUND = new Key<>(Color.class);
-    public static final Key<Color> KEY_COLOR_BORDER = new Key<>(Color.class);
-    public static final Key<Boolean> KEY_FONT_ITALIC = new Key<>(Boolean.class);
-    public static final Key<Boolean> KEY_FONT_BOLD = new Key<>(Boolean.class);
-    public static final Key<Icon> KEY_ICON = new Key<>(Icon.class);
-    public static final Key<String> KEY_TOOLTIP = new Key<>(String.class);
-    public static final Key<String> KEY_TEXT = new Key<>(String.class);
+    /** foreground color of the node */
+    public Color foreground;
 
-    @Nonnull
-    public <T> Style set(@Nonnull Key<T> key, @Nullable T value) {
-        if (!sealed.contains(key)) {
-            styles.put(key, value);
-        }
-        return this;
-    }
+    /** background color of the node */
+    public Color background;
 
-    @Nonnull
-    public <T> Style setAndSeal(@Nonnull Key<T> key, @Nullable T value) {
-        set(key, value);
-        sealed.add(key);
-        return this;
-    }
+    /** border color of the node */
+    public Color border;
 
-    public <T> boolean contains(@Nonnull Key<T> key) {
-        return styles.containsKey(key);
-    }
-
-    @Nullable
-    @SuppressWarnings("unchecked")
-    public <T> T get(@Nonnull Key<T> key, @Nullable T defaultValue) {
-        return (T) styles.getOrDefault(key, defaultValue);
-    }
-
-    @Nullable
-    public <T> T get(@Nonnull Key<T> key) {
-        return get(key, null);
-    }
-
-    public boolean getBoolean(Key<Boolean> key) {
-        return get(key) == Boolean.TRUE;
-    }
+    /** icon of the node */
+    public Icon icon;
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -1,7 +1,13 @@
 package de.uka.ilkd.key.gui.prooftree;
 
-import javax.swing.*;
-import java.awt.*;
+import de.uka.ilkd.key.pp.LogicPrinter;
+
+import javax.annotation.Nonnull;
+import javax.swing.Icon;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Alexander Weigl
@@ -26,9 +32,89 @@ public class Style {
     /** icon of the node */
     public Icon icon;
 
+    /** Wrapper class for the tooltip */
     public static class Tooltip {
-        public String title = "";
-        public String notes = "";
-        public String additionalInfo = "";
+        /** title, can also be null and empty */
+        private String title;
+
+        /** infos */
+        private final ArrayList<Fragment> additionalInfo = new ArrayList<>();
+
+        /**
+         * @return the title
+         */
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * Sets the title.
+         *
+         * @param title tooltip title
+         */
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        /**
+         * Adds a piece of additional information.
+         *
+         * @param key the key
+         * @param value the value
+         * @param block whether this should be rendered as a block
+         */
+        public void addAdditionalInfo(@Nonnull String key, @Nonnull String value, boolean block) {
+            additionalInfo.add(new Fragment(key, value, block));
+        }
+
+        /**
+         * Adds notes
+         *
+         * @param notes the notes
+         */
+        public void addNotes(@Nonnull String notes) {
+            addAdditionalInfo("Notes", notes, false);
+        }
+
+        /**
+         * Adds rule information
+         *
+         * @param rule the rule
+         */
+        public void addRule(@Nonnull String rule) {
+            addAdditionalInfo("Rule", rule, false);
+        }
+
+        /**
+         * Adds applied on infos
+         *
+         * @param on the info
+         */
+        public void addAppliedOn(@Nonnull String on) {
+            addAdditionalInfo("Applied on", LogicPrinter.escapeHTML(on, true), true);
+        }
+
+        /**
+         * @return list of all additional infos, immutable
+         */
+        public List<Fragment> getAdditionalInfos() {
+            return Collections.unmodifiableList(additionalInfo);
+        }
+
+        /** wrapper class for additional infos */
+        public static final class Fragment {
+            /** key */
+            public final String key;
+            /** value */
+            public final String value;
+            /** whether this is a block */
+            public final boolean block;
+
+            public Fragment(String key, String value, boolean block) {
+                this.key = key;
+                this.value = value;
+                this.block = block;
+            }
+        }
     }
 }

--- a/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
@@ -179,7 +179,7 @@ class ExplorationRenderer implements Styler<GUIAbstractTreeNode> {
         if (data != null) {
             style.border = DARK_PURPLE_COLOR.get();
             style.background = LIGHT_PURPLE_COLOR.get();
-            style.tooltip = "Exploration Action Performed";
+            style.tooltip.title = "Exploration Action Performed";
         }
     }
 }

--- a/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
@@ -166,8 +166,6 @@ public class ExplorationExtension implements KeYGuiExtension, KeYGuiExtension.Co
 
 
 class ExplorationRenderer implements Styler<GUIAbstractTreeNode> {
-    public static final ColorSettings.ColorProperty DARK_TURQOUIS_COLOR =
-        ColorSettings.define("[proofTree]turqois", "", new Color(19, 110, 128));
     public static final ColorSettings.ColorProperty DARK_PURPLE_COLOR =
         ColorSettings.define("[proofTree]darkPurple", "", new Color(112, 17, 191));
     public static final ColorSettings.ColorProperty LIGHT_PURPLE_COLOR =
@@ -176,20 +174,12 @@ class ExplorationRenderer implements Styler<GUIAbstractTreeNode> {
     @Override
     public void style(@Nonnull Style style, GUIAbstractTreeNode treeNode) {
         Node node = treeNode.getNode();
-        ExplorationNodeData data;
-        try {
-            data = node.lookup(ExplorationNodeData.class);
+        ExplorationNodeData data = node.lookup(ExplorationNodeData.class);
 
-            if (data != null) {
-                style.set(Style.KEY_COLOR_BORDER, DARK_PURPLE_COLOR.get());
-                style.set(Style.KEY_COLOR_BACKGROUND, LIGHT_PURPLE_COLOR.get());
-                style.set(Style.KEY_TOOLTIP, "Exploration Action Performed");
-
-            } else {
-                style.set(Style.KEY_COLOR_BORDER, null);
-            }
-        } catch (IllegalStateException e) {
-            style.set(Style.KEY_COLOR_BORDER, null);
+        if (data != null) {
+            style.border = DARK_PURPLE_COLOR.get();
+            style.background = LIGHT_PURPLE_COLOR.get();
+            style.tooltip = "Exploration Action Performed";
         }
     }
 }

--- a/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
@@ -179,7 +179,7 @@ class ExplorationRenderer implements Styler<GUIAbstractTreeNode> {
         if (data != null) {
             style.border = DARK_PURPLE_COLOR.get();
             style.background = LIGHT_PURPLE_COLOR.get();
-            style.tooltip.title = "Exploration Action Performed";
+            style.tooltip.setTitle("Exploration Action Performed");
         }
     }
 }


### PR DESCRIPTION
I've digged these changes up from my main branch from over a year ago and made them cleaner.

* Cleanup some of the code
* Speed up ProofTreeSearchBar by caching the search strings (Makes a huge difference for large proofs)
* Fix example dialog loading previously hidden example on double-click on a folder

### Elide long rule app names and move them to the tooltip

![grafik](https://user-images.githubusercontent.com/23399687/216086114-a5e442db-c30d-4e66-9b28-a192ab4f79b7.png)

### Normalize whitespace in rule names
After: ![grafik](https://user-images.githubusercontent.com/23399687/216086358-e2badf5a-f3f6-424e-b867-eaba872f0470.png)

Before: ![grafik](https://user-images.githubusercontent.com/23399687/216086390-50dad39f-1c74-4300-bab2-d7b6f2c73fa4.png)

### Move applied on term of OSS nodes to the tooltip

After: 
![grafik](https://user-images.githubusercontent.com/23399687/216086641-7e7ec221-0130-4edd-aa53-dfa0104e6132.png)

Before: 
![grafik](https://user-images.githubusercontent.com/23399687/216086660-d1521c1b-bd57-404a-a297-45a4afb4f7de.png)

