### PR TITLE
Avoid tooltip NPE for incomplete proof nodes

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.java.PrettyPrinter;
 import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.rule.RuleApp;
@@ -983,9 +984,12 @@ public class ProofTreeView extends JPanel implements TabPanel {
             style.foreground = Color.black;
 
             style.tooltip.addRule(node.getAppliedRuleApp().rule().name().toString());
-            String on = LogicPrinter.quickPrintTerm(
-                node.getAppliedRuleApp().posInOccurrence().subTerm(), node.proof().getServices());
-            style.tooltip.addAppliedOn(on);
+            PosInOccurrence pio = node.getAppliedRuleApp().posInOccurrence();
+            if (pio != null) {
+                String on = LogicPrinter.quickPrintTerm(
+                    pio.subTerm(), node.proof().getServices());
+                style.tooltip.addAppliedOn(on);
+            }
 
             final String notes = node.getNodeInfo().getNotes();
             if (notes != null) {


### PR DESCRIPTION
Steps to reproduce issue: try to instante a rule manually (e.g. cut). Observe that a NPE is thrown.

Caused by: #3012