### PR TITLE
Fix non duplicate feature perf

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
@@ -18,6 +18,7 @@ import de.uka.ilkd.key.rule.metaconstruct.arith.Polynomial;
 import de.uka.ilkd.key.strategy.IfInstantiationCachePool;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.AbstractBetaFeature.TermInfo;
+import de.uka.ilkd.key.strategy.feature.AppliedRuleAppsNameCache;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.ClausesGraph;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.TriggersSet;
 import de.uka.ilkd.key.util.Pair;
@@ -139,6 +140,9 @@ public class ServiceCaches {
     private final IfFormulaInstantiationCache ifFormulaInstantiationCache =
         new IfFormulaInstantiationCache();
 
+    /** applied rule apps name cache */
+    private final AppliedRuleAppsNameCache appliedRuleAppsNameCache =
+        new AppliedRuleAppsNameCache();
 
     /**
      * Returns the cache used by {@link TermTacletAppIndexCacheSet} instances.
@@ -209,4 +213,7 @@ public class ServiceCaches {
         return ifFormulaInstantiationCache;
     }
 
+    public AppliedRuleAppsNameCache getAppliedRuleAppsNameCache() {
+        return appliedRuleAppsNameCache;
+    }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AppliedRuleAppsNameCache.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AppliedRuleAppsNameCache.java
@@ -1,0 +1,126 @@
+package de.uka.ilkd.key.strategy.feature;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nonnull;
+
+import de.uka.ilkd.key.logic.Name;
+import de.uka.ilkd.key.proof.Node;
+import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.util.AssertionFailure;
+
+import org.key_project.util.LRUCache;
+
+/**
+ * Establishes a cache for the applied rule apps to query them by name.
+ * See the get method for additional required constraints for correctness.
+ *
+ * @author Julian Wiesler
+ */
+public class AppliedRuleAppsNameCache {
+    /** cache of all applied rules by name of a node */
+    private final LRUCache<Node, HashMap<Name, List<RuleApp>>> cache = new LRUCache<>(32);
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+    private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+
+    public AppliedRuleAppsNameCache() {}
+
+    /**
+     * Fills the cache value of this instance for node
+     *
+     * @param node the node
+     * @return the value
+     */
+    private @Nonnull HashMap<Name, List<RuleApp>> fillCacheForNode(Node node) {
+        HashMap<Name, List<RuleApp>> nodeCache;
+        try {
+            writeLock.lock();
+            nodeCache = cache.get(node);
+            if (nodeCache == null) {
+                // Try to use parent cache to initialize the new cache
+                HashMap<Name, List<RuleApp>> parentCache =
+                    node.root() ? null : cache.get(node.parent());
+                nodeCache = new HashMap<>();
+
+                if (parentCache != null) {
+                    if (node.parent().childrenCount() <= 1) {
+                        // Parent cache will be removed, reuse it
+                        nodeCache = parentCache;
+                    } else {
+                        // Copy the parent cache
+                        for (Map.Entry<Name, List<RuleApp>> entry : parentCache.entrySet()) {
+                            nodeCache.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+                        }
+                    }
+
+                    // Parent did not have a rule applied when we calculated this, add the rule
+                    // applied
+                    // there
+                    RuleApp parentApp = node.parent().getAppliedRuleApp();
+                    nodeCache.computeIfAbsent(parentApp.rule().name(), k -> new ArrayList<>())
+                            .add(parentApp);
+
+                    // If this is an inner node, we hope we will never revisit it, remove it from
+                    // the
+                    // cache
+                    if (node.parent().childrenCount() <= 1) {
+                        cache.remove(node.parent());
+                    }
+                } else {
+                    // Check all earlier rule applications
+                    Node current = node;
+                    while (!current.root()) {
+                        final Node par = current.parent();
+
+                        RuleApp a = par.getAppliedRuleApp();
+                        nodeCache.computeIfAbsent(a.rule().name(), k -> new ArrayList<>()).add(a);
+
+                        current = par;
+                    }
+                }
+
+                cache.put(node, nodeCache);
+            }
+        } finally {
+            writeLock.unlock();
+        }
+
+        return nodeCache;
+    }
+
+    /**
+     * Gets rule apps applied to any node before the given node with the given name.
+     *
+     * Multiple assumptions about nodes:
+     * * The given node is a leaf, no children, no applied rule
+     * * Only *new* nodes are appended to nodes
+     * * Non leaf nodes are not changed, pruning is allowed
+     * * If the tree is pruned the removed nodes are discarded and not reused
+     *
+     * @param node the node
+     * @param name the name
+     * @return rule apps
+     */
+    public @Nonnull List<RuleApp> get(@Nonnull Node node, @Nonnull Name name) {
+        if (node.getAppliedRuleApp() != null || node.childrenCount() != 0) {
+            throw new AssertionFailure("Expected an empty leaf node");
+        }
+
+        HashMap<Name, List<RuleApp>> nodeCache;
+        try {
+            readLock.lock();
+            nodeCache = cache.get(node);
+        } finally {
+            readLock.unlock();
+        }
+
+        if (nodeCache == null) {
+            nodeCache = fillCacheForNode(node);
+        }
+
+        List<RuleApp> apps = nodeCache.get(name);
+        return apps == null ? Collections.emptyList() : Collections.unmodifiableList(apps);
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/EqNonDuplicateAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/EqNonDuplicateAppFeature.java
@@ -1,8 +1,6 @@
 package de.uka.ilkd.key.strategy.feature;
 
 import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.Semisequent;
-import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.TacletApp;
 
@@ -27,10 +25,6 @@ public class EqNonDuplicateAppFeature extends AbstractNonDuplicateAppFeature {
         }
 
         return noDuplicateFindTaclet(app, pos, goal);
-    }
-
-    protected boolean semiSequentContains(Semisequent semisequent, SequentFormula cfma) {
-        return semisequent.containsEqual(cfma);
     }
 
     protected boolean comparePio(TacletApp newApp, TacletApp oldApp, PosInOccurrence newPio,

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppFeature.java
@@ -1,13 +1,10 @@
 package de.uka.ilkd.key.strategy.feature;
 
 import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.Semisequent;
-import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.proof.Goal;
-import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.TacletApp;
 
-import org.key_project.util.collection.ImmutableList;
+
 
 /**
  * Binary feature that returns zero iff a certain Taclet app has not already been performed
@@ -16,25 +13,9 @@ public class NonDuplicateAppFeature extends AbstractNonDuplicateAppFeature {
 
     public static final Feature INSTANCE = new NonDuplicateAppFeature();
 
-    protected boolean containsRuleApp(ImmutableList<RuleApp> list, TacletApp rapp,
-            PosInOccurrence pio) {
-
-        for (RuleApp aList : list) {
-            if (sameApplication(aList, rapp, pio)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     public boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
         if (!app.ifInstsComplete()) {
             return true;
-        }
-
-        if (pos == null) {
-            return !containsRuleApp(goal.appliedRuleApps(), app, pos);
         }
 
         return noDuplicateFindTaclet(app, pos, goal);
@@ -43,9 +24,5 @@ public class NonDuplicateAppFeature extends AbstractNonDuplicateAppFeature {
     protected boolean comparePio(TacletApp newApp, TacletApp oldApp, PosInOccurrence newPio,
             PosInOccurrence oldPio) {
         return oldPio.equals(newPio);
-    }
-
-    protected boolean semiSequentContains(Semisequent semisequent, SequentFormula cfma) {
-        return semisequent.contains(cfma);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppModPositionFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppModPositionFeature.java
@@ -22,7 +22,7 @@ public class NonDuplicateAppModPositionFeature extends NonDuplicateAppFeature {
             return true;
         }
 
-        return !containsRuleApp(goal.appliedRuleApps(), app, pos);
+        return noDuplicateFindTaclet(app, pos, goal);
     }
 
     @Override


### PR DESCRIPTION
I optimized the non duplicate app feature calculation by caching a map `rule name => [RuleApp]`.
This lead to an overall performance gain of about 20% for most cost computations done by the strategies.

I made some assumptions about `Node` that are not guaranteed by the interface (although I think they should be and `Node` could easily be made immutable).
See the doc of `getRuleAppsWithName`.

Two more things I noticed: 
* `NonDuplicateAppFeature::containsRuleApp` is always inverted
* Inverting the method to "does not contain" makes the code equal to `noDuplicateFindTaclet`, so I called this one instead

Is this really the case? `NonDuplicateAppFeature::filter` does a (now useless) case distinction over whether the position in occurrence is null and calls one of the two methods... It would be very odd if they did the same thing. Why would it be there if they were?