### PR TITLE
fixing error reporting in AbstractBuilder

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/AbstractBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/AbstractBuilder.java
@@ -46,7 +46,7 @@ abstract class AbstractBuilder<T> extends KeYParserBaseVisitor<T> {
             return (T) ctx.accept(this);
         } catch (Exception e) {
             if (!(e instanceof BuildingException) && ctx instanceof ParserRuleContext) {
-                semanticError((ParserRuleContext) ctx, e.getMessage(), e);
+                throw new BuildingException((ParserRuleContext) ctx, e);
             }
             // otherwise we rethrow
             throw e;

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
@@ -1,6 +1,5 @@
 package de.uka.ilkd.key.nparser.builder;
 
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -49,12 +48,6 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
         this.nss = nss;
     }
 
-    protected void semanticErrorMsg(String label, ParserRuleContext ctx, Object... args) {
-        String msg = bundle.getString(label);
-        MessageFormat formatter = new MessageFormat(msg);
-        semanticError(ctx, formatter.format(args));
-    }
-
     @Override
     public List<String> visitPvset(KeYParser.PvsetContext ctx) {
         return mapOf(ctx.varId());
@@ -83,13 +76,13 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
     }
 
     protected Named lookup(Name n) {
-        final Namespace[] lookups =
+        final Namespace<?>[] lookups =
             { programVariables(), variables(), schemaVariables(), functions() };
         return doLookup(n, lookups);
     }
 
-    protected <T> T doLookup(Name n, Namespace... lookups) {
-        for (Namespace lookup : lookups) {
+    protected <T> T doLookup(Name n, Namespace<?>... lookups) {
+        for (Namespace<?> lookup : lookups) {
             Object l;
             if (lookup != null && (l = lookup.lookup(n)) != null) {
                 try {
@@ -369,8 +362,7 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
             try {
                 String guess = "java.lang." + type;
                 kjt = getJavaInfo().getKeYJavaType(guess);
-            } catch (Exception e) {
-                kjt = null;
+            } catch (Exception ignored) {
             }
         }
 
@@ -380,8 +372,7 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
                 JavaBlock jb = getJavaInfo().readJavaBlock("{" + type + " k;}");
                 kjt = ((VariableDeclaration) ((StatementBlock) jb.program()).getChildAt(0))
                         .getTypeReference().getKeYJavaType();
-            } catch (Exception e) {
-                kjt = null;
+            } catch (Exception ignored) {
             }
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1066,7 +1066,15 @@ public class ExpressionBuilder extends DefaultBuilder {
         if (sort != null && id != null) {
             return bindVar(id, sort);
         }
-        return doLookup(new Name(ctx.id.getText()), schemaVariables(), variables());
+
+        // TODO Does this not check schemaVariables() for the second time?
+        QuantifiableVariable result = doLookup(new Name(ctx.id.getText()), schemaVariables(), variables());
+
+        if (result == null) {
+            semanticError(ctx, "There is no schema variable or variable named " + id);
+        }
+
+        return result;
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1068,7 +1068,8 @@ public class ExpressionBuilder extends DefaultBuilder {
         }
 
         // TODO Does this not check schemaVariables() for the second time?
-        QuantifiableVariable result = doLookup(new Name(ctx.id.getText()), schemaVariables(), variables());
+        QuantifiableVariable result =
+            doLookup(new Name(ctx.id.getText()), schemaVariables(), variables());
 
         if (result == null) {
             semanticError(ctx, "There is no schema variable or variable named " + id);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1067,9 +1067,8 @@ public class ExpressionBuilder extends DefaultBuilder {
             return bindVar(id, sort);
         }
 
-        // TODO Does this not check schemaVariables() for the second time?
         QuantifiableVariable result =
-            doLookup(new Name(ctx.id.getText()), schemaVariables(), variables());
+            doLookup(new Name(ctx.id.getText()), variables());
 
         if (result == null) {
             semanticError(ctx, "There is no schema variable or variable named " + id);


### PR DESCRIPTION
the original code was not correct, threw NPEs and forgot the original cause exception.

* `e.getMessage()` could produce an NPE
* using `e.getMessage()` as format string was probably not the desired functionality here.

---

There is a second small bugfix related to error reporting: If an undefined schema variable is used as a bound variable, an NPE was thrown. This fix makes sure that "No schema variable x has been defined" is reported.