### PR TITLE
Add `merge_group` event to checks

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,6 +1,7 @@
 name: CodeQuality
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '21 21 * * 4'
+  merge_group:
 
 jobs:
   analyze:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
+  merge_group:
+  
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
This PR adds the `merge_group` event as a trigger to the Github Action workflows. 

By adding this PR, we should be able to deploy the Merge Group (aka Merge Train) feature. Merge Group are the solution to allow to merge multiple PRs in one go, without updating them. 

 