### PR TITLE
Register modifier when parsing JML spec

### DIFF
--- a/key.core/src/main/antlr4/JmlParser.g4
+++ b/key.core/src/main/antlr4/JmlParser.g4
@@ -50,7 +50,7 @@ class_invariant: INVARIANT expression SEMI_TOPLEVEL;
 method_specification: (also_keyword)* spec_case ((also_keyword)+ spec_case)*;
 also_keyword: (ALSO | FOR_EXAMPLE | IMPLIES_THAT);
 spec_case:
-  (modifier)?
+  (modifiers)?
   behavior=(BEHAVIOR | NORMAL_BEHAVIOR | MODEL_BEHAVIOUR | EXCEPTIONAL_BEHAVIOUR
            | BREAK_BEHAVIOR | CONTINUE_BEHAVIOR | RETURN_BEHAVIOR )?
   spec_body

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
@@ -104,11 +104,19 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public Object visitSpec_case(JmlParser.Spec_caseContext ctx) {
+        // read contract modifier and behavior ID
+        mods = ImmutableSLList.nil();
+        if (ctx.modifiers() != null) {
+            for (JmlParser.ModifierContext mod : ctx.modifiers().modifier()) {
+                mods = mods.append(modifierFromToken(mod.mod));
+            }
+        }
         Behavior behaviour = getBehavior(ctx.behavior);
+
         methodContract = new TextualJMLSpecCase(mods, behaviour);
         loopContract = null;
         constructs = constructs.append(methodContract);
-        super.visitSpec_case(ctx);
+        super.visitSpec_body(ctx.spec_body());
         methodContract = null;
         return null;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -2044,7 +2044,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public de.uka.ilkd.key.speclang.Contract visitSpec_case(JmlParser.Spec_caseContext ctx) {
-        this.mods = accept(ctx.modifier());
+        this.mods = accept(ctx.modifiers());
         contractClauses = new ContractClauses();
         accept(ctx.spec_body());
         return null;


### PR DESCRIPTION
Fixes #1722. Previously, the modifier was read after construction of `TextualJMLSpecCase`.