### PR TITLE
Activate Z3 if no other SMT solver is configured

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
@@ -352,9 +352,18 @@ public final class ProofIndependentSMTSettings
     }
 
     public SolverTypeCollection computeActiveSolverUnion() {
+        // if there is already a solver union configured, return that
         if (activeSolverUnion.isUsable()) {
             return activeSolverUnion;
         }
+        // otherwise, first try the default solver: Z3
+        Optional<SolverTypeCollection> z3 = solverUnions.stream()
+                .filter(x -> x.name().equals("Z3")).findFirst();
+        if (z3.isPresent() && z3.get().isUsable()) {
+            setActiveSolverUnion(z3.get());
+            return z3.get();
+        }
+        // failing that, any usable solver is accepted...
         for (SolverTypeCollection solverUnion : solverUnions) {
             if (solverUnion.isUsable()) {
                 setActiveSolverUnion(solverUnion);

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
@@ -306,7 +306,8 @@ public class TestFile implements Serializable {
                     .limit(10)
                     .collect(Collectors.toList());
             assertTrue(reloadedProof.closed(),
-                "Reloaded proof did not close: " + proofFile + ", open goals were " + goalsSerials);
+                "Reloaded proof did not close: " + proofFile + ", open goals were " + goalsSerials
+                    + ", replay status: " + result.getStatus());
         } catch (Throwable t) {
             throw new Exception(
                 "Exception while loading proof (see cause for details): " + proofFile, t);


### PR DESCRIPTION
This fixes the recent `testRunAllFunProofs` failures. Without this fix, only `Z3_FP` is run when reloading a proof.