### PR TITLE
AutoPerf: Lazy rule indices

### DIFF
--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
@@ -3,6 +3,7 @@ package de.uka.ilkd.key.symbolic_execution.rule;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
@@ -34,8 +35,6 @@ import de.uka.ilkd.key.util.Triple;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-
-import javax.annotation.Nonnull;
 
 /**
  * <p>

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
@@ -35,6 +35,8 @@ import de.uka.ilkd.key.util.Triple;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 
+import javax.annotation.Nonnull;
+
 /**
  * <p>
  * A {@link BuiltInRule} which evaluates a modality in a side proof.
@@ -129,6 +131,7 @@ public class ModalitySideProofRule extends AbstractSideProofRule {
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/declaration/VariableSpecification.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/declaration/VariableSpecification.java
@@ -294,9 +294,6 @@ public class VariableSpecification extends JavaNonTerminalProgramElement
         final ProgramElement pe = source.getSource();
         matchCond = super.match(source, matchCond);
         if (matchCond != null && getDimensions() != ((VariableSpecification) pe).getDimensions()) {
-            LOGGER.debug(
-                "Program match. Variables have different dimension " + "(template {}, source {})",
-                this, pe);
             return null;
         }
         return matchCond;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
@@ -421,6 +421,9 @@ public class Semisequent implements Iterable<SequentFormula> {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof Semisequent)) {
             return false;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
@@ -141,6 +141,7 @@ public class Semisequent implements Iterable<SequentFormula> {
      */
     private SemisequentChangeInfo insertAndRemoveRedundancyHelper(int idx,
             SequentFormula sequentFormula, SemisequentChangeInfo semiCI, FormulaChangeInfo fci) {
+        assert idx >= 0;
 
         // Search for equivalent formulas and weakest constraint
         ImmutableList<SequentFormula> searchList = semiCI.getFormulaList();
@@ -256,6 +257,7 @@ public class Semisequent implements Iterable<SequentFormula> {
      */
     public SemisequentChangeInfo replace(PosInOccurrence pos, SequentFormula sequentFormula) {
         final int idx = indexOf(pos.sequentFormula());
+        assert idx >= 0;
         final FormulaChangeInfo fci = new FormulaChangeInfo(pos, sequentFormula);
         return insertAndRemoveRedundancyHelper(idx, sequentFormula, remove(idx), fci);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/Sequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/Sequent.java
@@ -248,6 +248,9 @@ public class Sequent implements Iterable<SequentFormula> {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof Sequent)) {
             return false;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
@@ -122,7 +122,7 @@ public class BuiltInRuleAppIndex {
         }
     }
 
-    public void reportRuleApps(NewRuleListener l, Goal goal) {
+    public void reportRuleApps(Goal goal, NewRuleListener l) {
         var time = System.nanoTime();
         scanSimplificationRule(goal, l);
         sequentChangeInfo = null;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
@@ -135,10 +135,6 @@ public class BuiltInRuleAppIndex {
      * @param sci SequentChangeInfo describing the change of the sequent
      */
     public void sequentChanged(SequentChangeInfo sci) {
-        if (!sci.hasChanged()) {
-            return;
-        }
-        assert sci.getOriginalSequent() != sci.sequent();
         if (sequentChangeInfo == null) {
             // Nothing stored, store change
             sequentChangeInfo = sci.copy();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -362,6 +362,12 @@ public final class Goal {
             assert sci.sequent().equals(sci.getOriginalSequent());
             return;
         }
+        // sci.hasChanged() can be true for added: f, removed: f
+        // This afaik only ever happens in TestApplyTaclet.testBugBrokenApply
+        // Since SequentChangeInfo does not filter this we have to
+        // work with maybe sci.original.equals(sci.sequent)
+        // Checking this is probably too expensive for what it's worth
+        assert sci.sequent() != sci.getOriginalSequent();
         node().setSequent(sci.sequent());
         node().getNodeInfo().setSequentChangeInfo(sci);
         var time = System.nanoTime();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -88,7 +88,6 @@ public final class RuleAppIndex {
     private void setNewRuleListeners() {
         interactiveTacletAppIndex.setNewRuleListener(newRuleListener);
         automatedTacletAppIndex.setNewRuleListener(newRuleListener);
-        builtInRuleAppIndex.setNewRuleListener(newRuleListener);
     }
 
     /**
@@ -233,8 +232,7 @@ public final class RuleAppIndex {
      * constraint and position
      */
     public ImmutableList<IBuiltInRuleApp> getBuiltInRules(Goal g, PosInOccurrence pos) {
-
-        return builtInRuleAppIndex().getBuiltInRule(g, pos);
+        return builtInRuleAppIndex.getBuiltInRule(g, pos);
     }
 
 
@@ -296,7 +294,7 @@ public final class RuleAppIndex {
             interactiveTacletAppIndex.sequentChanged(sci);
         }
         automatedTacletAppIndex.sequentChanged(sci);
-        builtInRuleAppIndex.sequentChanged(goal, sci, newRuleListener);
+        builtInRuleAppIndex.sequentChanged(sci);
     }
 
     /**
@@ -315,6 +313,7 @@ public final class RuleAppIndex {
         // Currently this only applies to the taclet index
         interactiveTacletAppIndex.clearIndexes();
         automatedTacletAppIndex.clearIndexes();
+        builtInRuleAppIndex.resetSequentChanges();
     }
 
     /**
@@ -325,6 +324,7 @@ public final class RuleAppIndex {
             interactiveTacletAppIndex.fillCache();
         }
         automatedTacletAppIndex.fillCache();
+        builtInRuleAppIndex.flushSequentChanges(goal, newRuleListener);
     }
 
     /**
@@ -345,7 +345,7 @@ public final class RuleAppIndex {
      * @param p_goal the Goal which to scan
      */
     public void scanBuiltInRules(Goal p_goal) {
-        builtInRuleAppIndex().scanApplicableRules(p_goal, newRuleListener);
+        builtInRuleAppIndex.scanApplicableRules(p_goal, newRuleListener);
     }
 
     /**
@@ -379,7 +379,7 @@ public final class RuleAppIndex {
         TacletAppIndex copiedAutomatedTacletAppIndex =
             automatedTacletAppIndex.copyWith(copiedTacletIndex, goal);
         return new RuleAppIndex(copiedTacletIndex, copiedInteractiveTacletAppIndex,
-            copiedAutomatedTacletAppIndex, builtInRuleAppIndex().copy(), goal, autoMode);
+            copiedAutomatedTacletAppIndex, builtInRuleAppIndex.copy(), goal, autoMode);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -290,9 +290,7 @@ public final class RuleAppIndex {
      * @param sci SequentChangeInfo describing the change of the sequent
      */
     public void sequentChanged(SequentChangeInfo sci) {
-        if (!autoMode) {
-            interactiveTacletAppIndex.sequentChanged(sci);
-        }
+        interactiveTacletAppIndex.sequentChanged(sci);
         automatedTacletAppIndex.sequentChanged(sci);
         builtInRuleAppIndex.sequentChanged(sci);
     }
@@ -330,13 +328,10 @@ public final class RuleAppIndex {
     /**
      * Report all rule applications that are supposed to be applied automatically, and that are
      * currently stored by the index
-     *
-     * @param l the NewRuleListener
-     * @param services the Services
      */
-    public void reportAutomatedRuleApps(NewRuleListener l, Services services) {
-        automatedTacletAppIndex.reportRuleApps(l, services);
-        builtInRuleAppIndex.reportRuleApps(l, goal);
+    public void reportAutomatedRuleApps() {
+        automatedTacletAppIndex.reportRuleApps(newRuleListener, goal.proof().getServices());
+        builtInRuleAppIndex.reportRuleApps(goal, newRuleListener);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -54,30 +55,25 @@ public class TacletAppIndex {
      */
     private RuleFilter ruleFilter;
 
-    /**
-     * The sequent with the formulas for which taclet indices are hold by this object. Invariant:
-     * <code>seq != null</code> implies that the indices <code>antecIndex</code>,
-     * <code>succIndex</code> are up to date for the sequent <code>seq</code>
-     */
-    private Sequent seq;
+    private State state;
 
     private final Map<CacheKey, TermTacletAppIndex> cache;
 
     public TacletAppIndex(TacletIndex tacletIndex, Goal goal, Services services) {
-        this(tacletIndex, null, null, goal, null, TacletFilter.TRUE,
+        this(tacletIndex, null, null, goal, new State(), TacletFilter.TRUE,
             new TermTacletAppIndexCacheSet(services.getCaches().getTermTacletAppIndexCache()),
             services.getCaches().getTermTacletAppIndexCache());
     }
 
     private TacletAppIndex(TacletIndex tacletIndex, SemisequentTacletAppIndex antecIndex,
-            SemisequentTacletAppIndex succIndex, @Nonnull Goal goal, Sequent seq,
+            SemisequentTacletAppIndex succIndex, @Nonnull Goal goal, State state,
             RuleFilter ruleFilter,
             TermTacletAppIndexCacheSet indexCaches, Map<CacheKey, TermTacletAppIndex> cache) {
         this.tacletIndex = tacletIndex;
         this.antecIndex = antecIndex;
         this.succIndex = succIndex;
         this.goal = goal;
-        this.seq = seq;
+        this.state = state;
         this.ruleFilter = ruleFilter;
         this.indexCaches = indexCaches;
         this.cache = cache;
@@ -98,13 +94,13 @@ public class TacletAppIndex {
      * returns a new TacletAppIndex with a given TacletIndex
      */
     TacletAppIndex copyWith(TacletIndex p_tacletIndex, Goal goal) {
-        return new TacletAppIndex(p_tacletIndex, antecIndex, succIndex, goal, getSequent(),
+        return new TacletAppIndex(p_tacletIndex, antecIndex, succIndex, goal, state.copy(),
             ruleFilter, indexCaches, cache);
     }
 
     /**
      * Delete all cached information about taclet apps. This also makes the index cache of this
-     * index independent from the caches of other indexes (expensive)
+     * index independent of the caches of other indexes (expensive)
      */
     public void clearAndDetachCache() {
         clearIndexes();
@@ -112,7 +108,7 @@ public class TacletAppIndex {
     }
 
     public void clearIndexes() {
-        seq = null; // This leads to a delayed rebuild
+        this.state.clear();
         antecIndex = null;
         succIndex = null;
     }
@@ -132,44 +128,75 @@ public class TacletAppIndex {
      * (NewRuleListener gets informed)
      */
     public void fillCache() {
-        ensureIndicesExist();
+        update(false);
     }
 
-    private void createAllFromGoal() {
+    private void createAllFromGoal(boolean silent) {
         var time = System.nanoTime();
-        try {
-            this.seq = getNode().sequent();
 
-            antecIndex =
-                new SemisequentTacletAppIndex(getSequent(), true, getServices(), tacletIndex(),
-                    newRuleListener, ruleFilter, indexCaches);
-            succIndex =
-                new SemisequentTacletAppIndex(getSequent(), false, getServices(), tacletIndex(),
-                    newRuleListener, ruleFilter, indexCaches);
-        } finally {
-            PERF_CREATE_ALL.getAndAdd(System.nanoTime() - time);
-        }
+        this.state.seq = goal.sequent();
+        var listener = silent ? NullNewRuleListener.INSTANCE : newRuleListener;
+
+        antecIndex =
+            new SemisequentTacletAppIndex(this.state.seq, true, getServices(), tacletIndex,
+                listener, ruleFilter, indexCaches);
+        succIndex =
+            new SemisequentTacletAppIndex(this.state.seq, false, getServices(), tacletIndex,
+                listener, ruleFilter, indexCaches);
+
+        // Full rebuild from the taclet index
+        this.state.sci = null;
+        this.state.newRules = null;
+
+        PERF_CREATE_ALL.getAndAdd(System.nanoTime() - time);
     }
 
-    private void ensureIndicesExist() {
-        if (isOutdated()) {
-            // Indices are not up-to-date
-            createAllFromGoal();
+    private void update(boolean silent) {
+        if (!isOutdated()) {
+            return;
         }
+        if (this.state.sci != null && this.state.sci.sequent() == goal.sequent()) {
+            deltaUpdateIndices(this.state.sci, silent);
+        } else {
+            createAllFromGoal(silent);
+        }
+        this.state.sci = null;
+    }
+
+    private void deltaUpdateIndices(SequentChangeInfo sci, boolean silent) {
+        var time = System.nanoTime();
+        this.state.seq = sci.sequent();
+
+        var listener = silent ? NullNewRuleListener.INSTANCE : newRuleListener;
+        // Sequent changes
+        antecIndex =
+            antecIndex.sequentChanged(sci, getServices(), tacletIndex, listener);
+        succIndex =
+            succIndex.sequentChanged(sci, getServices(), tacletIndex, listener);
+
+        if (this.state.newRules != null) {
+            // New rules
+            antecIndex =
+                antecIndex.addTaclets(this.state.newRules, getServices(), tacletIndex, listener);
+            succIndex =
+                succIndex.addTaclets(this.state.newRules, getServices(), tacletIndex, listener);
+            this.state.newRules = null;
+        }
+
+        PERF_UPDATE.getAndAdd(System.nanoTime() - time);
     }
 
     /**
-     * @return true iff this index is currently outdated with respect to the sequent of the
-     *         associated goal; this does not detect other modifications
-     *         like an altered user
-     *         constraint
+     * @return true iff this index is currently outdated; this does not detect other modifications
+     *         like an altered user constraint
      */
     private boolean isOutdated() {
-        return getGoal() == null || getSequent() != getNode().sequent();
+        assert state.seq == null || (state.seq != goal.sequent()) == (state.sci != null);
+        return state.seq != goal.sequent() || state.newRules != null;
     }
 
     private SemisequentTacletAppIndex getIndex(PosInOccurrence pos) {
-        ensureIndicesExist();
+        update(false);
         return pos.isInAntec() ? antecIndex : succIndex;
     }
 
@@ -233,7 +260,7 @@ public class TacletAppIndex {
      */
     public ImmutableList<NoPosTacletApp> getNoFindTaclet(TacletFilter filter, Services services) {
         RuleFilter effectiveFilter = new AndRuleFilter(filter, ruleFilter);
-        return tacletIndex().getNoFindTaclet(effectiveFilter, services);
+        return tacletIndex.getNoFindTaclet(effectiveFilter, services);
     }
 
     /**
@@ -295,31 +322,19 @@ public class TacletAppIndex {
      * @param sci SequentChangeInfo describing the change of the sequent
      */
     public void sequentChanged(SequentChangeInfo sci) {
-        if (sci.getOriginalSequent() != getSequent()) {
-            // we are not up-to-date and have to rebuild everything (lazy)
-            clearIndexes();
+        if (state.sci == null) {
+            if (state.seq != sci.getOriginalSequent()) {
+                // we are not up-to-date and have to rebuild everything
+                clearIndexes();
+            } else {
+                // Nothing stored, store change
+                state.sci = sci.copy();
+            }
         } else {
-            var time = System.nanoTime();
-            updateIndices(sci);
-            PERF_UPDATE.getAndAdd(System.nanoTime() - time);
+            assert state.sci.sequent() == sci.getOriginalSequent();
+            // Combine the changes
+            state.sci.combine(sci);
         }
-    }
-
-    private void updateIndices(SequentChangeInfo sci) {
-        seq = sci.sequent();
-
-        antecIndex =
-            antecIndex.sequentChanged(sci, getServices(), tacletIndex, newRuleListener);
-
-        succIndex =
-            succIndex.sequentChanged(sci, getServices(), tacletIndex, newRuleListener);
-    }
-
-    private void updateIndices(final SetRuleFilter newTaclets) {
-        antecIndex =
-            antecIndex.addTaclets(newTaclets, getServices(), tacletIndex, newRuleListener);
-        succIndex =
-            succIndex.addTaclets(newTaclets, getServices(), tacletIndex, newRuleListener);
     }
 
 
@@ -337,12 +352,6 @@ public class TacletAppIndex {
             createNewIndexCache();
         }
 
-        if (isOutdated()) {
-            // we are not up-to-date and have to rebuild everything (lazy)
-            clearIndexes();
-            return;
-        }
-
         if (tacletApp.taclet() instanceof NoFindTaclet) {
             if (ruleFilter.filter(tacletApp.taclet())) {
                 newRuleListener.ruleAdded(tacletApp, null);
@@ -350,10 +359,10 @@ public class TacletAppIndex {
             return;
         }
 
-        final SetRuleFilter newTaclets = new SetRuleFilter();
-        newTaclets.addRuleToSet(tacletApp.taclet());
-
-        updateIndices(newTaclets);
+        if (state.newRules == null) {
+            state.newRules = new SetRuleFilter();
+        }
+        state.newRules.addRuleToSet(tacletApp.taclet());
     }
 
     /**
@@ -373,31 +382,23 @@ public class TacletAppIndex {
             }
         }
 
-        if (isOutdated()) {
-            // we are not up-to-date and have to rebuild everything (lazy)
-            clearIndexes();
-            return;
+        if (state.newRules == null) {
+            state.newRules = new SetRuleFilter();
         }
-
-        final SetRuleFilter newTaclets = new SetRuleFilter();
         for (NoPosTacletApp tacletApp : tacletApps) {
             if (tacletApp.taclet() instanceof NoFindTaclet) {
                 if (ruleFilter.filter(tacletApp.taclet())) {
                     newRuleListener.ruleAdded(tacletApp, null);
                 }
             } else {
-                newTaclets.addRuleToSet(tacletApp.taclet());
+                state.newRules.addRuleToSet(tacletApp.taclet());
             }
         }
 
-        if (newTaclets.isEmpty()) {
-            return;
+        if (state.newRules.isEmpty()) {
+            state.newRules = null;
         }
-
-        updateIndices(newTaclets);
     }
-
-
 
     /**
      * updates the internal caches after a Taclet with instantiation information has been removed
@@ -430,31 +431,8 @@ public class TacletAppIndex {
         return l1;
     }
 
-    private Goal getGoal() {
-        return goal;
-    }
-
-    private Sequent getSequent() {
-        return seq;
-    }
-
     private Services getServices() {
-        return getProof().getServices();
-    }
-
-    private Proof getProof() {
-        return getNode().proof();
-    }
-
-    private Node getNode() {
-        return goal.node();
-    }
-
-    /**
-     * returns the Taclet index for this ruleAppIndex.
-     */
-    public TacletIndex tacletIndex() {
-        return tacletIndex;
+        return goal.node().proof().getServices();
     }
 
     /**
@@ -462,13 +440,60 @@ public class TacletAppIndex {
      * taclet app.
      */
     public void reportRuleApps(NewRuleListener l, Services services) {
-        if (antecIndex != null) {
+        if (antecIndex != null && succIndex != null) {
+            update(true);
             antecIndex.reportRuleApps(l);
-        }
-        if (succIndex != null) {
             succIndex.reportRuleApps(l);
         }
 
         l.rulesAdded(getNoFindTaclet(TacletFilter.TRUE, services), null);
+    }
+
+    private static final class State {
+        /**
+         * The sequent with the formulas for which taclet indices are hold by this object.
+         * Invariant:
+         * <code>seq != null</code> implies that the indices <code>antecIndex</code>,
+         * <code>succIndex</code> are up-to-date for the sequent <code>seq</code>
+         */
+        @Nullable
+        public Sequent seq;
+
+        /**
+         * Used for delta updates. If this is nonnull, originalSequent == seq and resultingSequent
+         * ==
+         * goal.sequent.
+         */
+        @Nullable
+        public SequentChangeInfo sci;
+        @Nullable
+        public SetRuleFilter newRules;
+
+        public State() {
+            this(null, null, null);
+        }
+
+        public State(@Nullable Sequent seq, @Nullable SequentChangeInfo sequentChangeInfo,
+                @Nullable SetRuleFilter newRules) {
+            this.seq = seq;
+            this.sci = sequentChangeInfo;
+            this.newRules = newRules;
+        }
+
+        public State copy() {
+            return new State(
+                seq,
+                sci == null ? null : sci.copy(),
+                newRules == null ? null : newRules.copy());
+        }
+
+        public void clear() {
+            // This leads to a delayed rebuild
+            this.seq = null;
+            // This is needed since delta updates must be disabled as well (e.g. new taclet was
+            // added)
+            this.sci = null;
+            this.newRules = null;
+        }
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/rulefilter/SetRuleFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/rulefilter/SetRuleFilter.java
@@ -10,7 +10,19 @@ import de.uka.ilkd.key.rule.Rule;
  */
 public class SetRuleFilter implements RuleFilter {
 
-    private final HashSet<Rule> set = new LinkedHashSet<>();
+    private final HashSet<Rule> set;
+
+    public SetRuleFilter() {
+        this.set = new LinkedHashSet<>();
+    }
+
+    private SetRuleFilter(HashSet<Rule> set) {
+        this.set = set;
+    }
+
+    public SetRuleFilter copy() {
+        return new SetRuleFilter(new LinkedHashSet<>(this.set));
+    }
 
     public void addRuleToSet(Rule rule) {
         set.add(rule);

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
@@ -5,6 +5,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
+import de.uka.ilkd.key.proof.BuiltInRuleAppIndex;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.SemisequentTacletAppIndex;
 import de.uka.ilkd.key.proof.TacletAppIndex;
@@ -35,11 +36,13 @@ public class PerfScope {
         new Pair<>("Goal setSequent", Goal.PERF_SET_SEQUENT),
         new Pair<>("Goal update tag manager", Goal.PERF_UPDATE_TAG_MANAGER),
         new Pair<>("Goal update rule app index", Goal.PERF_UPDATE_RULE_APP_INDEX),
-        new Pair<>("Taclet app index update", TacletAppIndex.PERF_UPDATE),
         new Pair<>("Semi Taclet app index update remove", SemisequentTacletAppIndex.PERF_REMOVE),
         new Pair<>("Semi Taclet app index update add", SemisequentTacletAppIndex.PERF_ADD),
         new Pair<>("Semi Taclet app index update update", SemisequentTacletAppIndex.PERF_UPDATE),
+        new Pair<>("Taclet app index update", TacletAppIndex.PERF_UPDATE),
         new Pair<>("Taclet app index create all", TacletAppIndex.PERF_CREATE_ALL),
+        new Pair<>("Builtin app index update", BuiltInRuleAppIndex.PERF_UPDATE),
+        new Pair<>("Builtin app index create all", BuiltInRuleAppIndex.PERF_CREATE_ALL),
         new Pair<>("Goal update listeners", Goal.PERF_UPDATE_LISTENERS),
         new Pair<>("TacletApp execute", TacletApp.PERF_EXECUTE),
         new Pair<>("TacletApp pre", TacletApp.PERF_PRE),

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -96,8 +96,7 @@ public class QueueRuleApplicationManager implements AutomatedRuleApplicationMana
         // <code>FocussedRuleApplicationManager</code>) the rule index
         // reports its contents to the rule manager of the goal, which is not
         // necessarily this object
-        goal.ruleAppIndex().reportAutomatedRuleApps(goal.getRuleAppManager(),
-            goal.proof().getServices());
+        goal.ruleAppIndex().reportAutomatedRuleApps();
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
@@ -115,4 +115,11 @@ public abstract class RuleAppContainer implements Comparable<RuleAppContainer> {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "RuleAppContainer{" +
+            "ruleApp=" + ruleApp.rule().name() +
+            ", cost=" + cost +
+            '}';
+    }
 }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/testAttachCommentsCompilationUnit_LockSpec.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/testAttachCommentsCompilationUnit_LockSpec.txt
@@ -234,7 +234,7 @@
   * /*@model @*/
 (82/82) -- recoder.java.reference.TypeReference
   * /*@ non_null @*/
-(104/108) -- recoder.java.declaration.MethodDeclaration
+(104/109) -- recoder.java.declaration.MethodDeclaration
   * //@ invariant this.lock != \dl_currentThread() &&
   * //@ accessible<heap> \inv : this.lock, lock.spec;
   * //@ accessible<permissions> \inv : this.lock, lock
@@ -247,3 +247,5 @@
   * /*@ model Lock lockRef() { return this.lock; } @*/
   * /*@ model boolean lockStatus(boolean locked) { ret
   * /*@ normal_behavior          requires lockStatus(\
+(-1/-1) -- recoder.java.statement.EmptyStatement
+  * //@ assert lockStatus(\dl_FALSE());

--- a/key.core/tacletProofs/seqPerm2/Taclet_schiffl_lemma_2.proof
+++ b/key.core/tacletProofs/seqPerm2/Taclet_schiffl_lemma_2.proof
@@ -88,14 +88,14 @@ rule impLeft;
 tryclose branch;
 rule andLeft;
 rule andLeft;
-rule castAdd formula='s_0[jv_0] = v_x_0' occ=0;
+rule castAdd formula='s_0[jv_0] = v_x_0' occ=0;
 # 5. set of equations
 instantiate hide var=iv with='jv_1' occ=1;
 rule impLeft;
 tryclose branch;
 rule andLeft;
 rule andLeft;
-rule castAdd formula='s_0[jv_1] = v_y_0' occ=0;
+rule castAdd formula='s_0[jv_1] = v_y_0' occ=0;
 # 6. set of equations
 instantiate var=iv  with='v_x_0';
 rule impLeft;
@@ -165,7 +165,7 @@ tryclose branch;
 tryclose branch;
 # established: r fixes v_y_0
 # from now on v_x_0 != v_y_0
-cut '(int)s_0[v_x_0] = (int)s_0[v_y_0]';
+cut '(int)s_0[v_x_0] = (int)s_0[v_y_0]';
 rule seqNPermInjective;
 instantiate hide var=iv with='v_x_0';
 instantiate hide var=jv with='v_y_0';
@@ -284,7 +284,7 @@ instantiate hide var=iv with='jv_0';
 instantiate hide var=jv with='v_x_0';
 rule impLeft;
 tryclose branch;
-rule seqNPermSwapNPerm formula='seqNPerm(seqSwap(s_0, jv_0, v_x_0))';
+rule seqNPermSwapNPerm formula='seqNPerm(seqSwap(s_0, jv_0, v_x_0))';
 instantiate hide var=iv with='jv_0';
 instantiate hide var=jv with='v_y_0';
 rule impLeft;
@@ -371,7 +371,7 @@ tryclose branch;
 # established: r3 fixes v_y_0
 # from now on  v_x_0 != v_y_0 and s_0[v_x_0]!= v_x_0 and  
 # s_0[v_y_0]!= v_y_0  and s_0[v_x_0]!= v_y_0
-cut 'int::seqGet(s_0, v_y_0)=v_x_0';
+cut 'int::seqGet(s_0, v_y_0)=v_x_0';
 # This corresponds to case B4ii  in the Notes.
 # in the following r4 refers to this instantion
 tryclose branch;
@@ -403,7 +403,7 @@ tryclose branch;
 rule seqNPermSwapNPerm formula='seqNPerm(seqSwap(s_0,v_x_0,jv_0))';
 instantiate hide var=iv with='v_y_0';
 instantiate hide var=jv with='jv_1';
-instantiate hide var=v_r with='seqSwap(seqSwap(s_0, v_x_0, jv_0), v_y_0, jv_1)';
+instantiate hide var=v_r with='seqSwap(seqSwap(s_0, v_x_0, jv_0), v_y_0, jv_1)';
 tryclose branch;
 "
 

--- a/key.ui/examples/heap/permissions/lockspec/src/LockSpec.java
+++ b/key.ui/examples/heap/permissions/lockspec/src/LockSpec.java
@@ -105,6 +105,7 @@ public class Counter implements LockSpec {
         lock.lock();
         val++;
         lock.unlock();
+        //@ assert lockStatus(\dl_FALSE());
     }
 }
 

--- a/key.ui/src/main/resources/logback.xml
+++ b/key.ui/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
             <pattern>[%date{HH:mm:ss.SSS}] %highlight(%-5level) %cyan(%logger{0}) - %msg%ex%n</pattern>
         </encoder>
         <!--
-            The threshold of this filter is also selected by the command line option "verbosity <int>" where
+            The threshold of this filter is also selected by the command line option "verbose <int>" where
                 SILENT = 0 (completely off)
                 NORMAL = 1
                 INFO = 2


### PR DESCRIPTION
Make the rule app indices **lazy**, this speeds up all proof loading by at least 25% (the larger the proof the larger this number since the indices get slower). This is a refactoring needed to make enable further optimizations (skipping updates to the indices when not needed).

- [x] Builtin rule app index: working
- [x] Taclet app index: working