### PR TITLE
Fix handling of multiline log messages

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/LogView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/LogView.java
@@ -250,7 +250,7 @@ public class LogView implements KeYGuiExtension, KeYGuiExtension.StatusLine {
 
         private void appendLine(String[] fields) {
             for (int i = 0; i < fields.length; i++) {
-                appendField(fields[i], STYLES[i]);
+                appendField(fields[i].replace("\\n", "\n"), STYLES[i]);
                 if (i == fields.length - 1) {
                     appendField("\n", ATTRIB_EMPTY);
                 } else {

--- a/key.ui/src/main/resources/logback.xml
+++ b/key.ui/src/main/resources/logback.xml
@@ -9,7 +9,8 @@
         <append>false</append>
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%date|%level|%thread|%logger|%file:%line|%msg|%ex|%n</pattern>
+            <!-- replace newlines by \n to allow line-based filtering (see LogView) -->
+            <pattern>%date|%level|%thread|%logger|%file:%line|%replace(%msg){'[\n\r]','\\n'}|%replace(%ex){'[\n\r]','\\n'}%nopex|%n</pattern>
             <outputPatternAsHeader>true</outputPatternAsHeader>
         </encoder>
     </appender>


### PR DESCRIPTION
Previously the filtering logic in LogView would fail to work properly if a log message contained a newline.