### PR TITLE
New .git-blame-ignore-revs after history rewrite

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,6 @@
 # commit with automatic reformatting for Java files
-d1be82c163b48fcc87991afc33f50c1380bf4949
+92ef20754111bce673603debf9934ae98816a70f
 # commit with automatic reformatting for .key files
-f8441bba87de6fdc63ea3078a9fa0c79139b8b0a
+b1ed8d6bc836ea40f357a839707d41fbb04ed6e2
 # commit with manual formatting corrections
-e405e67cb69ac9621efaa6098e87d03fb39a3efa
+a9fcedc6c8d96f2480549254a307b3fbe31f04bd


### PR DESCRIPTION
After the git repository rewrite to remove a large file, the commit hashes changed. This PR fixes the commits listed in the `.git-blame-ignore-revs` file.