### PR TITLE
Fix type of `Long.MIN_VALUE` and `Long.MAX_VALUE`

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/java/JavaRedux/java/lang/Long.java
+++ b/key.core/src/main/resources/de/uka/ilkd/key/java/JavaRedux/java/lang/Long.java
@@ -4,8 +4,8 @@
 package java.lang;
 
 public final class Long implements java.lang.Comparable {
-   public final static int MIN_VALUE = 0x8000000000000000L;
-   public final static int MAX_VALUE = 0x7fffffffffffffffL;
+   public final static long MIN_VALUE = 0x8000000000000000L;
+   public final static long MAX_VALUE = 0x7fffffffffffffffL;
    public final static java.lang.Class TYPE;
    public final static int SIZE = 64;
 }


### PR DESCRIPTION
`Long.MIN_VALUE` and `Long.MAX_VALUE` should be of type `long` like it is in the JDK sources.

This change shouldn't impact any previously working proofs since these values get translated to the correct numbers in JavaDL as sort `int` regardless.

Theoretically this change could introduce new type issues when parsing previously working Java code, but this seems unlikely since the `int` types would probably have been widened to `long` before anyway.