### PR TITLE
Expand oss nodes

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeExpansionState.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeExpansionState.java
@@ -7,6 +7,7 @@ package de.uka.ilkd.key.gui.prooftree;
  */
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 import javax.swing.JTree;
@@ -71,8 +72,9 @@ import javax.swing.tree.TreePath;
  *
  * <p>
  * Note: For optimization purposes, this class is now tailored to ProofTreeView. In particular, the
- * method {@link #expandAllBelow(JTree, TreePath)} temporarily removes most TreeExpansionListeners
- * to avoid flooding them with events. This massively increases performance on large trees.
+ * method {@link #expandAllBelow(JTree, TreePath, Predicate)} temporarily removes most
+ * TreeExpansionListeners to avoid flooding them with events. This massively increases performance
+ * on large trees.
  * <p>
  * Note: The current implementation probably does not work correctly with TreeWillExpandListeners.
  *
@@ -291,9 +293,12 @@ class ProofTreeExpansionState extends AbstractSet<TreePath> {
     /**
      * Expands the given JTree completely.
      *
+     * Expands the given JTree completely except for the filtered out nodes.
+     *
      * @param tree the JTree to expand
+     * @param filter only the nodes that pass this filter will be expanded
      */
-    public static void expandAll(JTree tree) {
+    public static void expandAll(JTree tree, Predicate<TreePath> filter) {
         TreeModel data = tree.getModel();
 
         if (data == null) {
@@ -306,17 +311,19 @@ class ProofTreeExpansionState extends AbstractSet<TreePath> {
             return;
         }
 
-        expandAllBelow(tree, new TreePath(root));
+        expandAllBelow(tree, new TreePath(root), filter);
     }
 
     /**
-     * Completely expands all nodes of the given JTree that are below the given path. Requires that
-     * path is not a leaf. That implies the tree has a model, and that has a root.
+     * Completely expands all nodes of the given JTree that are below the given path and pass the
+     * given filter. Requires that path is not a leaf. That implies the tree has a model, and that
+     * has a root.
      *
      * @param tree the JTree to expand
      * @param path the root path under which everything should be expanded afterwards
+     * @param filter only the nodes that pass this filter will be expanded
      */
-    public static void expandAllBelow(JTree tree, TreePath path) {
+    public static void expandAllBelow(JTree tree, TreePath path, Predicate<TreePath> filter) {
         // we temporarily remove all expansion listeners (except that which updates the expanded
         // paths set) before expanding
         TreeExpansionListener[] expansionListeners = tree.getTreeExpansionListeners();
@@ -325,7 +332,7 @@ class ProofTreeExpansionState extends AbstractSet<TreePath> {
                 tree.removeTreeExpansionListener(exl);
             }
         }
-        for (TreePath tp : extremalPaths(tree.getModel(), path)) {
+        for (TreePath tp : extremalPaths(tree.getModel(), path, filter)) {
             tree.expandPath(tp);
         }
         for (TreeExpansionListener exl : expansionListeners) {
@@ -346,39 +353,46 @@ class ProofTreeExpansionState extends AbstractSet<TreePath> {
      * collection of a leave is empty. The extremal paths are stored in the order in which they
      * appear in pre-order in the tree model.
      */
-    private static Collection<TreePath> extremalPaths(TreeModel data, TreePath path) {
+    private static Collection<TreePath> extremalPaths(TreeModel data, TreePath path,
+            Predicate<TreePath> filter) {
         LinkedHashSet<TreePath> result = new LinkedHashSet<>();
 
         if (data.isLeaf(path.getLastPathComponent())) {
             return result; // should really be forbidden (?)
         }
 
-        extremalPathsImpl(data, path, result);
+        extremalPathsImpl(data, path, result, filter);
         return result;
     }
 
     private static void extremalPathsImpl(TreeModel data, TreePath path,
-            Collection<TreePath> result) {
+            Collection<TreePath> result, Predicate<TreePath> filter) {
         Object node = path.getLastPathComponent();
 
         boolean hasNonLeafChildren = false;
 
         int count = data.getChildCount(node);
 
+        // check if there is a child that is not leaf and passes the filter
         for (int i = 0; i < count; i++) {
-            if (!data.isLeaf(data.getChild(node, i))) {
+            Object child = data.getChild(node, i);
+            if (!data.isLeaf(child) && filter.test(path.pathByAddingChild(child))) {
                 hasNonLeafChildren = true;
+                break;
             }
         }
 
         if (!hasNonLeafChildren) {
-            result.add(path);
+            // filtered out nodes (e.g. OSS nodes) must not be expanded
+            if (filter.test(path)) {
+                result.add(path);
+            }
         } else {
             for (int i = 0; i < count; i++) {
                 Object child = data.getChild(node, i);
 
                 if (!data.isLeaf(child)) {
-                    extremalPathsImpl(data, path.pathByAddingChild(child), result);
+                    extremalPathsImpl(data, path.pathByAddingChild(child), result, filter);
                 }
             }
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -10,7 +10,6 @@ import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.nodeviews.SequentViewDock;
 import de.uka.ilkd.key.gui.notification.events.GeneralInformationEvent;
-import de.uka.ilkd.key.macros.ProofMacro;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
@@ -24,8 +23,6 @@ import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.awt.event.ActionEvent;
 import java.util.Iterator;
-
-import static de.uka.ilkd.key.gui.ProofMacroMenu.REGISTERED_MACROS;
 
 public class ProofTreePopupFactory {
     public static final int ICON_SIZE = 16;
@@ -241,7 +238,7 @@ public class ProofTreePopupFactory {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path);
+            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path, tp -> true);
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -34,7 +34,7 @@ public class ProofTreePopupFactory {
     /**
      * A filter that returns true iff the given TreePath denotes a One-Step-Simplifier-Node.
      */
-    public static final Predicate<TreePath> OSS_FILTER = tp -> {
+    public static boolean ossPathFilter(TreePath tp) {
         // filter out nodes with only OSS children (i.e., OSS nodes are not expanded)
         // (take care to not filter out any GUIBranchNodes accidentally!)
         Object o = tp.getLastPathComponent();
@@ -45,7 +45,14 @@ public class ProofTreePopupFactory {
             }
         }
         return true;
-    };
+    }
+
+    /**
+     * A predicate that filters oss nodes if filterOss is true
+     */
+    public static Predicate<TreePath> ossPathFilter(boolean filterOss) {
+        return filterOss ? n -> true : ProofTreePopupFactory::ossPathFilter;
+    }
 
     public static ProofTreeContext createContext(ProofTreeView view, TreePath selectedPath) {
         ProofTreeContext context = new ProofTreeContext();
@@ -257,7 +264,8 @@ public class ProofTreePopupFactory {
         @Override
         public void actionPerformed(ActionEvent e) {
             // expands everything below the given path except for OSS nodes
-            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path, OSS_FILTER);
+            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path,
+                ossPathFilter(context.proofTreeView.isExpandOSSNodes()));
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -13,6 +13,7 @@ import de.uka.ilkd.key.gui.notification.events.GeneralInformationEvent;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.rule.OneStepSimplifierRuleApp;
 import de.uka.ilkd.key.settings.GeneralSettings;
 import de.uka.ilkd.key.util.Pair;
 import org.key_project.util.collection.ImmutableList;
@@ -23,11 +24,28 @@ import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.awt.event.ActionEvent;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 public class ProofTreePopupFactory {
     public static final int ICON_SIZE = 16;
 
     private ProofTreePopupFactory() {}
+
+    /**
+     * A filter that returns true iff the given TreePath denotes a One-Step-Simplifier-Node.
+     */
+    public static final Predicate<TreePath> OSS_FILTER = tp -> {
+        // filter out nodes with only OSS children (i.e., OSS nodes are not expanded)
+        // (take care to not filter out any GUIBranchNodes accidentally!)
+        Object o = tp.getLastPathComponent();
+        if (o instanceof GUIProofTreeNode) {
+            GUIProofTreeNode n = ((GUIProofTreeNode) o);
+            if (n.getNode().getAppliedRuleApp() instanceof OneStepSimplifierRuleApp) {
+                return false;
+            }
+        }
+        return true;
+    };
 
     public static ProofTreeContext createContext(ProofTreeView view, TreePath selectedPath) {
         ProofTreeContext context = new ProofTreeContext();
@@ -238,7 +256,8 @@ public class ProofTreePopupFactory {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path, tp -> true);
+            // expands everything below the given path except for OSS nodes
+            ProofTreeExpansionState.expandAllBelow(context.delegateView, context.path, OSS_FILTER);
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
@@ -18,8 +18,6 @@ public class ProofTreeSettingsMenuFactory {
     private ProofTreeSettingsMenuFactory() {}
 
     public static CAction create(ProofTreeView view) {
-        // TODO: action is used only to extract the properties from it
-        // TODO: our classes (DockingHelper) can currently not really handle CMenu
         Supplier<CMenu> supplier = () -> {
             CMenu menu = new CMenu();
 
@@ -36,6 +34,7 @@ public class ProofTreeSettingsMenuFactory {
             }
             menu.addSeparator();
 
+            menu.add(createExpandOSSToggle(view));
             menu.add(createTacletInfoToggle());
             return menu;
         };
@@ -49,7 +48,7 @@ public class ProofTreeSettingsMenuFactory {
         button.setText("Expand All");
         button.setIcon(IconFactory.plus(ICON_SIZE));
         button.addActionListener(e -> ProofTreeExpansionState.expandAll(view.delegateView,
-            ProofTreePopupFactory.OSS_FILTER));
+            ProofTreePopupFactory.ossPathFilter(view.isExpandOSSNodes())));
         return button;
     }
 
@@ -105,6 +104,19 @@ public class ProofTreeSettingsMenuFactory {
             }
         });
         return button;
+    }
+
+    private static CCheckBox createExpandOSSToggle(ProofTreeView view) {
+        CCheckBox check = new CCheckBox() {
+            @Override
+            protected void changed() {
+                final boolean selected = isSelected();
+                view.setExpandOSSNodes(selected);
+            }
+        };
+        check.setText("Expand One Step Simplifications nodes");
+        check.setSelected(view.isExpandOSSNodes());
+        return check;
     }
 
     private static CCheckBox createTacletInfoToggle() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
@@ -48,7 +48,8 @@ public class ProofTreeSettingsMenuFactory {
         CButton button = new CButton();
         button.setText("Expand All");
         button.setIcon(IconFactory.plus(ICON_SIZE));
-        button.addActionListener(e -> ProofTreeExpansionState.expandAll(view.delegateView));
+        button.addActionListener(e -> ProofTreeExpansionState.expandAll(view.delegateView,
+            ProofTreePopupFactory.OSS_FILTER));
         return button;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -70,8 +70,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
     private static final long serialVersionUID = 3732875161168302809L;
 
-    // Taclet info can be shown for inner nodes.
-    private boolean showTacletInfo = false;
+    /** Whether to expand oss nodes when using expand all */
+    private boolean expandOSSNodes = false;
 
     /**
      * The JTree that is used for actual display and interaction
@@ -254,12 +254,12 @@ public class ProofTreeView extends JPanel implements TabPanel {
             KeYGuiExtension.KeyboardShortcuts.PROOF_TREE_VIEW);
     }
 
-    public void setShowTacletInfo(boolean value) {
-        showTacletInfo = value;
+    public boolean isExpandOSSNodes() {
+        return expandOSSNodes;
     }
 
-    public boolean getShowTacletInfo() {
-        return showTacletInfo;
+    public void setExpandOSSNodes(boolean expandOSSNodes) {
+        this.expandOSSNodes = expandOSSNodes;
     }
 
     @Override


### PR DESCRIPTION
This MR brings a new entry to the context menu of the proof tree settings, which allows users to expand all, but keep One Step Simplifier nodes collapsed.

I'm not really happy with the [label]() so I'm open to suggestions for a better name.