### PR TITLE
Depromote optional-tests

### DIFF
--- a/.github/workflows/opttest.yml
+++ b/.github/workflows/opttest.yml
@@ -1,0 +1,38 @@
+name: Optional Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 */10 * *"
+
+jobs:
+  optional-tests:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java: [11, 17]
+        tests: [:key.core.proof_references:test, :key.core.symbolic_execution:test]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{matrix.java}}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{matrix.java}}
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2.3.3
+        with:
+          arguments: --continue ${{ matrix.tests }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3.1.1
+        if: success() || failure()
+        with:
+          name: test-results
+          path: |
+            **/build/test-results/*/*.xml
+            **/build/reports/            

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,28 +106,3 @@ jobs:
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/
-            
-  optional-tests:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.3.3
-        with:
-          arguments: --continue :key.core.proof_references:test :key.core.symbolic_execution:test
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3.1.1
-        if: success() || failure()        # run this step even if previous step failed
-        with:
-          name: test-results
-          path: |
-            **/build/test-results/*/*.xml
-            **/build/reports/            


### PR DESCRIPTION
Optional tests are currently the tests of symbolic execution and proof references, required by KeY4clipse. 

**Before:** Optional tests were always executed on pushes on main and pull-requests.

**With this PR:** Optional tests are only executed every 10 days on the main branch or on manually demand. 
