### PR TITLE
Critical changes to the KeY parser/grammer for more performance

### DIFF
--- a/key.core/src/main/antlr4/KeYParser.g4
+++ b/key.core/src/main/antlr4/KeYParser.g4
@@ -304,7 +304,7 @@ id_declaration
 
 funcpred_name
 :
-  (sortId DOUBLECOLON)? name=simple_ident_dots
+  (sortId DOUBLECOLON)? (name=simple_ident_dots|num=INT_LITERAL)
 ;
 
 
@@ -330,7 +330,7 @@ literals:
 ;
 
 
-term: equivalence_term;
+term: parallel_term; // weigl: should normally be equivalence_term
 //labeled_term: a=parallel_term (LGUILLEMETS labels=label RGUILLEMETS)?;
 parallel_term: a=elementary_update_term (PARALLEL b=elementary_update_term)*;
 elementary_update_term: a=equivalence_term (ASSIGN b=equivalence_term)?;
@@ -361,7 +361,7 @@ atom_prefix:
     update_term
   | substitution_term
   | locset_term
-  //| cast_term
+  | cast_term
   | unary_minus_term
   | bracket_term
 ;
@@ -382,16 +382,9 @@ primitive_term:
   | ifThenElseTerm
   | ifExThenElseTerm
   | abbreviation
-  | prim_conflicting;
-
-prim_conflicting:
-   accessterm  |
-     boolean_literal
-     | char_literal
-     | integer
-     | floatnum
-     | string_literal
-;
+  | accessterm
+  | literals
+  ;
 
 /*
 weigl, 2021-03-12:
@@ -451,15 +444,15 @@ term
 accessterm
 :
   // OLD
-  //(sortId DOUBLECOLON)?
-  //firstName=simple_ident
+  (sortId DOUBLECOLON)?
+  firstName=simple_ident
 
-  //Faster version
+  /*Faster version
   simple_ident_dots
   ( EMPTYBRACKETS*
     DOUBLECOLON
     simple_ident
-  )?
+  )?*/
   call?
   ( attribute )*
 ;
@@ -684,8 +677,7 @@ varexp_argument
 :
     //weigl: Ambguity between term (which can also contain simple_ident_dots and sortId)
     //       suggestion add an explicit keyword to request the sort by name or manually resolve later in builder
-    SORT sortId //also covers possible varId
-  | TYPEOF LPAREN y=varId RPAREN
+    TYPEOF LPAREN y=varId RPAREN
   | CONTAINERTYPE LPAREN y=varId RPAREN
   | DEPENDINGON LPAREN y=varId RPAREN
   | term

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -1,5 +1,16 @@
 package de.uka.ilkd.key.nparser;
 
+import de.uka.ilkd.key.nparser.builder.ChoiceFinder;
+import de.uka.ilkd.key.proof.io.RuleSource;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -10,16 +21,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.nio.file.Path;
 import java.util.*;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import de.uka.ilkd.key.nparser.builder.ChoiceFinder;
-import de.uka.ilkd.key.proof.io.RuleSource;
-
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.tree.TerminalNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This facade provides low-level access to the ANTLR4 Parser and Lexer.
@@ -101,9 +102,9 @@ public final class ParsingFacade {
     public static KeyAst.File parseFile(URL url) throws IOException {
         long start = System.currentTimeMillis();
         try (BufferedInputStream is = new BufferedInputStream(url.openStream());
-                ReadableByteChannel channel = Channels.newChannel(is)) {
+             ReadableByteChannel channel = Channels.newChannel(is)) {
             CodePointCharStream stream = CharStreams.fromChannel(channel, Charset.defaultCharset(),
-                4096, CodingErrorAction.REPLACE, url.toString(), -1);
+                    4096, CodingErrorAction.REPLACE, url.toString(), -1);
             return parseFile(stream);
         } finally {
             long stop = System.currentTimeMillis();
@@ -119,10 +120,30 @@ public final class ParsingFacade {
         return parseFile(file.toPath());
     }
 
+    static int sum = 0;
+
     public static KeyAst.File parseFile(CharStream stream) {
         KeYParser p = createParser(stream);
-        KeYParser.FileContext ctx = p.file();
+
+        p.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        // we don't want error messages or recovery during first try
+        p.removeErrorListeners();
+        p.setErrorHandler(new BailErrorStrategy());
+        var start = System.currentTimeMillis();
+        KeYParser.FileContext ctx;
+        try {
+            ctx = p.file();
+        } catch (ParseCancellationException ex) {
+            LOGGER.warn("SLL was not enough");
+            p = createParser(stream);
+            ctx = p.file();
+        }
+        var stop = System.currentTimeMillis();
+
         p.getErrorReporter().throwException();
+        sum += (stop - start);
+        LOGGER.warn("{} took {} ms to parse.", stream.getSourceName(), stop - start);
+        LOGGER.warn("Parsing time {} ms.", sum);
         return new KeyAst.File(ctx);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -120,8 +120,6 @@ public final class ParsingFacade {
         return parseFile(file.toPath());
     }
 
-    static int sum = 0;
-
     public static KeyAst.File parseFile(CharStream stream) {
         KeYParser p = createParser(stream);
 
@@ -129,7 +127,6 @@ public final class ParsingFacade {
         // we don't want error messages or recovery during first try
         p.removeErrorListeners();
         p.setErrorHandler(new BailErrorStrategy());
-        var start = System.currentTimeMillis();
         KeYParser.FileContext ctx;
         try {
             ctx = p.file();
@@ -138,12 +135,8 @@ public final class ParsingFacade {
             p = createParser(stream);
             ctx = p.file();
         }
-        var stop = System.currentTimeMillis();
 
         p.getErrorReporter().throwException();
-        sum += (stop - start);
-        LOGGER.warn("{} took {} ms to parse.", stream.getSourceName(), stop - start);
-        LOGGER.warn("Parsing time {} ms.", sum);
         return new KeyAst.File(ctx);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -1,16 +1,5 @@
 package de.uka.ilkd.key.nparser;
 
-import de.uka.ilkd.key.nparser.builder.ChoiceFinder;
-import de.uka.ilkd.key.proof.io.RuleSource;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
-import org.antlr.v4.runtime.tree.TerminalNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +10,18 @@ import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.nio.file.Path;
 import java.util.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import de.uka.ilkd.key.nparser.builder.ChoiceFinder;
+import de.uka.ilkd.key.proof.io.RuleSource;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This facade provides low-level access to the ANTLR4 Parser and Lexer.
@@ -102,9 +103,9 @@ public final class ParsingFacade {
     public static KeyAst.File parseFile(URL url) throws IOException {
         long start = System.currentTimeMillis();
         try (BufferedInputStream is = new BufferedInputStream(url.openStream());
-             ReadableByteChannel channel = Channels.newChannel(is)) {
+                ReadableByteChannel channel = Channels.newChannel(is)) {
             CodePointCharStream stream = CharStreams.fromChannel(channel, Charset.defaultCharset(),
-                    4096, CodingErrorAction.REPLACE, url.toString(), -1);
+                4096, CodingErrorAction.REPLACE, url.toString(), -1);
             return parseFile(stream);
         } finally {
             long stop = System.currentTimeMillis();

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1142,8 +1142,8 @@ public class ExpressionBuilder extends DefaultBuilder {
         List<String> parts = mapOf(ctx.name.simple_ident());
         String varfuncid = ctx.name.getText();
 
-        if (ctx.name.INT_LITERAL() != null) {// number
-            return toZNotation(ctx.name.INT_LITERAL().getText(), functions());
+         if (ctx.INT_LITERAL() != null) {// number
+            return toZNotation(ctx.INT_LITERAL().getText(), functions());
         }
 
         assert parts != null && varfuncid != null;
@@ -1172,7 +1172,7 @@ public class ExpressionBuilder extends DefaultBuilder {
             }
         } else {
             String firstName =
-                ctx.name.simple_ident().size() == 0 ? ctx.name.INT_LITERAL().getText()
+                ctx.name == null ? ctx.INT_LITERAL().getText()
                         : ctx.name.simple_ident(0).getText();
             op = lookupVarfuncId(ctx, firstName,
                 ctx.sortId() != null ? ctx.sortId().getText() : null, sortId);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1142,7 +1142,7 @@ public class ExpressionBuilder extends DefaultBuilder {
         List<String> parts = mapOf(ctx.name.simple_ident());
         String varfuncid = ctx.name.getText();
 
-         if (ctx.INT_LITERAL() != null) {// number
+        if (ctx.INT_LITERAL() != null) {// number
             return toZNotation(ctx.INT_LITERAL().getText(), functions());
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -1,12 +1,10 @@
 package de.uka.ilkd.key.nparser.builder;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import antlr.RecognitionException;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
+import de.uka.ilkd.key.java.abstraction.PrimitiveType;
+import de.uka.ilkd.key.java.abstraction.Type;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.Modality;
 import de.uka.ilkd.key.logic.op.Operator;
@@ -23,18 +21,21 @@ import de.uka.ilkd.key.parser.SchemaVariableModifierSet;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.conditions.TypeResolver;
 import de.uka.ilkd.key.rule.tacletbuilder.*;
+import de.uka.ilkd.key.util.Pair;
 import de.uka.ilkd.key.util.parsing.BuildingException;
-
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
-
-import antlr.RecognitionException;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
@@ -65,7 +66,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     public TacletPBuilder(Services services, NamespaceSet namespaces,
-            HashMap<Taclet, TacletBuilder<? extends Taclet>> taclet2Builder) {
+                          HashMap<Taclet, TacletBuilder<? extends Taclet>> taclet2Builder) {
         this(services, namespaces);
         this.taclet2Builder = taclet2Builder;
     }
@@ -215,7 +216,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     private void announceTaclet(ParserRuleContext ctx, Taclet taclet) {
         taclet2Builder.put(taclet, peekTBuilder());
         LOGGER.trace("Taclet announced: \"{}\" from {}:{}", taclet.name(),
-            ctx.start.getTokenSource().getSourceName(), ctx.start.getLine());
+                ctx.start.getTokenSource().getSourceName(), ctx.start.getLine());
     }
 
     private TacletBuilder<?> peekTBuilder() {
@@ -258,9 +259,9 @@ public class TacletPBuilder extends ExpressionBuilder {
         String name = ctx.varexpId().getText();
         List<KeYParser.Varexp_argumentContext> arguments = ctx.varexp_argument();
         List<TacletBuilderCommand> suitableManipulators =
-            TacletBuilderManipulators.getConditionBuildersFor(name);
+                TacletBuilderManipulators.getConditionBuildersFor(name);
         List<String> parameters =
-            ctx.parameter.stream().map(Token::getText).collect(Collectors.toList());
+                ctx.parameter.stream().map(Token::getText).collect(Collectors.toList());
         boolean applied = false;
         Object[] argCache = new Object[arguments.size()];
         for (TacletBuilderCommand manipulator : suitableManipulators) {
@@ -279,8 +280,8 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private boolean applyManipulator(boolean negated, Object[] args,
-            TacletBuilderCommand manipulator, List<KeYParser.Varexp_argumentContext> arguments,
-            List<String> parameters) {
+                                     TacletBuilderCommand manipulator, List<KeYParser.Varexp_argumentContext> arguments,
+                                     List<String> parameters) {
         assert args.length == arguments.size();
         ArgumentType[] types = manipulator.getArgumentTypes();
 
@@ -299,35 +300,69 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private Object evaluateVarcondArgument(ArgumentType expectedType, Object prevValue,
-            KeYParser.Varexp_argumentContext ctx) {
+                                           KeYParser.Varexp_argumentContext ctx) {
         if (prevValue != null && expectedType.clazz.isAssignableFrom(prevValue.getClass())) {
             return prevValue; // previous value is of suitable type, we do not re-evaluate
         }
 
         switch (expectedType) {
-        case TYPE_RESOLVER:
-            return buildTypeResolver(ctx);
-        case SORT:
-            return accept(ctx.sortId());
-        case JAVA_TYPE:
-            return getOrCreateJavaType(ctx.sortId());
-        case VARIABLE:
-            return varId(ctx, ctx.getText());
-        case STRING:
-            return ctx.getText();
-        case TERM:
-            return accept(ctx.term());
+            case TYPE_RESOLVER:
+                return buildTypeResolver(ctx);
+            case SORT:
+                return visitSortId(ctx.term().getText(), ctx.term());
+            case JAVA_TYPE:
+                return getOrCreateJavaType(ctx.term().getText(), ctx);
+            case VARIABLE:
+                return varId(ctx, ctx.getText());
+            case STRING:
+                return ctx.getText();
+            case TERM:
+                return accept(ctx.term());
         }
         assert false;
         return null;
     }
 
-    private KeYJavaType getOrCreateJavaType(KeYParser.SortIdContext sortId) {
-        KeYJavaType t = getJavaInfo().getKeYJavaType(sortId.getText());
+    private Sort visitSortId(String text, ParserRuleContext ctx) {
+        String primitiveName = text;
+        Type t = null;
+        if (primitiveName.equals(PrimitiveType.JAVA_BYTE.getName())) {
+            t = PrimitiveType.JAVA_BYTE;
+            primitiveName = PrimitiveType.JAVA_INT.getName();
+        } else if (primitiveName.equals(PrimitiveType.JAVA_CHAR.getName())) {
+            t = PrimitiveType.JAVA_CHAR;
+            primitiveName = PrimitiveType.JAVA_INT.getName();
+        } else if (primitiveName.equals(PrimitiveType.JAVA_SHORT.getName())) {
+            t = PrimitiveType.JAVA_SHORT;
+            primitiveName = PrimitiveType.JAVA_INT.getName();
+        } else if (primitiveName.equals(PrimitiveType.JAVA_INT.getName())) {
+            t = PrimitiveType.JAVA_INT;
+            primitiveName = PrimitiveType.JAVA_INT.getName();
+        } else if (primitiveName.equals(PrimitiveType.JAVA_LONG.getName())) {
+            t = PrimitiveType.JAVA_LONG;
+            primitiveName = PrimitiveType.JAVA_INT.getName();
+        } else if (primitiveName.equals(PrimitiveType.JAVA_BIGINT.getName())) {
+            t = PrimitiveType.JAVA_BIGINT;
+            primitiveName = PrimitiveType.JAVA_BIGINT.getName();
+        }
+        Sort s = lookupSort(primitiveName);
+        if (s == null) {
+            semanticError(ctx, "Could not find sort: %s", text);
+        }
+
+        if (text.contains("[")) {
+            var num = text.indexOf('[') - text.lastIndexOf(']') / 2 + 1;
+            return toArraySort(new Pair<>(s, t), num);
+        }
+        return s;
+    }
+
+    private KeYJavaType getOrCreateJavaType(String sortId, ParserRuleContext ctx) {
+        KeYJavaType t = getJavaInfo().getKeYJavaType(sortId);
         if (t != null) {
             return t;
         }
-        return new KeYJavaType((Sort) accept(sortId));
+        return new KeYJavaType((Sort) visitSortId(sortId, ctx));
     }
 
 
@@ -340,7 +375,7 @@ public class TacletPBuilder extends ExpressionBuilder {
             return TypeResolver.createContainerTypeResolver(y);
         }
 
-        Sort s = accept(ctx.sortId());
+        Sort s = visitSortId(ctx.term().getText(), ctx.term());
         if (s != null) {
             if (s instanceof GenericSort) {
                 return TypeResolver.createGenericSortResolver((GenericSort) s);
@@ -376,13 +411,10 @@ public class TacletPBuilder extends ExpressionBuilder {
 
     @Override
     public ChoiceExpr visitOption_list(KeYParser.Option_listContext ctx) {
-        if (ctx.option().isEmpty()) {
-            return accept(ctx.option_expr());
-        } else {
-            return ctx.option().stream()
-                    .map(it -> ChoiceExpr.variable(it.cat.getText(), it.value.getText()))
-                    .reduce(ChoiceExpr::and).orElse(ChoiceExpr.TRUE);
-        }
+        return ctx.option_expr().stream()
+                .map(it -> (ChoiceExpr) accept(it))
+                .reduce(ChoiceExpr::and)
+                .orElse(ChoiceExpr.TRUE);
     }
 
     @Override
@@ -463,7 +495,7 @@ public class TacletPBuilder extends ExpressionBuilder {
 
     @Nonnull
     private TacletBuilder<?> createTacletBuilderFor(Object find, int applicationRestriction,
-            ParserRuleContext ctx) {
+                                                    ParserRuleContext ctx) {
         if (find == null) {
             return new NoFindTacletBuilder();
         } else if (find instanceof Term) {
@@ -478,14 +510,14 @@ public class TacletPBuilder extends ExpressionBuilder {
                 AntecTacletBuilder b = new AntecTacletBuilder();
                 b.setFind(findFma);
                 b.setIgnoreTopLevelUpdates(
-                    (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
+                        (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
                 return b;
             } else if (findSeq.antecedent().size() == 0 && findSeq.succedent().size() == 1) {
                 Term findFma = findSeq.succedent().get(0).formula();
                 SuccTacletBuilder b = new SuccTacletBuilder();
                 b.setFind(findFma);
                 b.setIgnoreTopLevelUpdates(
-                    (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
+                        (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
                 return b;
             } else {
                 semanticError(ctx, "Unknown find-sequent (perhaps null?):" + findSeq);
@@ -495,12 +527,12 @@ public class TacletPBuilder extends ExpressionBuilder {
         }
 
         throw new IllegalArgumentException(
-            format("Could not find a suitable TacletBuilder for {0}", find));
+                format("Could not find a suitable TacletBuilder for {0}", find));
     }
 
     private void addGoalTemplate(String id, Object rwObj, Sequent addSeq,
-            ImmutableList<Taclet> addRList, ImmutableSet<SchemaVariable> pvs,
-            @Nullable ChoiceExpr soc, ParserRuleContext ctx) {
+                                 ImmutableList<Taclet> addRList, ImmutableSet<SchemaVariable> pvs,
+                                 @Nullable ChoiceExpr soc, ParserRuleContext ctx) {
         TacletBuilder<?> b = peekTBuilder();
         TacletGoalTemplate gt = null;
         if (rwObj == null) {
@@ -515,7 +547,7 @@ public class TacletPBuilder extends ExpressionBuilder {
                     gt = new AntecSuccTacletGoalTemplate(addSeq, addRList, (Sequent) rwObj, pvs);
                 } else {
                     semanticError(ctx, // new UnfittingReplacewithException
-                        "Replacewith in a Antec-or SuccTaclet has to contain a sequent (not a term)");
+                            "Replacewith in a Antec-or SuccTaclet has to contain a sequent (not a term)");
 
                 }
             } else if (b instanceof RewriteTacletBuilder) {
@@ -524,13 +556,13 @@ public class TacletPBuilder extends ExpressionBuilder {
                 } else {
                     // throwEx(/new UnfittingReplacewithException
                     semanticError(ctx,
-                        "Replacewith in a RewriteTaclet has to contain a term (not a sequent)");
+                            "Replacewith in a RewriteTaclet has to contain a term (not a sequent)");
                 }
             }
         }
         if (gt == null) {
             throw new NullPointerException(
-                "Could not find a suitable goal template builder for: " + b.getClass());
+                    "Could not find a suitable goal template builder for: " + b.getClass());
         }
         gt.setName(id);
         b.addTacletGoalTemplate(gt);
@@ -629,7 +661,7 @@ public class TacletPBuilder extends ExpressionBuilder {
 
         for (String id : ids) {
             declareSchemaVariable(ctx, id, s, makeVariableSV, makeSkolemTermSV, makeTermLabelSV,
-                mods);
+                    mods);
         }
         return null;
     }
@@ -641,7 +673,7 @@ public class TacletPBuilder extends ExpressionBuilder {
         for (String id : ids) {
             if (!mods.addModifier(id)) {
                 semanticError(ctx,
-                    "Illegal or unknown modifier in declaration of schema variable: %s", id);
+                        "Illegal or unknown modifier in declaration of schema variable: %s", id);
             }
         }
         return null;
@@ -653,8 +685,8 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     protected void declareSchemaVariable(ParserRuleContext ctx, String name, Sort s,
-            boolean makeVariableSV, boolean makeSkolemTermSV, boolean makeTermLabelSV,
-            SchemaVariableModifierSet mods) {
+                                         boolean makeVariableSV, boolean makeSkolemTermSV, boolean makeTermLabelSV,
+                                         SchemaVariableModifierSet mods) {
         SchemaVariable v;
         if (s == Sort.FORMULA && !makeSkolemTermSV) {
             v = SchemaVariableFactory.createFormulaSV(new Name(name), mods.rigid());
@@ -662,7 +694,7 @@ public class TacletPBuilder extends ExpressionBuilder {
             v = SchemaVariableFactory.createUpdateSV(new Name(name));
         } else if (s instanceof ProgramSVSort) {
             v = SchemaVariableFactory.createProgramSV(new ProgramElementName(name),
-                (ProgramSVSort) s, mods.list());
+                    (ProgramSVSort) s, mods.list());
         } else {
             if (makeVariableSV) {
                 v = SchemaVariableFactory.createVariableSV(new Name(name), s);
@@ -672,21 +704,21 @@ public class TacletPBuilder extends ExpressionBuilder {
                 v = SchemaVariableFactory.createTermLabelSV(new Name(name));
             } else {
                 v = SchemaVariableFactory.createTermSV(new Name(name), s, mods.rigid(),
-                    mods.strict());
+                        mods.strict());
             }
         }
 
         if (variables().lookup(v.name()) != null) {
             semanticError(null, "Schema variables shadows previous declared variable: %s.",
-                v.name());
+                    v.name());
         }
 
         if (schemaVariables().lookup(v.name()) != null) {
             SchemaVariable old = schemaVariables().lookup(v.name());
             if (!old.sort().equals(v.sort())) {
                 semanticError(null,
-                    "Schema variables clashes with previous declared schema variable: %s.",
-                    v.name());
+                        "Schema variables clashes with previous declared schema variable: %s.",
+                        v.name());
             }
             LOGGER.error("Override: {} {}", old, v);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -1,6 +1,10 @@
 package de.uka.ilkd.key.nparser.builder;
 
-import antlr.RecognitionException;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
 import de.uka.ilkd.key.java.abstraction.PrimitiveType;
@@ -23,19 +27,17 @@ import de.uka.ilkd.key.rule.conditions.TypeResolver;
 import de.uka.ilkd.key.rule.tacletbuilder.*;
 import de.uka.ilkd.key.util.Pair;
 import de.uka.ilkd.key.util.parsing.BuildingException;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
+
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
+
+import antlr.RecognitionException;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
@@ -66,7 +68,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     public TacletPBuilder(Services services, NamespaceSet namespaces,
-                          HashMap<Taclet, TacletBuilder<? extends Taclet>> taclet2Builder) {
+            HashMap<Taclet, TacletBuilder<? extends Taclet>> taclet2Builder) {
         this(services, namespaces);
         this.taclet2Builder = taclet2Builder;
     }
@@ -216,7 +218,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     private void announceTaclet(ParserRuleContext ctx, Taclet taclet) {
         taclet2Builder.put(taclet, peekTBuilder());
         LOGGER.trace("Taclet announced: \"{}\" from {}:{}", taclet.name(),
-                ctx.start.getTokenSource().getSourceName(), ctx.start.getLine());
+            ctx.start.getTokenSource().getSourceName(), ctx.start.getLine());
     }
 
     private TacletBuilder<?> peekTBuilder() {
@@ -259,9 +261,9 @@ public class TacletPBuilder extends ExpressionBuilder {
         String name = ctx.varexpId().getText();
         List<KeYParser.Varexp_argumentContext> arguments = ctx.varexp_argument();
         List<TacletBuilderCommand> suitableManipulators =
-                TacletBuilderManipulators.getConditionBuildersFor(name);
+            TacletBuilderManipulators.getConditionBuildersFor(name);
         List<String> parameters =
-                ctx.parameter.stream().map(Token::getText).collect(Collectors.toList());
+            ctx.parameter.stream().map(Token::getText).collect(Collectors.toList());
         boolean applied = false;
         Object[] argCache = new Object[arguments.size()];
         for (TacletBuilderCommand manipulator : suitableManipulators) {
@@ -280,8 +282,8 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private boolean applyManipulator(boolean negated, Object[] args,
-                                     TacletBuilderCommand manipulator, List<KeYParser.Varexp_argumentContext> arguments,
-                                     List<String> parameters) {
+            TacletBuilderCommand manipulator, List<KeYParser.Varexp_argumentContext> arguments,
+            List<String> parameters) {
         assert args.length == arguments.size();
         ArgumentType[] types = manipulator.getArgumentTypes();
 
@@ -300,24 +302,24 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private Object evaluateVarcondArgument(ArgumentType expectedType, Object prevValue,
-                                           KeYParser.Varexp_argumentContext ctx) {
+            KeYParser.Varexp_argumentContext ctx) {
         if (prevValue != null && expectedType.clazz.isAssignableFrom(prevValue.getClass())) {
             return prevValue; // previous value is of suitable type, we do not re-evaluate
         }
 
         switch (expectedType) {
-            case TYPE_RESOLVER:
-                return buildTypeResolver(ctx);
-            case SORT:
-                return visitSortId(ctx.term().getText(), ctx.term());
-            case JAVA_TYPE:
-                return getOrCreateJavaType(ctx.term().getText(), ctx);
-            case VARIABLE:
-                return varId(ctx, ctx.getText());
-            case STRING:
-                return ctx.getText();
-            case TERM:
-                return accept(ctx.term());
+        case TYPE_RESOLVER:
+            return buildTypeResolver(ctx);
+        case SORT:
+            return visitSortId(ctx.term().getText(), ctx.term());
+        case JAVA_TYPE:
+            return getOrCreateJavaType(ctx.term().getText(), ctx);
+        case VARIABLE:
+            return varId(ctx, ctx.getText());
+        case STRING:
+            return ctx.getText();
+        case TERM:
+            return accept(ctx.term());
         }
         assert false;
         return null;
@@ -495,7 +497,7 @@ public class TacletPBuilder extends ExpressionBuilder {
 
     @Nonnull
     private TacletBuilder<?> createTacletBuilderFor(Object find, int applicationRestriction,
-                                                    ParserRuleContext ctx) {
+            ParserRuleContext ctx) {
         if (find == null) {
             return new NoFindTacletBuilder();
         } else if (find instanceof Term) {
@@ -510,14 +512,14 @@ public class TacletPBuilder extends ExpressionBuilder {
                 AntecTacletBuilder b = new AntecTacletBuilder();
                 b.setFind(findFma);
                 b.setIgnoreTopLevelUpdates(
-                        (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
+                    (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
                 return b;
             } else if (findSeq.antecedent().size() == 0 && findSeq.succedent().size() == 1) {
                 Term findFma = findSeq.succedent().get(0).formula();
                 SuccTacletBuilder b = new SuccTacletBuilder();
                 b.setFind(findFma);
                 b.setIgnoreTopLevelUpdates(
-                        (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
+                    (applicationRestriction & RewriteTaclet.IN_SEQUENT_STATE) == 0);
                 return b;
             } else {
                 semanticError(ctx, "Unknown find-sequent (perhaps null?):" + findSeq);
@@ -527,12 +529,12 @@ public class TacletPBuilder extends ExpressionBuilder {
         }
 
         throw new IllegalArgumentException(
-                format("Could not find a suitable TacletBuilder for {0}", find));
+            format("Could not find a suitable TacletBuilder for {0}", find));
     }
 
     private void addGoalTemplate(String id, Object rwObj, Sequent addSeq,
-                                 ImmutableList<Taclet> addRList, ImmutableSet<SchemaVariable> pvs,
-                                 @Nullable ChoiceExpr soc, ParserRuleContext ctx) {
+            ImmutableList<Taclet> addRList, ImmutableSet<SchemaVariable> pvs,
+            @Nullable ChoiceExpr soc, ParserRuleContext ctx) {
         TacletBuilder<?> b = peekTBuilder();
         TacletGoalTemplate gt = null;
         if (rwObj == null) {
@@ -547,7 +549,7 @@ public class TacletPBuilder extends ExpressionBuilder {
                     gt = new AntecSuccTacletGoalTemplate(addSeq, addRList, (Sequent) rwObj, pvs);
                 } else {
                     semanticError(ctx, // new UnfittingReplacewithException
-                            "Replacewith in a Antec-or SuccTaclet has to contain a sequent (not a term)");
+                        "Replacewith in a Antec-or SuccTaclet has to contain a sequent (not a term)");
 
                 }
             } else if (b instanceof RewriteTacletBuilder) {
@@ -556,13 +558,13 @@ public class TacletPBuilder extends ExpressionBuilder {
                 } else {
                     // throwEx(/new UnfittingReplacewithException
                     semanticError(ctx,
-                            "Replacewith in a RewriteTaclet has to contain a term (not a sequent)");
+                        "Replacewith in a RewriteTaclet has to contain a term (not a sequent)");
                 }
             }
         }
         if (gt == null) {
             throw new NullPointerException(
-                    "Could not find a suitable goal template builder for: " + b.getClass());
+                "Could not find a suitable goal template builder for: " + b.getClass());
         }
         gt.setName(id);
         b.addTacletGoalTemplate(gt);
@@ -661,7 +663,7 @@ public class TacletPBuilder extends ExpressionBuilder {
 
         for (String id : ids) {
             declareSchemaVariable(ctx, id, s, makeVariableSV, makeSkolemTermSV, makeTermLabelSV,
-                    mods);
+                mods);
         }
         return null;
     }
@@ -673,7 +675,7 @@ public class TacletPBuilder extends ExpressionBuilder {
         for (String id : ids) {
             if (!mods.addModifier(id)) {
                 semanticError(ctx,
-                        "Illegal or unknown modifier in declaration of schema variable: %s", id);
+                    "Illegal or unknown modifier in declaration of schema variable: %s", id);
             }
         }
         return null;
@@ -685,8 +687,8 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     protected void declareSchemaVariable(ParserRuleContext ctx, String name, Sort s,
-                                         boolean makeVariableSV, boolean makeSkolemTermSV, boolean makeTermLabelSV,
-                                         SchemaVariableModifierSet mods) {
+            boolean makeVariableSV, boolean makeSkolemTermSV, boolean makeTermLabelSV,
+            SchemaVariableModifierSet mods) {
         SchemaVariable v;
         if (s == Sort.FORMULA && !makeSkolemTermSV) {
             v = SchemaVariableFactory.createFormulaSV(new Name(name), mods.rigid());
@@ -694,7 +696,7 @@ public class TacletPBuilder extends ExpressionBuilder {
             v = SchemaVariableFactory.createUpdateSV(new Name(name));
         } else if (s instanceof ProgramSVSort) {
             v = SchemaVariableFactory.createProgramSV(new ProgramElementName(name),
-                    (ProgramSVSort) s, mods.list());
+                (ProgramSVSort) s, mods.list());
         } else {
             if (makeVariableSV) {
                 v = SchemaVariableFactory.createVariableSV(new Name(name), s);
@@ -704,21 +706,21 @@ public class TacletPBuilder extends ExpressionBuilder {
                 v = SchemaVariableFactory.createTermLabelSV(new Name(name));
             } else {
                 v = SchemaVariableFactory.createTermSV(new Name(name), s, mods.rigid(),
-                        mods.strict());
+                    mods.strict());
             }
         }
 
         if (variables().lookup(v.name()) != null) {
             semanticError(null, "Schema variables shadows previous declared variable: %s.",
-                    v.name());
+                v.name());
         }
 
         if (schemaVariables().lookup(v.name()) != null) {
             SchemaVariable old = schemaVariables().lookup(v.name());
             if (!old.sort().equals(v.sort())) {
                 semanticError(null,
-                        "Schema variables clashes with previous declared schema variable: %s.",
-                        v.name());
+                    "Schema variables clashes with previous declared schema variable: %s.",
+                    v.name());
             }
             LOGGER.error("Override: {} {}", old, v);
         }


### PR DESCRIPTION
This PR brings restructuring of the KeY's grammar `KeYParser.g4`  for more performance.

Some of the changes are critical as they change the grammar, and need to be discuss.

The **current situation** is as follows. All given benchmarks given on our biggest Key-file `javaRules.key`. *Parse time* should be treated carefully, as JIT and caching effects have critical. 

![Screenshot from 2023-04-15 03-36-14](https://user-images.githubusercontent.com/104259/232178141-c8ae4d5c-8f58-41c2-93b0-e236aa7ea03b.png)

You see a lots of ambiguities and sometimes high maximal lookahead (max. 105).

The problem lies more in the *primitives* and some stupid rules. 

The following is possible, depending on the severity on changes. 

![Screenshot from 2023-04-15 04-03-41](https://user-images.githubusercontent.com/104259/232178099-7ae84f2f-e666-4026-8ae9-6119570fedf7.png)

![Screenshot from 2023-04-15 04-01-50](https://user-images.githubusercontent.com/104259/232178108-40bd78e6-3acc-4209-8a00-896dfc697ced.png)


### For discussing the changes, please refer to the comments on the source code below. 

/cc @jwiesler @mattulbrich @unp1 



