### PR TITLE
Fix program element printing in proof saver

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
@@ -88,6 +88,19 @@ public class PrettyPrinter implements Visitor {
     }
 
     /**
+     * Alternative entry method for this class. Omits the trailing semicolon in the output.
+     *
+     * @param s source element to print
+     */
+    public void printFragment(SourceElement s) {
+        l.beginRelativeC(0);
+        markStart(s);
+        s.visit(this);
+        markEnd(s);
+        l.end();
+    }
+
+    /**
      * Marks the start of the first executable statement ...
      *
      * @param stmt current statement;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
@@ -739,7 +739,7 @@ public class OutputStreamProofSaver {
 
     public static String printProgramElement(ProgramElement pe) {
         PrettyPrinter printer = PrettyPrinter.purePrinter();
-        printer.print(pe);
+        printer.printFragment(pe);
         return printer.result();
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/pp/PrettyPrinterTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/pp/PrettyPrinterTest.java
@@ -1,0 +1,20 @@
+package de.uka.ilkd.key.pp;
+
+import de.uka.ilkd.key.java.abstraction.KeYJavaType;
+import de.uka.ilkd.key.logic.ProgramElementName;
+import de.uka.ilkd.key.logic.op.LocationVariable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PrettyPrinterTest {
+    @Test
+    void printLocationVariable() {
+        // Test that the pretty printer does not add a ';' when using printFragment.
+        // This is important for saving instantiations (see #3071)
+        PrettyPrinter pp = PrettyPrinter.purePrinter();
+        ProgramElementName name = new ProgramElementName("x");
+        LocationVariable variable = new LocationVariable(name, KeYJavaType.VOID_TYPE);
+        pp.printFragment(variable);
+        Assertions.assertEquals("x", pp.result());
+    }
+}


### PR DESCRIPTION
See #3071. This PR changes the saver to use a new printer method that omits the final `;`. Probably the behaviour was inadvertantly modified in #3034.