### PR TITLE
AutoPerf: Refactorings and minor changes

### DIFF
--- a/key.core.proof_references/src/test/resources/logback.xml
+++ b/key.core.proof_references/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.core.symbolic_execution/src/test/resources/logback.xml
+++ b/key.core.symbolic_execution/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.core.testgen/src/test/resources/logback.xml
+++ b/key.core.testgen/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.core/src/main/java/de/uka/ilkd/key/control/AbstractProofControl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/AbstractProofControl.java
@@ -126,9 +126,8 @@ public abstract class AbstractProofControl implements ProofControl {
         if (pos != null && focusedGoal != null) {
             LOGGER.debug("NoPosTacletApp: Looking for applicables rule at node {}",
                 focusedGoal.node().serialNr());
-            return filterTaclet(focusedGoal, focusedGoal.ruleAppIndex()
-                    .getFindTaclet(TacletFilter.TRUE, pos, focusedGoal.proof().getServices()),
-                pos);
+            return filterTaclet(focusedGoal,
+                focusedGoal.ruleAppIndex().getFindTaclet(TacletFilter.TRUE, pos), pos);
         }
         return ImmutableSLList.nil();
     }
@@ -136,8 +135,8 @@ public abstract class AbstractProofControl implements ProofControl {
     @Override
     public ImmutableList<TacletApp> getRewriteTaclet(Goal focusedGoal, PosInOccurrence pos) {
         if (pos != null) {
-            return filterTaclet(focusedGoal, focusedGoal.ruleAppIndex().getRewriteTaclet(
-                TacletFilter.TRUE, pos, focusedGoal.proof().getServices()), pos);
+            return filterTaclet(focusedGoal,
+                focusedGoal.ruleAppIndex().getRewriteTaclet(TacletFilter.TRUE, pos), pos);
         }
 
         return ImmutableSLList.nil();

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
@@ -300,7 +300,7 @@ public class Recoder2KeY implements JavaReader {
         de.uka.ilkd.key.java.CompilationUnit[] result =
             new de.uka.ilkd.key.java.CompilationUnit[cUnits.size()];
         for (int i = 0, sz = cUnits.size(); i < sz; i++) {
-            LOGGER.debug("converting now {}", cUnitStrings[i]);
+            LOGGER.trace("Converting {}", cUnitStrings[i]);
             try {
                 recoder.java.CompilationUnit cu = cUnits.get(i);
                 result[i] = getConverter().processCompilationUnit(cu, cu.getDataLocation());

--- a/key.core/src/main/java/de/uka/ilkd/key/java/TypeConverter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/TypeConverter.java
@@ -149,7 +149,7 @@ public final class TypeConverter {
             TypeCast tc = (TypeCast) op;
             return tb.cast(tc.getKeYJavaType(services).getSort(), subs[0]);
         } else {
-            LOGGER.debug("typeconverter: no data type model " + "available to convert:{} {}", op,
+            LOGGER.warn("no data type model " + "available to convert:{} {}", op,
                 op.getClass());
             throw new IllegalArgumentException(
                 "TypeConverter could not handle" + " this operator: " + op);
@@ -158,19 +158,15 @@ public final class TypeConverter {
 
 
     private Term convertReferencePrefix(ReferencePrefix prefix, ExecutionContext ec) {
-        LOGGER.debug("typeconverter: (prefix {}, class {})", prefix,
-            (prefix != null ? prefix.getClass() : null));
         if (prefix instanceof FieldReference) {
             return convertVariableReference((FieldReference) prefix, ec);
         } else if (prefix instanceof MetaClassReference) {
-            LOGGER.debug("typeconverter: " + "WARNING: metaclass-references not supported yet");
+            LOGGER.warn("WARNING: metaclass-references not supported yet");
             throw new IllegalArgumentException("TypeConverter could not handle" + " this");
         } else if (prefix instanceof ProgramVariable) {
             // the base case: the leftmost item is a local variable
             return tb.var((ProgramVariable) prefix);
         } else if (prefix instanceof VariableReference) {
-            LOGGER.debug("variablereference: {}",
-                (((VariableReference) prefix).getProgramVariable()));
             return tb.var(((VariableReference) prefix).getProgramVariable());
         } else if (prefix instanceof ArrayReference) {
             return convertArrayReference((ArrayReference) prefix, ec);
@@ -183,7 +179,7 @@ public final class TypeConverter {
             }
             return convertToLogicElement(ec.getRuntimeInstance());
         } else {
-            LOGGER.debug("WARNING: unknown reference prefix: {} {}", prefix,
+            LOGGER.warn("unknown reference prefix: {} {}", prefix,
                 prefix == null ? null : prefix.getClass());
             throw new IllegalArgumentException("TypeConverter failed to convert " + prefix);
         }
@@ -225,7 +221,6 @@ public final class TypeConverter {
     }
 
     public Term convertMethodReference(MethodReference mr, ExecutionContext ec) {
-        LOGGER.debug("TypeConverter: MethodReference: {}", mr);
         // FIXME this needs to handle two state?
         final ReferencePrefix prefix = mr.getReferencePrefix();
         Term p = convertReferencePrefix(prefix, ec);
@@ -250,7 +245,6 @@ public final class TypeConverter {
     }
 
     public Term convertVariableReference(VariableReference fr, ExecutionContext ec) {
-        LOGGER.debug("TypeConverter: FieldReference: {}", fr);
         final ReferencePrefix prefix = fr.getReferencePrefix();
         final ProgramVariable var = fr.getProgramVariable();
         if (var instanceof ProgramConstant) {
@@ -275,7 +269,7 @@ public final class TypeConverter {
                 heapLDT.getFieldSymbolForPV((LocationVariable) var, services);
             return tb.dot(var.sort(), convertReferencePrefix(prefix, ec), fieldSymbol);
         }
-        LOGGER.debug("Not supported reference type (fr {} , class {})", fr, fr.getClass());
+        LOGGER.warn("Not supported reference type (fr {} , class {})", fr, fr.getClass());
         throw new IllegalArgumentException("TypeConverter could not handle this");
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/SemisequentChangeInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/SemisequentChangeInfo.java
@@ -33,6 +33,19 @@ public class SemisequentChangeInfo {
         this.modifiedSemisequent = formulas;
     }
 
+    private SemisequentChangeInfo(SemisequentChangeInfo o) {
+        this.added = o.added;
+        this.removed = o.removed;
+        this.modified = o.modified;
+        this.modifiedSemisequent = o.modifiedSemisequent;
+        this.rejected = o.rejected;
+        this.lastFormulaIndex = o.lastFormulaIndex;
+    }
+
+    public SemisequentChangeInfo copy() {
+        return new SemisequentChangeInfo(this);
+    }
+
     /**
      * returns true if the semisequent has changed
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/SequentChangeInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/SequentChangeInfo.java
@@ -109,8 +109,8 @@ public class SequentChangeInfo {
      * @return true iff the sequent has been changed by the operation
      */
     public boolean hasChanged() {
-        return (antecedent == null || antecedent.hasChanged())
-                || (succedent == null || succedent.hasChanged());
+        return (antecedent != null && antecedent.hasChanged())
+                || (succedent != null && succedent.hasChanged());
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/SequentChangeInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/SequentChangeInfo.java
@@ -103,6 +103,14 @@ public class SequentChangeInfo {
         this.originalSequent = originalSequent;
     }
 
+    public SequentChangeInfo copy() {
+        return new SequentChangeInfo(
+            antecedent == null ? null : antecedent.copy(),
+            succedent == null ? null : succedent.copy(),
+            resultingSequent,
+            originalSequent);
+    }
+
     /**
      * returns true iff the sequent has been changed by the operation
      *
@@ -331,6 +339,4 @@ public class SequentChangeInfo {
 
         return result;
     }
-
-
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramSV.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramSV.java
@@ -292,9 +292,6 @@ public final class ProgramSV extends AbstractSV implements ProgramConstruct, Upd
 
         while (src != null) {
             if (!check(src, ec, services)) {
-                LOGGER.debug(
-                    "taclet: Stopped list matching because of " + "incompatible elements {} {}",
-                    this, src);
                 break;
             }
             matchedElements.add(src);

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
@@ -509,20 +509,20 @@ public class PrettyPrinter implements Visitor {
 
     @Override
     public void performActionOnForUpdates(ForUpdates x) {
-        // handled by loop methods
-        throw new UnsupportedOperationException();
+        writeCommaList(x.getUpdates());
     }
 
     @Override
     public void performActionOnGuard(Guard x) {
-        // handled by loop methods
-        throw new UnsupportedOperationException();
+        var child = x.getChildAt(0);
+        if (child != null) {
+            child.visit(this);
+        }
     }
 
     @Override
     public void performActionOnLoopInit(LoopInit x) {
-        // handled by loop methods
-        throw new UnsupportedOperationException();
+        writeCommaList(x.getInits());
     }
 
     @Override
@@ -947,8 +947,8 @@ public class PrettyPrinter implements Visitor {
         l.keyWord("while");
         l.print(" ");
         beginMultilineBracket();
-        if (x.getGuardExpression() != null) {
-            x.getGuardExpression().visit(this);
+        if (x.getGuard() != null) {
+            x.getGuard().visit(this);
         }
         endMultilineBracket();
         l.print(";");
@@ -993,13 +993,10 @@ public class PrettyPrinter implements Visitor {
 
         // there is no "getLoopInit" method
         // so get the first child of the for loop
+
         ILoopInit init = x.getILoopInit();
         if (init != null) {
-            if (init instanceof ProgramSV) {
-                init.visit(this);
-            } else {
-                writeCommaList(x.getInitializers());
-            }
+            init.visit(this);
         }
         l.print(";").brk();
         if (x.getGuardExpression() != null) {
@@ -1009,10 +1006,10 @@ public class PrettyPrinter implements Visitor {
 
         IForUpdates upd = x.getIForUpdates();
         if (upd != null) {
+            upd.visit(this);
             if (upd instanceof ProgramSV) {
-                upd.visit(this);
+
             } else {
-                writeCommaList(x.getUpdates());
             }
         }
         endMultilineBracket();
@@ -1668,8 +1665,7 @@ public class PrettyPrinter implements Visitor {
 
     @Override
     public void performActionOnThen(Then x) {
-        // Handled by if
-        throw new UnsupportedOperationException();
+        handleBlockOrSingleStatement(x.getBody());
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
@@ -1,11 +1,6 @@
 package de.uka.ilkd.key.proof;
 
-import de.uka.ilkd.key.logic.FormulaChangeInfo;
-import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.PosInTerm;
-import de.uka.ilkd.key.logic.Sequent;
-import de.uka.ilkd.key.logic.SequentChangeInfo;
-import de.uka.ilkd.key.logic.SequentFormula;
+import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.rule.BuiltInRule;
 import de.uka.ilkd.key.rule.IBuiltInRuleApp;
 
@@ -64,12 +59,8 @@ public class BuiltInRuleAppIndex {
         return index;
     }
 
-    private NewRuleListener getNewRulePropagator() {
-        return newRuleListener;
-    }
-
-    public void scanApplicableRules(Goal goal) {
-        scanSimplificationRule(goal, getNewRulePropagator());
+    public void scanApplicableRules(Goal goal, NewRuleListener newRuleListener) {
+        scanSimplificationRule(goal, newRuleListener);
     }
 
     private void scanSimplificationRule(Goal goal, NewRuleListener listener) {
@@ -87,8 +78,6 @@ public class BuiltInRuleAppIndex {
             scanSimplificationRule(index.rules(), goal, true, listener);
         }
     }
-
-
 
     private void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal, boolean antec,
             NewRuleListener listener) {
@@ -143,17 +132,17 @@ public class BuiltInRuleAppIndex {
      *
      * @param sci SequentChangeInfo describing the change of the sequent
      */
-    public void sequentChanged(Goal goal, SequentChangeInfo sci) {
-        scanAddedFormulas(goal, true, sci);
-        scanAddedFormulas(goal, false, sci);
+    public void sequentChanged(Goal goal, SequentChangeInfo sci, NewRuleListener listener) {
+        scanAddedFormulas(goal, true, sci, listener);
+        scanAddedFormulas(goal, false, sci, listener);
 
-        scanModifiedFormulas(goal, true, sci);
-        scanModifiedFormulas(goal, false, sci);
+        scanModifiedFormulas(goal, true, sci, listener);
+        scanModifiedFormulas(goal, false, sci, listener);
     }
 
-    private void scanAddedFormulas(Goal goal, boolean antec, SequentChangeInfo sci) {
+    private void scanAddedFormulas(Goal goal, boolean antec, SequentChangeInfo sci,
+            NewRuleListener listener) {
         ImmutableList<SequentFormula> cfmas = sci.addedFormulas(antec);
-        final NewRuleListener listener = getNewRulePropagator();
         while (!cfmas.isEmpty()) {
             final SequentFormula cfma = cfmas.head();
             scanSimplificationRule(index.rules(), goal, antec, cfma, listener);
@@ -162,9 +151,8 @@ public class BuiltInRuleAppIndex {
     }
 
 
-    private void scanModifiedFormulas(Goal goal, boolean antec, SequentChangeInfo sci) {
-
-        final NewRuleListener listener = getNewRulePropagator();
+    private void scanModifiedFormulas(Goal goal, boolean antec, SequentChangeInfo sci,
+            NewRuleListener listener) {
         ImmutableList<FormulaChangeInfo> fcis = sci.modifiedFormulas(antec);
 
         while (!fcis.isEmpty()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleIndex.java
@@ -6,7 +6,7 @@ import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
 /**
- * Index for managing built-in-rules usch as integer decision or update simplification rule.
+ * Index for managing built-in rules such as integer decision or update simplification rule.
  */
 public class BuiltInRuleIndex implements java.io.Serializable {
 
@@ -14,7 +14,7 @@ public class BuiltInRuleIndex implements java.io.Serializable {
      *
      */
     private static final long serialVersionUID = -4399004272449882750L;
-    /** list of available built in rules */
+    /** list of available built-in rules */
     private ImmutableList<BuiltInRule> rules = ImmutableSLList.nil();
 
     /** constructs empty rule index */
@@ -24,7 +24,7 @@ public class BuiltInRuleIndex implements java.io.Serializable {
     /**
      * creates a new index with the given built-in-rules
      *
-     * @param rules a IList<BuiltInRule> with available built in rules
+     * @param rules a IList<BuiltInRule> with available built-in rules
      */
     public BuiltInRuleIndex(ImmutableList<BuiltInRule> rules) {
         this.rules = rules;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/FormulaTagManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/FormulaTagManager.java
@@ -3,13 +3,7 @@ package de.uka.ilkd.key.proof;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 
-import de.uka.ilkd.key.logic.FormulaChangeInfo;
-import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.PosInTerm;
-import de.uka.ilkd.key.logic.Semisequent;
-import de.uka.ilkd.key.logic.Sequent;
-import de.uka.ilkd.key.logic.SequentChangeInfo;
-import de.uka.ilkd.key.logic.SequentFormula;
+import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.util.Debug;
 
 import org.key_project.util.collection.ImmutableList;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -163,14 +163,14 @@ public final class Goal {
 
     public void setRuleAppManager(AutomatedRuleApplicationManager manager) {
         if (ruleAppManager != null) {
-            ruleAppIndex().removeNewRuleListener(ruleAppManager);
+            ruleAppIndex.setNewRuleListener(null);
             ruleAppManager.setGoal(null);
         }
 
         ruleAppManager = manager;
 
         if (ruleAppManager != null) {
-            ruleAppIndex().addNewRuleListener(ruleAppManager);
+            ruleAppIndex.setNewRuleListener(ruleAppManager);
             ruleAppManager.setGoal(this);
         }
     }
@@ -222,7 +222,7 @@ public final class Goal {
         getFormulaTagManager().sequentChanged(this, sci);
         var time1 = System.nanoTime();
         PERF_UPDATE_TAG_MANAGER.getAndAdd(time1 - time);
-        ruleAppIndex().sequentChanged(this, sci);
+        ruleAppIndex.sequentChanged(sci);
         var time2 = System.nanoTime();
         PERF_UPDATE_RULE_APP_INDEX.getAndAdd(time2 - time1);
         for (GoalListener listener : listeners) {
@@ -237,7 +237,7 @@ public final class Goal {
         }
     }
 
-    private void fireAautomaticStateChanged(boolean oldAutomatic, boolean newAutomatic) {
+    private void fireAutomaticStateChanged(boolean oldAutomatic, boolean newAutomatic) {
         for (GoalListener listener : listeners) {
             listener.automaticStateChanged(this, oldAutomatic, newAutomatic);
         }
@@ -326,7 +326,7 @@ public final class Goal {
         boolean oldAutomatic = automatic;
         automatic = t;
         node().clearNameCache();
-        fireAautomaticStateChanged(oldAutomatic, automatic);
+        fireAutomaticStateChanged(oldAutomatic, automatic);
     }
 
     /**
@@ -336,15 +336,6 @@ public final class Goal {
      */
     public boolean isLinked() {
         return this.linkedGoal != null;
-    }
-
-    /**
-     * Returns the goal that this goal is linked to.
-     *
-     * @return The goal that this goal is linked to (or null if there is no such one).
-     */
-    public Goal getLinkedGoal() {
-        return this.linkedGoal;
     }
 
     /**
@@ -373,8 +364,8 @@ public final class Goal {
         }
         node().setSequent(sci.sequent());
         node().getNodeInfo().setSequentChangeInfo(sci);
-        // VK reminder: now update the index
         var time = System.nanoTime();
+        // updates the index
         fireSequentChanged(sci);
         PERF_SET_SEQUENT.getAndAdd(System.nanoTime() - time);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -126,8 +126,6 @@ public final class Goal {
 
     /**
      * creates a new goal referencing the given node
-     *
-     * @param namespaceSet
      */
     public Goal(Node node, RuleAppIndex ruleAppIndex) {
         this(node, ruleAppIndex, ImmutableSLList.nil(), null,
@@ -196,7 +194,7 @@ public final class Goal {
     /**
      * returns the namespaces for this goal.
      *
-     * @returns an up-to-date non-null namespaces-set.
+     * @return an up-to-date non-null namespaces-set.
      */
     public NamespaceSet getLocalNamespaces() {
         return localNamespaces;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -362,10 +362,15 @@ public final class Goal {
     /**
      * sets the sequent of the node
      *
-     * @param sci SequentChangeInfo containing the sequent to be set and desribing the applied
-     *        changes to the sequent of the parent node
+     * @param sci SequentChangeInfo containing the sequent to be set and describing the applied
+     *        changes to the sequent of the node currently pointed to by this goal
      */
     public void setSequent(SequentChangeInfo sci) {
+        assert sci.getOriginalSequent() == node().sequent();
+        if (!sci.hasChanged()) {
+            assert sci.sequent().equals(sci.getOriginalSequent());
+            return;
+        }
         node().setSequent(sci.sequent());
         node().getNodeInfo().setSequentChangeInfo(sci);
         // VK reminder: now update the index

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -619,28 +619,26 @@ public final class Goal {
         } finally {
             PERF_APP_EXECUTE.getAndAdd(System.nanoTime() - time);
         }
+        // can be null when the taclet failed to apply (RuleAbortException)
+        if (goalList == null) {
+            return null;
+        }
 
         proof.getServices().saveNameRecorder(n);
 
-        if (goalList != null) { // TODO: can goalList be null?
-            if (goalList.isEmpty()) {
-                proof.closeGoal(this);
-            } else {
-                proof.replace(this, goalList);
-                if (ruleApp instanceof TacletApp && ((TacletApp) ruleApp).taclet().closeGoal()) {
-                    // the first new goal is the one to be closed
-                    proof.closeGoal(goalList.head());
-                }
+        if (goalList.isEmpty()) {
+            proof.closeGoal(this);
+        } else {
+            proof.replace(this, goalList);
+            if (ruleApp instanceof TacletApp && ((TacletApp) ruleApp).taclet().closeGoal()) {
+                // the first new goal is the one to be closed
+                proof.closeGoal(goalList.head());
             }
         }
 
         adaptNamespacesNewGoals(goalList);
-
         final RuleAppInfo ruleAppInfo = journal.getRuleAppInfo(ruleApp);
-
-        if (goalList != null) {
-            proof.fireRuleApplied(new ProofEvent(proof, ruleAppInfo, goalList));
-        }
+        proof.fireRuleApplied(new ProofEvent(proof, ruleAppInfo, goalList));
         return goalList;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProgVarReplacer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProgVarReplacer.java
@@ -49,31 +49,6 @@ public final class ProgVarReplacer {
         this.services = services;
     }
 
-
-    /**
-     * merges "next" into "base" precondition: "next" is the result of replacing in "base" the
-     * formula at position "idx" by calling Semisequent.replace() (this implies that "next" contains
-     * exactly one removed and one added formula)
-     */
-    public static void mergeSemiCIs(SemisequentChangeInfo base, SemisequentChangeInfo next,
-            int idx) {
-        assert next.modifiedFormulas().isEmpty();
-
-        Iterator<SequentFormula> remIt = next.removedFormulas().iterator();
-        assert remIt.hasNext();
-        SequentFormula remCf = remIt.next();
-        assert !remIt.hasNext();
-        base.removedFormula(idx, remCf);
-
-        Iterator<SequentFormula> addIt = next.addedFormulas().iterator();
-        assert addIt.hasNext();
-        SequentFormula addCf = addIt.next();
-        assert !addIt.hasNext();
-        base.addedFormula(idx, addCf);
-
-        base.setFormulaList(next.getFormulaList());
-    }
-
     /**
      * replaces in a set
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -215,8 +215,7 @@ public class Proof implements Named {
         });
 
         var firstGoal =
-            new Goal(rootNode, new RuleAppIndex(new TacletAppIndex(rules, getServices()),
-                new BuiltInRuleAppIndex(builtInRules), getServices()));
+            new Goal(rootNode, rules, new BuiltInRuleAppIndex(builtInRules), getServices());
         openGoals = openGoals.prepend(firstGoal);
         setRoot(rootNode);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -1,8 +1,6 @@
 package de.uka.ilkd.key.proof;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -38,8 +36,7 @@ public final class RuleAppIndex {
 
     private final BuiltInRuleAppIndex builtInRuleAppIndex;
 
-    private final List<NewRuleListener> listenerList =
-        Collections.synchronizedList(new ArrayList<>(10));
+    private NewRuleListener ruleListener = null;
 
     /**
      * The current mode of the index: For <code>autoMode==true</code>, the index
@@ -128,17 +125,8 @@ public final class RuleAppIndex {
      *
      * @param l the AppIndexListener to add
      */
-    public void addNewRuleListener(NewRuleListener l) {
-        listenerList.add(l);
-    }
-
-    /**
-     * removes a change listener to the index
-     *
-     * @param l the AppIndexListener to remove
-     */
-    public void removeNewRuleListener(NewRuleListener l) {
-        listenerList.remove(l);
+    public void setNewRuleListener(@Nullable NewRuleListener l) {
+        ruleListener = l;
     }
 
     /**
@@ -301,15 +289,14 @@ public final class RuleAppIndex {
     /**
      * called if a formula has been replaced
      *
-     * @param g the Goal which sequent has been changed
      * @param sci SequentChangeInfo describing the change of the sequent
      */
-    public void sequentChanged(Goal g, SequentChangeInfo sci) {
+    public void sequentChanged(SequentChangeInfo sci) {
         if (!autoMode) {
             interactiveTacletAppIndex.sequentChanged(sci);
         }
         automatedTacletAppIndex.sequentChanged(sci);
-        builtInRuleAppIndex().sequentChanged(g, sci, newRuleListener);
+        builtInRuleAppIndex.sequentChanged(goal, sci, newRuleListener);
     }
 
     /**
@@ -349,7 +336,7 @@ public final class RuleAppIndex {
      */
     public void reportAutomatedRuleApps(NewRuleListener l, Services services) {
         automatedTacletAppIndex.reportRuleApps(l, services);
-        builtInRuleAppIndex().reportRuleApps(l, goal);
+        builtInRuleAppIndex.reportRuleApps(l, goal);
     }
 
     /**
@@ -365,8 +352,8 @@ public final class RuleAppIndex {
      * informs all observers, if a formula has been added, changed or removed
      */
     private void informNewRuleListener(RuleApp p_app, PosInOccurrence p_pos) {
-        for (final NewRuleListener listener : listenerList) {
-            listener.ruleAdded(p_app, p_pos);
+        if (ruleListener != null) {
+            ruleListener.ruleAdded(p_app, p_pos);
         }
     }
 
@@ -375,8 +362,8 @@ public final class RuleAppIndex {
      */
     private void informNewRuleListener(ImmutableList<? extends RuleApp> p_apps,
             PosInOccurrence p_pos) {
-        for (final NewRuleListener listener : listenerList) {
-            listener.rulesAdded(p_apps, p_pos);
+        if (ruleListener != null) {
+            ruleListener.rulesAdded(p_apps, p_pos);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -23,7 +23,7 @@ import org.key_project.util.collection.ImmutableSLList;
  */
 public final class RuleAppIndex {
 
-    private Goal goal;
+    private final Goal goal;
 
     private final TacletIndex tacletIndex;
 
@@ -58,17 +58,13 @@ public final class RuleAppIndex {
         }
     };
 
-
-    public RuleAppIndex(TacletAppIndex p_tacletAppIndex, BuiltInRuleAppIndex p_builtInRuleAppIndex,
-            Services services) {
-        this(p_tacletAppIndex.tacletIndex(), p_builtInRuleAppIndex, services);
-    }
-
     public RuleAppIndex(TacletIndex p_tacletIndex, BuiltInRuleAppIndex p_builtInRuleAppIndex,
+            Goal goal,
             Services services) {
         tacletIndex = p_tacletIndex;
-        automatedTacletAppIndex = new TacletAppIndex(tacletIndex, services);
-        interactiveTacletAppIndex = new TacletAppIndex(tacletIndex, services);
+        automatedTacletAppIndex = new TacletAppIndex(tacletIndex, goal, services);
+        interactiveTacletAppIndex = new TacletAppIndex(tacletIndex, goal, services);
+        this.goal = goal;
         builtInRuleAppIndex = p_builtInRuleAppIndex;
         // default to false to keep compatibility with old code
         autoMode = false;
@@ -81,12 +77,13 @@ public final class RuleAppIndex {
 
     private RuleAppIndex(TacletIndex tacletIndex, TacletAppIndex interactiveTacletAppIndex,
             TacletAppIndex automatedTacletAppIndex, BuiltInRuleAppIndex builtInRuleAppIndex,
-            boolean autoMode) {
+            Goal goal, boolean autoMode) {
         this.tacletIndex = tacletIndex;
         this.interactiveTacletAppIndex = interactiveTacletAppIndex;
         this.automatedTacletAppIndex = automatedTacletAppIndex;
         this.builtInRuleAppIndex = builtInRuleAppIndex;
         this.autoMode = autoMode;
+        this.goal = goal;
 
         setNewRuleListeners();
     }
@@ -95,12 +92,6 @@ public final class RuleAppIndex {
         interactiveTacletAppIndex.setNewRuleListener(newRuleListener);
         automatedTacletAppIndex.setNewRuleListener(newRuleListener);
         builtInRuleAppIndex.setNewRuleListener(newRuleListener);
-    }
-
-    public void setup(Goal p_goal) {
-        goal = p_goal;
-        interactiveTacletAppIndex.setup(p_goal);
-        automatedTacletAppIndex.setup(p_goal);
     }
 
     /**
@@ -394,14 +385,14 @@ public final class RuleAppIndex {
      * returns a new RuleAppIndex with a copied TacletIndex. Attention: the listener lists are not
      * copied
      */
-    public RuleAppIndex copy() {
+    public RuleAppIndex copy(Goal goal) {
         TacletIndex copiedTacletIndex = tacletIndex.copy();
         TacletAppIndex copiedInteractiveTacletAppIndex =
-            interactiveTacletAppIndex.copyWithTacletIndex(copiedTacletIndex);
+            interactiveTacletAppIndex.copyWith(copiedTacletIndex, goal);
         TacletAppIndex copiedAutomatedTacletAppIndex =
-            automatedTacletAppIndex.copyWithTacletIndex(copiedTacletIndex);
+            automatedTacletAppIndex.copyWith(copiedTacletIndex, goal);
         return new RuleAppIndex(copiedTacletIndex, copiedInteractiveTacletAppIndex,
-            copiedAutomatedTacletAppIndex, builtInRuleAppIndex().copy(), autoMode);
+            copiedAutomatedTacletAppIndex, builtInRuleAppIndex().copy(), goal, autoMode);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SemisequentTacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SemisequentTacletAppIndex.java
@@ -1,24 +1,17 @@
 package de.uka.ilkd.key.proof;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import de.uka.ilkd.key.java.Services;
-import de.uka.ilkd.key.logic.FormulaChangeInfo;
-import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.PosInTerm;
-import de.uka.ilkd.key.logic.Sequent;
-import de.uka.ilkd.key.logic.SequentChangeInfo;
-import de.uka.ilkd.key.logic.SequentFormula;
+import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.proof.rulefilter.RuleFilter;
 import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.TacletApp;
 
-import org.key_project.util.collection.DefaultImmutableMap;
-import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableMap;
-import org.key_project.util.collection.ImmutableMapEntry;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.*;
 
 /**
  * This class holds <code>TermTacletAppIndex</code>s for all formulas of a semisequent.
@@ -42,12 +35,12 @@ public class SemisequentTacletAppIndex {
      * Add indices for the given formulas to the map <code>termIndices</code>. Existing entries are
      * replaced with the new indices. Note: destructive, use only when constructing new index
      */
-    private void addTermIndices(ImmutableList<SequentFormula> cfmas, Sequent s, Services services,
+    private void addTermIndices(ImmutableList<SequentFormula> cfmas, Services services,
             TacletIndex tacletIndex, NewRuleListener listener) {
         while (!cfmas.isEmpty()) {
             final SequentFormula cfma = cfmas.head();
             cfmas = cfmas.tail();
-            addTermIndex(cfma, s, services, tacletIndex, listener);
+            addTermIndex(cfma, services, tacletIndex, listener);
         }
     }
 
@@ -55,7 +48,7 @@ public class SemisequentTacletAppIndex {
      * Add an index for the given formula to the map <code>termIndices</code>. An existing entry is
      * replaced with the new one. Note: destructive, use only when constructing new index
      */
-    private void addTermIndex(SequentFormula cfma, Sequent s, Services services,
+    private void addTermIndex(SequentFormula cfma, Services services,
             TacletIndex tacletIndex, NewRuleListener listener) {
         final PosInOccurrence pos = new PosInOccurrence(cfma, PosInTerm.getTopLevel(), antec);
         termIndices = termIndices.put(cfma, TermTacletAppIndex.create(pos, services, tacletIndex,
@@ -67,7 +60,7 @@ public class SemisequentTacletAppIndex {
      * <code>termIndices</code>, by adding the taclets that are selected by <code>filter</code>
      * Note: destructive, use only when constructing new index
      */
-    private void addTaclets(RuleFilter filter, SequentFormula cfma, Sequent s, Services services,
+    private void addTaclets(RuleFilter filter, SequentFormula cfma, Services services,
             TacletIndex tacletIndex, NewRuleListener listener) {
         final TermTacletAppIndex oldIndex = termIndices.get(cfma);
         assert oldIndex != null : "Term index that is supposed to be updated " + "does not exist";
@@ -102,20 +95,17 @@ public class SemisequentTacletAppIndex {
      * @return the old indices in the same order as the list <code>infos</code> Note: destructive,
      *         use only when constructing new index
      */
-    private ImmutableList<TermTacletAppIndex> removeFormulas(
-            ImmutableList<FormulaChangeInfo> infos) {
+    private List<TermTacletAppIndex> removeFormulas(ImmutableList<FormulaChangeInfo> infos) {
+        var oldIndices = new ArrayList<TermTacletAppIndex>(infos.size());
 
-        ImmutableList<TermTacletAppIndex> oldIndices = ImmutableSLList.nil();
-
-        for (FormulaChangeInfo info1 : infos) {
-            final FormulaChangeInfo info = info1;
+        for (FormulaChangeInfo info : infos) {
             final SequentFormula oldFor = info.getOriginalFormula();
 
-            oldIndices = oldIndices.prepend(termIndices.get(oldFor));
-            termIndices = termIndices.remove(oldFor);
+            oldIndices.add(termIndices.get(oldFor));
+            removeTermIndex(oldFor);
         }
 
-        return oldIndices.reverse();
+        return oldIndices;
     }
 
     /**
@@ -124,10 +114,9 @@ public class SemisequentTacletAppIndex {
      * The new indices are inserted in the map <code>termIndices</code>. Note: destructive, use only
      * when constructing new index
      */
-    private void updateTermIndices(ImmutableList<TermTacletAppIndex> oldIndices,
-            ImmutableList<FormulaChangeInfo> infos, Sequent newSeq, Services services,
-            TacletIndex tacletIndex, NewRuleListener listener) {
-
+    private void updateTermIndices(List<TermTacletAppIndex> oldIndices,
+            ImmutableList<FormulaChangeInfo> infos, Services services, TacletIndex tacletIndex,
+            NewRuleListener listener) {
         final Iterator<FormulaChangeInfo> infoIt = infos.iterator();
         final Iterator<TermTacletAppIndex> oldIndexIt = oldIndices.iterator();
 
@@ -139,7 +128,7 @@ public class SemisequentTacletAppIndex {
             if (oldIndex == null)
             // completely rebuild the term index
             {
-                addTermIndex(newFor, newSeq, services, tacletIndex, listener);
+                addTermIndex(newFor, services, tacletIndex, listener);
             } else {
                 final PosInOccurrence oldPos = info.getPositionOfModification();
                 final PosInOccurrence newPos = oldPos.replaceConstrainedFormula(newFor);
@@ -149,13 +138,13 @@ public class SemisequentTacletAppIndex {
         }
     }
 
-    private void updateTermIndices(ImmutableList<FormulaChangeInfo> infos, Sequent newSeq,
+    private void updateTermIndices(ImmutableList<FormulaChangeInfo> infos,
             Services services, TacletIndex tacletIndex, NewRuleListener listener) {
 
         // remove original indices
-        final ImmutableList<TermTacletAppIndex> oldIndices = removeFormulas(infos);
+        final List<TermTacletAppIndex> oldIndices = removeFormulas(infos);
 
-        updateTermIndices(oldIndices, infos, newSeq, services, tacletIndex, listener);
+        updateTermIndices(oldIndices, infos, services, tacletIndex, listener);
     }
 
     /**
@@ -172,7 +161,7 @@ public class SemisequentTacletAppIndex {
         this.antec = antec;
         this.ruleFilter = ruleFilter;
         this.indexCaches = indexCaches;
-        addTermIndices((antec ? s.antecedent() : s.succedent()).asList(), s, services, tacletIndex,
+        addTermIndices((antec ? s.antecedent() : s.succedent()).asList(), services, tacletIndex,
             listener);
     }
 
@@ -225,13 +214,11 @@ public class SemisequentTacletAppIndex {
             PERF_REMOVE.getAndAdd(System.nanoTime() - time);
 
             time = System.nanoTime();
-            result.updateTermIndices(sci.modifiedFormulas(antec), sci.sequent(), services,
-                tacletIndex, listener);
+            result.updateTermIndices(sci.modifiedFormulas(antec), services, tacletIndex, listener);
             PERF_UPDATE.getAndAdd(System.nanoTime() - time);
 
             time = System.nanoTime();
-            result.addTermIndices(sci.addedFormulas(antec), sci.sequent(), services, tacletIndex,
-                listener);
+            result.addTermIndices(sci.addedFormulas(antec), services, tacletIndex, listener);
             PERF_ADD.getAndAdd(System.nanoTime() - time);
             return result;
         }
@@ -246,13 +233,13 @@ public class SemisequentTacletAppIndex {
      *
      * @param filter The taclets that are supposed to be added
      */
-    public SemisequentTacletAppIndex addTaclets(RuleFilter filter, Sequent s, Services services,
+    public SemisequentTacletAppIndex addTaclets(RuleFilter filter, Services services,
             TacletIndex tacletIndex, NewRuleListener listener) {
         final SemisequentTacletAppIndex result = copy();
         final Iterator<SequentFormula> it = termIndices.keyIterator();
 
         while (it.hasNext()) {
-            result.addTaclets(filter, it.next(), s, services, tacletIndex, listener);
+            result.addTaclets(filter, it.next(), services, tacletIndex, listener);
         }
 
         return result;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/delayedcut/DelayedCutProcessor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/delayedcut/DelayedCutProcessor.java
@@ -5,25 +5,14 @@ import java.util.LinkedList;
 import java.util.List;
 
 import de.uka.ilkd.key.java.Services;
-import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.PosInTerm;
-import de.uka.ilkd.key.logic.SequentFormula;
-import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.TermServices;
+import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.SchemaVariable;
 import de.uka.ilkd.key.logic.op.SkolemTermSV;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.rulefilter.TacletFilter;
-import de.uka.ilkd.key.rule.BuiltInRule;
-import de.uka.ilkd.key.rule.FindTaclet;
-import de.uka.ilkd.key.rule.IBuiltInRuleApp;
-import de.uka.ilkd.key.rule.NoPosTacletApp;
-import de.uka.ilkd.key.rule.PosTacletApp;
-import de.uka.ilkd.key.rule.RuleApp;
-import de.uka.ilkd.key.rule.Taclet;
-import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.util.collection.ImmutableList;
@@ -181,7 +170,7 @@ public class DelayedCutProcessor implements Runnable {
         };
 
         ImmutableList<NoPosTacletApp> apps =
-            goal.ruleAppIndex().getFindTaclet(filter, pio, goal.proof().getServices());
+            goal.ruleAppIndex().getFindTaclet(filter, pio);
         assert apps.size() == 1;
         NoPosTacletApp app = apps.head();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
@@ -29,6 +29,7 @@ import de.uka.ilkd.key.proof.init.IPersistablePO.LoadedPOContainer;
 import de.uka.ilkd.key.proof.io.consistency.DiskFileRepo;
 import de.uka.ilkd.key.proof.io.consistency.FileRepo;
 import de.uka.ilkd.key.proof.io.consistency.SimpleFileRepo;
+import de.uka.ilkd.key.prover.impl.PerfScope;
 import de.uka.ilkd.key.rule.OneStepSimplifier;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.speclang.Contract;
@@ -306,10 +307,18 @@ public abstract class AbstractProblemLoader {
     protected void loadEnvironment() throws ProofInputException, IOException {
         FileRepo fileRepo = createFileRepo();
 
+        var timeBeforeEnv = System.nanoTime();
+        LOGGER.info("Loading environment from " + file);
         envInput = createEnvInput(fileRepo);
+        LOGGER.debug(
+            "Environment load took " + PerfScope.formatTime(System.nanoTime() - timeBeforeEnv));
         problemInitializer = createProblemInitializer(fileRepo);
+        var beforeInitConfig = System.nanoTime();
+        LOGGER.info("Creating init config");
         initConfig = createInitConfig();
         initConfig.setFileRepo(fileRepo);
+        LOGGER.debug(
+            "Init config took " + PerfScope.formatTime(System.nanoTime() - beforeInitConfig));
         if (!problemInitializer.getWarnings().isEmpty() && !ignoreWarnings) {
             control.reportWarnings(problemInitializer.getWarnings());
         }
@@ -704,6 +713,7 @@ public abstract class AbstractProblemLoader {
 
     private ReplayResult replayProof(Proof proof)
             throws ProofInputException, ProblemLoaderException {
+        LOGGER.info("Replaying proof " + proof.name());
         String status = "";
         List<Throwable> errors = new LinkedList<>();
         Node lastTouchedNode = proof.root();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -30,6 +30,7 @@ import de.uka.ilkd.key.proof.io.intermediate.MergeAppIntermediate;
 import de.uka.ilkd.key.proof.io.intermediate.MergePartnerAppIntermediate;
 import de.uka.ilkd.key.proof.io.intermediate.NodeIntermediate;
 import de.uka.ilkd.key.proof.io.intermediate.TacletAppIntermediate;
+import de.uka.ilkd.key.prover.impl.PerfScope;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.merge.MergePartner;
 import de.uka.ilkd.key.rule.merge.MergeProcedure;
@@ -163,6 +164,7 @@ public class IntermediateProofReplayer {
         int stepIndex = 0;
         int reportInterval = 1;
         int max = 0;
+        var time = System.nanoTime();
         if (listener != null && progressMonitor != null) {
             max = !queue.isEmpty() && queue.peekFirst().second != null
                     ? queue.peekFirst().second.countAllChildren()
@@ -354,6 +356,7 @@ public class IntermediateProofReplayer {
         if (listener != null && progressMonitor != null) {
             progressMonitor.setProgress(max);
         }
+        LOGGER.debug("Proof replay took " + PerfScope.formatTime(System.nanoTime() - time));
         return new Result(status, errors, currGoal);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
@@ -158,6 +158,7 @@ public class KeYFile implements EnvInput {
     protected KeyAst.File getParseContext() {
         if (fileCtx == null) {
             try {
+                LOGGER.trace("Reading KeY file {}", file);
                 fileCtx = ParsingFacade.parseFile(file.getCharStream());
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -304,7 +305,6 @@ public class KeYFile implements EnvInput {
             throw new IllegalStateException("KeYFile: InitConfig not set.");
         }
         // read .key file
-        LOGGER.debug("Reading KeY file {}", file);
         ChoiceInformation ci = getParseContext().getChoices();
         initConfig.addCategory2DefaultChoices(ci.getDefaultOptions());
 
@@ -320,9 +320,6 @@ public class KeYFile implements EnvInput {
      * @return list of parser warnings
      */
     public ImmutableSet<PositionedString> readContracts() {
-        LOGGER.debug("Read specifications obtained when parsing the Java files " +
-            "(usually JML and Strings.key) from {}", file);
-
         SpecificationRepository specRepos = initConfig.getServices().getSpecificationRepository();
         ContractsAndInvariantsFinder cinvs =
             new ContractsAndInvariantsFinder(initConfig.getServices(), initConfig.namespaces());

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/join/JoinProcessor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/join/JoinProcessor.java
@@ -156,7 +156,7 @@ public class JoinProcessor implements Runnable {
 
         };
         ImmutableList<NoPosTacletApp> apps =
-            goal.ruleAppIndex().getFindTaclet(filter, pio, services);
+            goal.ruleAppIndex().getFindTaclet(filter, pio);
 
         if (apps.isEmpty()) {
             return null;

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
@@ -8,6 +8,8 @@
 package de.uka.ilkd.key.prover.impl;
 
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.proof.proofevent.RuleAppInfo;
 import de.uka.ilkd.key.prover.GoalChooser;
@@ -31,6 +33,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ApplyStrategy extends AbstractProverCore {
     public static final Logger LOGGER = LoggerFactory.getLogger(ApplyStrategy.class);
+
+    public static final AtomicLong PERF_GOAL_APPLY = new AtomicLong();
 
     /**
      * the proof that is worked with
@@ -108,11 +112,15 @@ public class ApplyStrategy extends AbstractProverCore {
                 "No more rules automatically applicable to any goal.", g, app);
         } else {
             assert g != null;
-            g.apply(app);
+            var time = System.nanoTime();
+            try {
+                g.apply(app);
+            } finally {
+                PERF_GOAL_APPLY.getAndAdd(System.nanoTime() - time);
+            }
             return new SingleRuleApplicationInfo(g, app);
         }
     }
-
 
     /**
      * applies rules until this is no longer possible or the thread is interrupted.
@@ -121,13 +129,22 @@ public class ApplyStrategy extends AbstractProverCore {
             final StopCondition stopCondition) {
         time = System.currentTimeMillis();
         SingleRuleApplicationInfo srInfo = null;
+
+        var perfScope = new PerfScope();
+        long applyAutomatic = 0;
         try {
             LOGGER.trace("Strategy started.");
             boolean shouldStop = stopCondition.shouldStop(maxApplications, timeout, proof, time,
                 countApplied, srInfo);
 
             while (!shouldStop) {
-                srInfo = applyAutomaticRule(goalChooser, stopCondition, stopAtFirstNonClosableGoal);
+                var applyAutomaticTime = System.nanoTime();
+                try {
+                    srInfo =
+                        applyAutomaticRule(goalChooser, stopCondition, stopAtFirstNonClosableGoal);
+                } finally {
+                    applyAutomatic += System.nanoTime() - applyAutomaticTime;
+                }
                 if (!srInfo.isSuccess()) {
                     return new ApplyStrategyInfo(srInfo.message(), proof, null, srInfo.getGoal(),
                         System.currentTimeMillis() - time, countApplied, closedGoals);
@@ -158,6 +175,9 @@ public class ApplyStrategy extends AbstractProverCore {
         } finally {
             time = (System.currentTimeMillis() - time);
             LOGGER.trace("Strategy stopped, applied {} steps in {}ms", countApplied, time);
+
+            PerfScope.displayTime("applyAutomaticRule", applyAutomatic);
+            perfScope.report();
         }
         assert srInfo != null;
         return new ApplyStrategyInfo(srInfo.message(), proof, null, srInfo.getGoal(), time,

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
@@ -176,7 +176,7 @@ public class ApplyStrategy extends AbstractProverCore {
             time = (System.currentTimeMillis() - time);
             LOGGER.trace("Strategy stopped, applied {} steps in {}ms", countApplied, time);
 
-            PerfScope.displayTime("applyAutomaticRule", applyAutomatic);
+            LOGGER.trace("applyAutomaticRule: " + PerfScope.formatTime(applyAutomatic));
             perfScope.report();
         }
         assert srInfo != null;

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
@@ -1,6 +1,8 @@
 package de.uka.ilkd.key.prover.impl;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
 import de.uka.ilkd.key.proof.Goal;
@@ -52,7 +54,8 @@ public class PerfScope {
         new Pair<>("AbstractBuiltInRuleApp Goal setSequent",
             AbstractBuiltInRuleApp.PERF_SET_SEQUENT),
     };
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.##");
+    private static final DecimalFormat DECIMAL_FORMAT =
+        new DecimalFormat("#.##", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     private final long timeNs = System.nanoTime();
     private final long[] timesBefore = new long[PERF_COUNTERS.length];
@@ -63,7 +66,7 @@ public class PerfScope {
         }
     }
 
-    public static void displayTime(String name, long dt) {
+    public static String formatTime(long dt) {
         String unit;
         double time;
         if (dt < 1000000) {
@@ -77,7 +80,11 @@ public class PerfScope {
             unit = "s";
         }
 
-        LOGGER.trace(name + ": " + DECIMAL_FORMAT.format(time) + unit);
+        return DECIMAL_FORMAT.format(time) + unit;
+    }
+
+    private static void displayTime(String name, long dt) {
+        LOGGER.trace(name + ": " + formatTime(dt));
     }
 
     public void report() {

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
@@ -1,0 +1,93 @@
+package de.uka.ilkd.key.prover.impl;
+
+import java.text.DecimalFormat;
+import java.util.concurrent.atomic.AtomicLong;
+
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.SemisequentTacletAppIndex;
+import de.uka.ilkd.key.proof.TacletAppIndex;
+import de.uka.ilkd.key.rule.AbstractBuiltInRuleApp;
+import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.rule.executor.javadl.FindTacletExecutor;
+import de.uka.ilkd.key.rule.executor.javadl.NoFindTacletExecutor;
+import de.uka.ilkd.key.strategy.JavaCardDLStrategy;
+import de.uka.ilkd.key.strategy.QueueRuleApplicationManager;
+import de.uka.ilkd.key.util.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PerfScope {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerfScope.class);
+    private static final Pair<String, AtomicLong>[] PERF_COUNTERS = new Pair[] {
+        new Pair<>("JavaCardDLStrategy approve", JavaCardDLStrategy.PERF_APPROVE),
+        new Pair<>("JavaCardDLStrategy instantiate", JavaCardDLStrategy.PERF_INSTANTIATE),
+        new Pair<>("JavaCardDLStrategy compute", JavaCardDLStrategy.PERF_COMPUTE),
+        new Pair<>("QueueRuleApplicationManager peek", QueueRuleApplicationManager.PERF_PEEK),
+        new Pair<>("QueueRuleApplicationManager queue ops",
+            QueueRuleApplicationManager.PERF_QUEUE_OPS),
+        new Pair<>("QueueRuleApplicationManager create container",
+            QueueRuleApplicationManager.PERF_CREATE_CONTAINER),
+        new Pair<>("Goal apply", ApplyStrategy.PERF_GOAL_APPLY),
+        new Pair<>("RuleApp execute", Goal.PERF_APP_EXECUTE),
+        new Pair<>("Goal setSequent", Goal.PERF_SET_SEQUENT),
+        new Pair<>("Goal update tag manager", Goal.PERF_UPDATE_TAG_MANAGER),
+        new Pair<>("Goal update rule app index", Goal.PERF_UPDATE_RULE_APP_INDEX),
+        new Pair<>("Taclet app index update", TacletAppIndex.PERF_UPDATE),
+        new Pair<>("Semi Taclet app index update remove", SemisequentTacletAppIndex.PERF_REMOVE),
+        new Pair<>("Semi Taclet app index update add", SemisequentTacletAppIndex.PERF_ADD),
+        new Pair<>("Semi Taclet app index update update", SemisequentTacletAppIndex.PERF_UPDATE),
+        new Pair<>("Taclet app index create all", TacletAppIndex.PERF_CREATE_ALL),
+        new Pair<>("Goal update listeners", Goal.PERF_UPDATE_LISTENERS),
+        new Pair<>("TacletApp execute", TacletApp.PERF_EXECUTE),
+        new Pair<>("TacletApp pre", TacletApp.PERF_PRE),
+        new Pair<>("TacletApp Goal setSequent", TacletApp.PERF_SET_SEQUENT),
+        new Pair<>("NoFindTacletExecutor apply", NoFindTacletExecutor.PERF_APPLY),
+        new Pair<>("NoFindTacletExecutor setSequent", NoFindTacletExecutor.PERF_SET_SEQUENT),
+        new Pair<>("NoFindTacletExecutor term labels", NoFindTacletExecutor.PERF_TERM_LABELS),
+        new Pair<>("FindTacletExecutor apply", FindTacletExecutor.PERF_APPLY),
+        new Pair<>("FindTacletExecutor setSequent", FindTacletExecutor.PERF_SET_SEQUENT),
+        new Pair<>("FindTacletExecutor term labels", FindTacletExecutor.PERF_TERM_LABELS),
+        new Pair<>("AbstractBuiltInRuleApp execute", AbstractBuiltInRuleApp.PERF_EXECUTE),
+        new Pair<>("AbstractBuiltInRuleApp Goal setSequent",
+            AbstractBuiltInRuleApp.PERF_SET_SEQUENT),
+    };
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.##");
+
+    private final long timeNs = System.nanoTime();
+    private final long[] timesBefore = new long[PERF_COUNTERS.length];
+
+    public PerfScope() {
+        for (int i = 0; i < PERF_COUNTERS.length; i++) {
+            timesBefore[i] = PERF_COUNTERS[i].second.get();
+        }
+    }
+
+    public static void displayTime(String name, long dt) {
+        String unit;
+        double time;
+        if (dt < 1000000) {
+            time = dt / 1e3;
+            unit = "ns";
+        } else if (dt < 1000000000) {
+            time = dt / 1e6;
+            unit = "ms";
+        } else {
+            time = dt / 1e9;
+            unit = "s";
+        }
+
+        LOGGER.trace(name + ": " + DECIMAL_FORMAT.format(time) + unit);
+    }
+
+    public void report() {
+        displayTime("Total", System.nanoTime() - timeNs);
+
+        for (int i = 0; i < PERF_COUNTERS.length; i++) {
+            Pair<String, AtomicLong> perf = PERF_COUNTERS[i];
+            long timeBefore = timesBefore[i];
+            var dt = perf.second.getAndSet(0) - timeBefore;
+            displayTime(perf.first, dt);
+        }
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -12,6 +13,8 @@ import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
 public abstract class AbstractBuiltInRuleApp implements IBuiltInRuleApp {
+    public static final AtomicLong PERF_EXECUTE = new AtomicLong();
+    public static final AtomicLong PERF_SET_SEQUENT = new AtomicLong();
 
     protected final BuiltInRule builtInRule;
 
@@ -65,17 +68,21 @@ public abstract class AbstractBuiltInRuleApp implements IBuiltInRuleApp {
      */
     @Override
     public ImmutableList<Goal> execute(Goal goal, Services services) {
-        goal.addAppliedRuleApp(this);
-        ImmutableList<Goal> result = null;
+        var time = System.nanoTime();
+        var timeSetSequent = Goal.PERF_SET_SEQUENT.get();
         try {
-            result = builtInRule.apply(goal, services, this);
-        } catch (RuleAbortException rae) {
+            goal.addAppliedRuleApp(this);
+            try {
+                return builtInRule.apply(goal, services, this);
+            } catch (RuleAbortException rae) {
+                goal.removeLastAppliedRuleApp();
+                goal.node().setAppliedRuleApp(null);
+                return null;
+            }
+        } finally {
+            PERF_EXECUTE.getAndAdd(System.nanoTime() - time);
+            PERF_SET_SEQUENT.getAndAdd(Goal.PERF_SET_SEQUENT.get() - timeSetSequent);
         }
-        if (result == null) {
-            goal.removeLastAppliedRuleApp();
-            goal.node().setAppliedRuleApp(null);
-        }
-        return result;
     }
 
     public abstract AbstractBuiltInRuleApp replacePos(PosInOccurrence newPos);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
@@ -73,7 +73,7 @@ public abstract class AbstractBuiltInRuleApp implements IBuiltInRuleApp {
         try {
             goal.addAppliedRuleApp(this);
             try {
-                return builtInRule.apply(goal, services, this);
+                return Objects.requireNonNull(builtInRule.apply(goal, services, this));
             } catch (RuleAbortException rae) {
                 goal.removeLastAppliedRuleApp();
                 goal.node().setAppliedRuleApp(null);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
@@ -3,6 +3,7 @@ package de.uka.ilkd.key.rule;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -67,7 +68,7 @@ public abstract class AbstractBuiltInRuleApp implements IBuiltInRuleApp {
      * @return list of new created goals
      */
     @Override
-    public ImmutableList<Goal> execute(Goal goal, Services services) {
+    public @Nullable ImmutableList<Goal> execute(Goal goal, Services services) {
         var time = System.nanoTime();
         var timeSetSequent = Goal.PERF_SET_SEQUENT.get();
         try {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/BlockContractExternalRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/BlockContractExternalRule.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.proof.InfFlowCheckInfo;
 import de.uka.ilkd.key.java.Services;
@@ -184,6 +185,7 @@ public final class BlockContractExternalRule extends AbstractBlockContractRule {
         return !InfFlowCheckInfo.isInfFlow(goal) && super.isApplicable(goal, occurrence);
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(final Goal goal, final Services services,
             final RuleApp ruleApp) throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/BlockContractInternalRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/BlockContractInternalRule.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.proof.InfFlowCheckInfo;
 import de.uka.ilkd.key.java.Services;
@@ -208,6 +209,7 @@ public final class BlockContractInternalRule extends AbstractBlockContractRule {
         return new BlockContractInternalBuiltInRuleApp(this, occurrence);
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(final Goal goal, final Services services,
             final RuleApp ruleApp) throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/JmlAssertRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/JmlAssertRule.java
@@ -1,6 +1,7 @@
 package de.uka.ilkd.key.rule;
 
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.JavaTools;
 import de.uka.ilkd.key.java.Services;
@@ -101,6 +102,7 @@ public final class JmlAssertRule implements BuiltInRule {
         return new JmlAssertBuiltInRuleApp(this, occurrence);
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/LoopApplyHeadRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/LoopApplyHeadRule.java
@@ -1,5 +1,7 @@
 package de.uka.ilkd.key.rule;
 
+import javax.annotation.Nonnull;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.StatementBlock;
 import de.uka.ilkd.key.java.statement.While;
@@ -57,6 +59,7 @@ public class LoopApplyHeadRule implements BuiltInRule {
      */
     public static final Name NAME = new Name("Loop Apply Head");
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp application)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/LoopContractExternalRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/LoopContractExternalRule.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.proof.InfFlowCheckInfo;
 import de.uka.ilkd.key.java.Services;
@@ -205,6 +206,7 @@ public final class LoopContractExternalRule extends AbstractLoopContractRule {
         }
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(final Goal goal, final Services services,
             final RuleApp ruleApp) throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/LoopContractInternalRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/LoopContractInternalRule.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
@@ -238,6 +239,7 @@ public final class LoopContractInternalRule extends AbstractLoopContractRule {
         return new LoopContractInternalBuiltInRuleApp(this, occurrence);
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(final Goal goal, final Services services,
             final RuleApp ruleApp) throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/LoopScopeInvariantRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/LoopScopeInvariantRule.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.rule;
 
 import java.util.ArrayList;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.proof.InfFlowCheckInfo;
 import de.uka.ilkd.key.java.KeYJavaASTFactory;
@@ -132,6 +133,7 @@ public class LoopScopeInvariantRule extends AbstractLoopInvariantRule {
                 && !(modality == Modality.BOX_TRANSACTION || modality == Modality.DIA_TRANSACTION);
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
@@ -573,6 +574,7 @@ public final class OneStepSimplifier implements BuiltInRule {
             null);
     }
 
+    @Nonnull
     @Override
     public synchronized ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp) {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/QueryExpand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/QueryExpand.java
@@ -1,6 +1,7 @@
 package de.uka.ilkd.key.rule;
 
 import java.util.*;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.*;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
@@ -53,6 +54,7 @@ public class QueryExpand implements BuiltInRule {
     private final WeakHashMap<Term, Long> timeOfTerm = new WeakHashMap<>(DEFAULT_MAP_SIZE);
 
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp) {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/Rule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/Rule.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ilkd.key.rule;
 
+import javax.annotation.Nonnull;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.proof.Goal;
@@ -20,8 +22,9 @@ public interface Rule extends HasOrigin {
      * @param ruleApp the rule application to be executed
      * @return all open goals below \old(goal.node()), i.e. the goals resulting from the rule
      *         application
-     * @throws Exception
+     * @throws RuleAbortException when this rule was aborted
      */
+    @Nonnull
     ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp)
             throws RuleAbortException;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/RuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/RuleApp.java
@@ -3,6 +3,7 @@
  */
 package de.uka.ilkd.key.rule;
 
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/RuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/RuleApp.java
@@ -4,6 +4,8 @@
 package de.uka.ilkd.key.rule;
 
 
+import javax.annotation.Nullable;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
@@ -32,6 +34,7 @@ public interface RuleApp extends EqualsModProofIrrelevancy {
      * @param services the Services encapsulating all java information
      * @return list of new created goals
      */
+    @Nullable
     ImmutableList<Goal> execute(Goal goal, Services services);
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/Taclet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/Taclet.java
@@ -1,6 +1,7 @@
 package de.uka.ilkd.key.rule;
 
 import java.util.*;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
@@ -928,6 +929,7 @@ public abstract class Taclet implements Rule, Named {
      *         close-goal-taclet ( this.closeGoal () ), the first goal of the return list is the
      *         goal that should be closed (with the constraint this taclet is applied under).
      */
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp tacletApp) {
         return getExecutor().apply(goal, services, tacletApp);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -1,6 +1,7 @@
 package de.uka.ilkd.key.rule;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.*;
@@ -33,6 +34,9 @@ import org.key_project.util.collection.*;
  * complete, so that is can be applied.
  */
 public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
+    public static final AtomicLong PERF_EXECUTE = new AtomicLong();
+    public static final AtomicLong PERF_SET_SEQUENT = new AtomicLong();
+    public static final AtomicLong PERF_PRE = new AtomicLong();
 
     /** the taclet for which the application information is collected */
     private final Taclet taclet;
@@ -322,18 +326,31 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      */
     @Override
     public ImmutableList<Goal> execute(Goal goal, Services services) {
-        if (!complete()) {
-            throw new IllegalStateException(
-                "Tried to apply rule \n" + taclet + "\nthat is not complete." + this);
-        }
+        var time = System.nanoTime();
+        var timeSetSequent = Goal.PERF_SET_SEQUENT.get();
+        try {
+            var timePre = System.nanoTime();
+            try {
+                if (!complete()) {
+                    throw new IllegalStateException(
+                        "Tried to apply rule \n" + taclet + "\nthat is not complete." + this);
+                }
 
-        if (!isExecutable(services)) {
-            throw new RuntimeException(
-                "taclet application with unsatisfied 'checkPrefix': " + this);
+                if (!isExecutable(services)) {
+                    throw new RuntimeException(
+                        "taclet application with unsatisfied 'checkPrefix': " + this);
+                }
+                registerSkolemConstants(goal.getLocalNamespaces());
+                goal.addAppliedRuleApp(this);
+            } finally {
+                PERF_PRE.getAndAdd(System.nanoTime() - timePre);
+            }
+
+            return taclet().apply(goal, services, this);
+        } finally {
+            PERF_EXECUTE.getAndAdd(System.nanoTime() - time);
+            PERF_SET_SEQUENT.getAndAdd(Goal.PERF_SET_SEQUENT.get() - timeSetSequent);
         }
-        registerSkolemConstants(goal.getLocalNamespaces());
-        goal.addAppliedRuleApp(this);
-        return taclet().apply(goal, services, this);
     }
 
     /*

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -325,7 +325,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      * @return list of new created goals
      */
     @Override
-    public ImmutableList<Goal> execute(Goal goal, Services services) {
+    public @Nullable ImmutableList<Goal> execute(Goal goal, Services services) {
         var time = System.nanoTime();
         var timeSetSequent = Goal.PERF_SET_SEQUENT.get();
         try {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractRule.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
@@ -367,6 +368,7 @@ public final class UseDependencyContractRule implements BuiltInRule {
     }
 
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp) {
         // collect information

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/UseOperationContractRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/UseOperationContractRule.java
@@ -3,6 +3,7 @@ package de.uka.ilkd.key.rule;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.proof.InfFlowCheckInfo;
 import de.uka.ilkd.key.informationflow.proof.InfFlowProof;
@@ -549,6 +550,7 @@ public final class UseOperationContractRule implements BuiltInRule {
         return false;
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp) {
         final TermLabelState termLabelState = new TermLabelState();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/WhileInvariantRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/WhileInvariantRule.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.informationflow.po.IFProofObligationVars;
 import de.uka.ilkd.key.informationflow.po.snippet.InfFlowPOSnippetFactory;
@@ -696,6 +697,7 @@ public final class WhileInvariantRule implements BuiltInRule {
     }
 
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, final RuleApp ruleApp)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/NoFindTacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/NoFindTacletExecutor.java
@@ -1,6 +1,7 @@
 package de.uka.ilkd.key.rule.executor.javadl;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Sequent;
@@ -19,6 +20,9 @@ import de.uka.ilkd.key.rule.tacletbuilder.TacletGoalTemplate;
 import org.key_project.util.collection.ImmutableList;
 
 public class NoFindTacletExecutor extends TacletExecutor<NoFindTaclet> {
+    public static final AtomicLong PERF_APPLY = new AtomicLong();
+    public static final AtomicLong PERF_SET_SEQUENT = new AtomicLong();
+    public static final AtomicLong PERF_TERM_LABELS = new AtomicLong();
 
     public NoFindTacletExecutor(NoFindTaclet taclet) {
         super(taclet);
@@ -78,20 +82,28 @@ public class NoFindTacletExecutor extends TacletExecutor<NoFindTaclet> {
 
             SequentChangeInfo currentSequent = newSequentsIt.next();
 
+            var timeApply = System.nanoTime();
             applyAdd(termLabelState, gt.sequent(), currentSequent, services, mc, goal, ruleApp);
 
             applyAddrule(gt.rules(), currentGoal, services, mc);
 
             applyAddProgVars(gt.addedProgVars(), currentSequent, currentGoal,
                 tacletApp.posInOccurrence(), services, mc);
+            PERF_APPLY.getAndAdd(System.nanoTime() - timeApply);
 
+            var timeTermLabels = System.nanoTime();
             TermLabelManager.mergeLabels(currentSequent, services);
+            timeTermLabels = System.nanoTime() - timeTermLabels;
 
+            var timeSetSequent = System.nanoTime();
             currentGoal.setSequent(currentSequent);
+            PERF_SET_SEQUENT.getAndAdd(System.nanoTime() - timeSetSequent);
 
             currentGoal.setBranchLabel(gt.name());
+            timeTermLabels = System.nanoTime() + timeTermLabels;
             TermLabelManager.refactorSequent(termLabelState, services, ruleApp.posInOccurrence(),
                 ruleApp.rule(), currentGoal, null, null);
+            PERF_TERM_LABELS.getAndAdd(System.nanoTime() - timeTermLabels);
         }
 
         return newGoals;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/merge/CloseAfterMerge.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/merge/CloseAfterMerge.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
@@ -87,6 +88,7 @@ public class CloseAfterMerge implements BuiltInRule {
         return DISPLAY_NAME;
     }
 
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(final Goal goal, final Services services,
             final RuleApp ruleApp) throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.JavaBlock;
@@ -127,6 +128,7 @@ public class MergeRule implements BuiltInRule {
         return displayName();
     }
 
+    @Nonnull
     @Override
     public final ImmutableList<Goal> apply(Goal goal, final Services services, RuleApp ruleApp)
             throws RuleAbortException {
@@ -134,7 +136,7 @@ public class MergeRule implements BuiltInRule {
         final MergeRuleBuiltInRuleApp mergeRuleApp = (MergeRuleBuiltInRuleApp) ruleApp;
 
         if (!mergeRuleApp.complete()) {
-            return null;
+            throw new RuleAbortException("Merge rule not complete");
         }
 
         // The number of goals needed for side conditions related to

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/MethodCall.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/MethodCall.java
@@ -190,7 +190,7 @@ public class MethodCall extends ProgramTransformer {
     @Override
     public ProgramElement[] transform(ProgramElement pe, Services services,
             SVInstantiations svInst) {
-        LOGGER.debug("method-call: called for {}", pe);
+        LOGGER.trace("method-call: called for {}", pe);
         if (resultVar != null) {
             pvar = (ProgramVariable) svInst.getInstantiation(resultVar);
         }
@@ -254,7 +254,7 @@ public class MethodCall extends ProgramTransformer {
 
     private Statement handleStatic(Services services) {
         Statement result;
-        LOGGER.debug("method-call: invocation of static method detected");
+        LOGGER.trace("method-call: invocation of static method detected");
         newContext = null;
         IProgramMethod staticMethod = getMethod(staticPrefixType, methRef, services);
         result = KeYJavaASTFactory.methodBody(pvar, newContext, staticMethod, arguments);
@@ -263,7 +263,7 @@ public class MethodCall extends ProgramTransformer {
 
     private Statement handleSuperReference(Services services) {
         Statement result;
-        LOGGER.debug(
+        LOGGER.trace(
             "method-call: super invocation of method detected." + "Requires static resolving.");
         IProgramMethod superMethod = getSuperMethod(execContext, methRef, services);
         result = KeYJavaASTFactory.methodBody(pvar, execContext.getRuntimeInstance(), superMethod,
@@ -276,11 +276,11 @@ public class MethodCall extends ProgramTransformer {
                 .equals(ConstructorNormalformBuilder.CONSTRUCTOR_NORMALFORM_IDENTIFIER))) {
             // private methods or constructor invocations are bound
             // statically
-            LOGGER.debug("method-call: invocation of private method detected."
+            LOGGER.trace("method-call: invocation of private method detected."
                 + "Requires static resolving.");
             result = makeMbs(staticPrefixType, services);
         } else {
-            LOGGER.debug("method-call: invocation of non-private" + " instance method detected."
+            LOGGER.trace("method-call: invocation of non-private" + " instance method detected."
                 + "Requires dynamic resolving.");
             ImmutableList<KeYJavaType> imps =
                 services.getJavaInfo().getKeYProgModelInfo().findImplementations(staticPrefixType,

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/WhileLoopTransformation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/WhileLoopTransformation.java
@@ -200,7 +200,6 @@ public class WhileLoopTransformation extends JavaASTVisitor {
     }
 
     public ProgramElement result() {
-        LOGGER.debug("While-Loop-Tranform-Result: {}", result);
         return result;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
@@ -33,8 +33,6 @@ public class TermLabelSettings extends AbstractSettings {
         if (str != null && (str.equals("true") || str.equals("false"))) {
             setUseOriginLabels(Boolean.parseBoolean(str));
         } else {
-            LOGGER.debug("TermLabelSettings: Failure while reading the setting \"UseOriginLabels\"."
-                + "Using the default value: true." + "The string read was: {}", str);
             setUseOriginLabels(true);
         }
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/RuleAppSMT.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/RuleAppSMT.java
@@ -1,5 +1,7 @@
 package de.uka.ilkd.key.smt;
 
+import javax.annotation.Nonnull;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -80,6 +82,7 @@ public class RuleAppSMT extends AbstractBuiltInRuleApp {
         }
 
 
+        @Nonnull
         @Override
         public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp) {
             if (goal.proof().getInitConfig().getJustifInfo().getJustification(rule) == null) {
@@ -88,9 +91,8 @@ public class RuleAppSMT extends AbstractBuiltInRuleApp {
 
             // RuleAppSMT app = (RuleAppSMT) ruleApp;
             // goal.node().getNodeInfo().setBranchLabel(app.getTitle());
-            ImmutableList<Goal> newGoals = goal.split(0);
 
-            return newGoals;
+            return goal.split(0);
         }
 
         /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
@@ -1,5 +1,7 @@
 package de.uka.ilkd.key.strategy;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.BooleanLDT;
 import de.uka.ilkd.key.ldt.CharListLDT;
@@ -59,6 +61,9 @@ import de.uka.ilkd.key.util.MiscTools;
  * Strategy tailored to be used as long as a java program can be found in the sequent.
  */
 public class JavaCardDLStrategy extends AbstractFeatureStrategy {
+    public static final AtomicLong PERF_COMPUTE = new AtomicLong();
+    public static final AtomicLong PERF_APPROVE = new AtomicLong();
+    public static final AtomicLong PERF_INSTANTIATE = new AtomicLong();
 
     public static final String JAVA_CARD_DL_STRATEGY = "JavaCardDLStrategy";
 
@@ -2036,7 +2041,12 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
      */
     @Override
     public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
-        return costComputationF.computeCost(app, pio, goal);
+        var time = System.nanoTime();
+        try {
+            return costComputationF.computeCost(app, pio, goal);
+        } finally {
+            PERF_COMPUTE.addAndGet(System.nanoTime() - time);
+        }
     }
 
     /**
@@ -2050,12 +2060,22 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
      */
     @Override
     public final boolean isApprovedApp(RuleApp app, PosInOccurrence pio, Goal goal) {
-        return !(approvalF.computeCost(app, pio, goal) instanceof TopRuleAppCost);
+        var time = System.nanoTime();
+        try {
+            return !(approvalF.computeCost(app, pio, goal) == TopRuleAppCost.INSTANCE);
+        } finally {
+            PERF_APPROVE.addAndGet(System.nanoTime() - time);
+        }
     }
 
     @Override
     protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal) {
-        return instantiationF.computeCost(app, pio, goal);
+        var time = System.nanoTime();
+        try {
+            return instantiationF.computeCost(app, pio, goal);
+        } finally {
+            PERF_INSTANTIATE.addAndGet(System.nanoTime() - time);
+        }
     }
 
     // //////////////////////////////////////////////////////////////////////////

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermLabelManager.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermLabelManager.java
@@ -138,10 +138,8 @@ public class TestTermLabelManager {
         Proof proof = new Proof("TestTermLabelManager", initConfig.deepCopy());
         Node node = new Node(proof, sequent);
         return new Goal(node,
-            new RuleAppIndex(
-                new TacletAppIndex(TacletIndexKit.getKit().createTacletIndex(),
-                    initConfig.getServices()),
-                new BuiltInRuleAppIndex(new BuiltInRuleIndex()), initConfig.getServices()));
+            TacletIndexKit.getKit().createTacletIndex(),
+            new BuiltInRuleAppIndex(new BuiltInRuleIndex()), initConfig.getServices());
     }
 
     protected void compareSequents(Sequent expected, Sequent current, boolean changed,

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestVariableNamer.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestVariableNamer.java
@@ -84,10 +84,7 @@ public class TestVariableNamer {
 
         TacletIndex tacletIndex = TacletIndexKit.getKit().createTacletIndex();
         BuiltInRuleAppIndex builtInRuleAppIndex = new BuiltInRuleAppIndex(new BuiltInRuleIndex());
-        RuleAppIndex ruleAppIndex =
-            new RuleAppIndex(tacletIndex, builtInRuleAppIndex, proof.getServices());
-
-        return new Goal(node, ruleAppIndex);
+        return new Goal(node, tacletIndex, builtInRuleAppIndex, proof.getServices());
     }
 
 

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
@@ -86,11 +86,8 @@ public class TestGoal {
                 .insert(0, new SequentFormula(TacletForTests.parseTerm("A"))).semisequent());
         Node root = new Node(proof, seq);
         proof.setRoot(root);
-        Goal g = new Goal(root,
-            new RuleAppIndex(
-                new TacletAppIndex(TacletIndexKit.getKit().createTacletIndex(),
-                    proof.getServices()),
-                new BuiltInRuleAppIndex(new BuiltInRuleIndex()), proof.getServices()));
+        Goal g = new Goal(root, TacletIndexKit.getKit().createTacletIndex(),
+            new BuiltInRuleAppIndex(new BuiltInRuleIndex()), proof.getServices());
         ImmutableList<Goal> lg = g.split(3);
         lg.head().addNoPosTacletApp(TacletForTests.getRules().lookup("imp_right"));
         lg.tail().head().addNoPosTacletApp(TacletForTests.getRules().lookup("imp_left"));

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestTacletIndex.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestTacletIndex.java
@@ -257,7 +257,7 @@ public class TestTacletIndex {
             new InitConfig(new Services(AbstractProfile.getDefaultProfile()))), seq_p5);
         final BuiltInRuleAppIndex builtinIdx = new BuiltInRuleAppIndex(new BuiltInRuleIndex());
         final Goal goal_p5 =
-            new Goal(node_p5, new RuleAppIndex(ruleIdx, builtinIdx, node_p5.proof().getServices()));
+            new Goal(node_p5, ruleIdx, builtinIdx, node_p5.proof().getServices());
         return goal_p5.ruleAppIndex();
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/io/consistency/TestProofBundleIO.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/io/consistency/TestProofBundleIO.java
@@ -10,8 +10,10 @@ import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
 import de.uka.ilkd.key.control.KeYEnvironment;
 import de.uka.ilkd.key.control.ProofControl;
 import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.proof.io.ProofBundleSaver;
+import de.uka.ilkd.key.proof.runallproofs.ProveTest;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.HelperClassForTests;
 
@@ -20,6 +22,8 @@ import org.key_project.util.java.IOUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Wolfram Pfeifer
  */
 public class TestProofBundleIO {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProveTest.class);
     /** the resources path for this test */
     private static Path testDir;
 
@@ -160,6 +165,13 @@ public class TestProofBundleIO {
      */
     private Proof loadBundle(Path p) throws ProblemLoaderException {
         KeYEnvironment<DefaultUserInterfaceControl> env = KeYEnvironment.load(p.toFile());
+        AbstractProblemLoader.ReplayResult replayResult = env.getReplayResult();
+        if (replayResult.hasErrors()) {
+            LOGGER.debug("Error(s) while loading");
+            for (Throwable error : replayResult.getErrorList()) {
+                LOGGER.debug("Error ", error);
+            }
+        }
         assertNotNull(env);
 
         Proof proof = env.getLoadedProof();

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
@@ -81,9 +81,10 @@ public class ProofCollections {
         // forkDebugPort = "wait:1234"
 
         /*
-         * By default runAllProofs does not print a lot of information.
+         * By default, runAllProofs does not print a lot of information.
          * Set this to true to get more output.
          */
+        settings.setVerboseOutput(true);
         // verboseOutput = true
 
         /*
@@ -597,7 +598,7 @@ public class ProofCollections {
         g.provable("standard_key/java_dl/methodCall.key");
         g.provable("standard_key/java_dl/methodCall1.key");
         g.provable("standard_key/java_dl/methodCall1box.key");
-        //// Commented out as this can not be proved modularly sound (See !183 which is related)
+        // Commented out as this can not be proved modularly sound (See !183 which is related)
         // g.provable("standard_key/java_dl/methodCall2.key");
         g.provable("standard_key/java_dl/methodCall3.key");
         g.provable("standard_key/java_dl/polishFlagSort.key");

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestApplyTaclet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestApplyTaclet.java
@@ -743,10 +743,7 @@ public class TestApplyTaclet {
 
     private Goal createGoal(Node n, TacletIndex tacletIndex) {
         final BuiltInRuleAppIndex birIndex = new BuiltInRuleAppIndex(new BuiltInRuleIndex());
-        final RuleAppIndex ruleAppIndex =
-            new RuleAppIndex(tacletIndex, birIndex, n.proof().getServices());
-        final Goal goal = new Goal(n, ruleAppIndex);
-        return goal;
+        return new Goal(n, tacletIndex, birIndex, n.proof().getServices());
     }
 
     /**

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestCollisionResolving.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestCollisionResolving.java
@@ -44,9 +44,7 @@ public class TestCollisionResolving {
         Node node = new Node(proof, seq);
         TacletIndex tacletIndex = TacletIndexKit.getKit().createTacletIndex();
         BuiltInRuleAppIndex builtInRuleAppIndex = new BuiltInRuleAppIndex(null);
-        RuleAppIndex ruleAppIndex =
-            new RuleAppIndex(tacletIndex, builtInRuleAppIndex, proof.getServices());
-        goal = new Goal(node, ruleAppIndex);
+        goal = new Goal(node, tacletIndex, builtInRuleAppIndex, proof.getServices());
     }
 
     @AfterEach

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
@@ -261,9 +261,7 @@ public class TestSchemaModalOperators {
 
     private Goal createGoal(Node n, TacletIndex tacletIndex) {
         final BuiltInRuleAppIndex birIndex = new BuiltInRuleAppIndex(new BuiltInRuleIndex());
-        final RuleAppIndex ruleAppIndex =
-            new RuleAppIndex(tacletIndex, birIndex, n.proof().getServices());
-        return new Goal(n, ruleAppIndex);
+        return new Goal(n, tacletIndex, birIndex, n.proof().getServices());
     }
 
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
@@ -180,10 +180,8 @@ public class TestTriggersSet {
 
         proof = new Proof("TestTriggersSet", TacletForTests.initConfig());
         g = new Goal(new Node(proof, Sequent.EMPTY_SEQUENT),
-            new RuleAppIndex(
-                new TacletAppIndex(TacletIndexKit.getKit().createTacletIndex(),
-                    proof.getServices()),
-                new BuiltInRuleAppIndex(new BuiltInRuleIndex()), proof.getServices()));
+            TacletIndexKit.getKit().createTacletIndex(),
+            new BuiltInRuleAppIndex(new BuiltInRuleIndex()), proof.getServices());
         proof.setRoot(g.node());
         proof.add(g);
 

--- a/key.core/src/test/resources/logback.xml
+++ b/key.core/src/test/resources/logback.xml
@@ -10,7 +10,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.removegenerics/src/test/resources/logback.xml
+++ b/key.removegenerics/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/KeyboardTacletExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/KeyboardTacletExtension.java
@@ -307,8 +307,8 @@ class KeyboardTacletPanel extends JPanel implements TabPanel {
                 }
             };
             try {
-                ImmutableList<NoPosTacletApp> t = lastGoal.ruleAppIndex().getFindTaclet(filter,
-                    pos.getPosInOccurrence(), services);
+                ImmutableList<NoPosTacletApp> t =
+                    lastGoal.ruleAppIndex().getFindTaclet(filter, pos.getPosInOccurrence());
                 t.forEach(taclets::add);
             } catch (NullPointerException e) {
                 LOGGER.debug("NPE", e);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/LogView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/LogView.java
@@ -234,7 +234,7 @@ public class LogView implements KeYGuiExtension, KeYGuiExtension.StatusLine {
                     if (line.isEmpty() || line.charAt(0) == '#') {
                         continue;
                     }
-                    String[] fields = line.split("[|]");
+                    String[] fields = line.split("[|]", STYLES.length);
                     boolean skipByMsgFilter = msgFilterApply && !fields[5].contains(msgFilter);
                     boolean skipByPkgFilter = pkgFilterApply && !fields[4].startsWith(pkgFilter);
                     boolean skipErrorLevel = !levelError && "ERROR".equals(fields[1]);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofScriptWorker.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofScriptWorker.java
@@ -157,7 +157,7 @@ public class ProofScriptWorker extends SwingWorker<Object, Object> implements In
         try {
             get();
         } catch (CancellationException ex) {
-            LOGGER.info("Scripting was cancelled.", ex);
+            LOGGER.info("Scripting was cancelled.");
         } catch (Throwable ex) {
             IssueDialog.showExceptionDialog(MainWindow.getInstance(), ex);
         }

--- a/key.ui/src/test/resources/logback.xml
+++ b/key.ui/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/key.util/src/test/resources/logback.xml
+++ b/key.util/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
This serves as a base to other coming changes to the taclet indices and the automatic.
These changes are chosen to not be controversial (and working).

Changes:
* Adds some performance counters (log level trace, close to 0 overhead) to allow some reasoning about why the automatic is slow
* Remove unused parameters
* Annotations
* Minor changes to the rule app index
* Logging: Timings of proof loading, log levels of tests, remove spammy logs or reduce level