### PR TITLE
Better artiweb comment workflow

### DIFF
--- a/.github/workflows/artiweb.yml
+++ b/.github/workflows/artiweb.yml
@@ -1,9 +1,10 @@
 on:
   workflow_run:
-    workflows: [Upload data]
+    workflows: [Tests]
     types:
       - completed
 
+# taken from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
 jobs:
   download:
     runs-on: ubuntu-latest
@@ -18,7 +19,7 @@ jobs:
                run_id: context.payload.workflow_run.id,
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr_number"
+              return artifact.name == "pr-number"
             })[0];
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
@@ -28,6 +29,10 @@ jobs:
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+            let testArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-results"
+            })[0];
+            echo "TEST_ARTIFACT_NUMBER={testArtifact.id}" >> $GITHUB_ENV
 
       - name: 'Unzip artifact'
         run: unzip pr_number.zip
@@ -56,4 +61,6 @@ jobs:
           issue-number: ${{ env.PR_NUMBER }}
           body: |
             Test artifacts will be available on [Artiweb](https://keyproject.github.io/artiweb/${env.PR_NUMBER}/).
+            
+            The newest artifact is [here](https://keyproject.github.io/artiweb/${env.PR_NUMBER}/${env.TEST_ARTIFACT_NUMBER}/).
           edit-mode: replace

--- a/.github/workflows/artiweb.yml
+++ b/.github/workflows/artiweb.yml
@@ -1,18 +1,59 @@
 on:
-  pull_request:
-    types: [opened, reopened]
+  workflow_run:
+    workflows: [Upload data]
+    types:
+      - completed
 
 jobs:
-  comment:
+  download:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v5
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Test artifacts will be available on [Artiweb](https://keyproject.github.io/artiweb/${context.issue.number}/).`
-            })
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+
+      - name: 'Read pr number'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number = Number(fs.readFileSync('./pr_number'));
+            echo "PR_NUMBER={issue_number}" >> $GITHUB_ENV
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'KiKi'
+          body-includes: Artiweb
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
+          body: |
+            Test artifacts will be available on [Artiweb](https://keyproject.github.io/artiweb/${env.PR_NUMBER}/).
+          edit-mode: replace

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr-number
-          - uses: actions/upload-artifact@v3
-            with:
-              name: pr_number
-              path: pr/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
+          echo $PR_NUMBER > ./pr/pr-number
           - uses: actions/upload-artifact@v3
             with:
               name: pr_number

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr-number
+          echo $PR_NUMBER > ./pr/pr_number
       - uses: actions/upload-artifact@v3
         with:
-          name: pr_number
+          name: pr-number
           path: pr/
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
   checks: write
 
-jobs:  
+jobs:
   unit-tests:
     strategy:
       fail-fast: false
@@ -27,6 +27,16 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+          - uses: actions/upload-artifact@v3
+            with:
+              name: pr_number
+              path: pr/
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION
Uses a workaround described [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow) to hopefully create the comment for pull requests by remote repositories as well.