### PR TITLE
A Github Action for nightly deploy

### DIFF
--- a/.github/workflows/nightlydeploy.yml
+++ b/.github/workflows/nightlydeploy.yml
@@ -1,0 +1,48 @@
+name: Nightly Deployer of Weekly Builds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 5 * * 1' # every monday morning
+
+permissions:
+  contents: write
+  id-token: write
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # weigl: Should produce fancier release notes, but needs some configuration
+      # # https://github.com/marketplace/actions/release-changelog-builder
+      # - name: "Build Changelog"
+      #   id: build_changelog
+      #   uses: mikepenz/release-changelog-builder-action@v3.7.0
+      #   with:
+      #     ignorePreReleases: true
+      #     fetchReviewers: true
+
+      - uses: actions/checkout@v3
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2.3.3
+        with:
+          arguments: --parallel assemble
+
+      - name: Delete previous nightly release
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly
+
+
+      - name: Create nightly release
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create --generate-notes --title "Nightly Release" \
+             --prerelease \
+             nightly key.ui/build/libs/key-*-exe.jar


### PR DESCRIPTION
On Jenkins, we had a "nightly" build of KeY that was also deployed on the www11 sub-domain at the KIT. 

This PR adds a Github Action, which will update (delete and create) a release entry on the Github repo. This entry is marked as pre-release and contains a generated changelog. The current shadow-jar is attached. 

Example see here: https://github.com/KeYProject/key/releases/tag/nightly

This allows you to simple download the current version of KeY via `gh`:

```sh
$ gh release download nightly -R keyproject/key -p '*-exe.jar'
```

or by URL

```sh
wget https://github.com/KeYProject/key/releases/download/nightly/key-2.11.0-exe.jar
```

## Discussion points: 

  * Add further build artifacts? (Javadoc, ...)


## Todo: 

* [x] Finalize by restricting the trigger to `main` branch only
* [x] `git rebase -i`
* [x] Re-activate other workflows

/cc @mattulbrich @jwiesler @unp1 