### PR TITLE
Fix double highlight in sequent view

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/InnerNodeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/InnerNodeView.java
@@ -168,6 +168,7 @@ public final class InnerNodeView extends SequentView implements ProofDisposedLis
     @Override
     public synchronized void printSequent() {
         var time = System.nanoTime();
+        getHighlighter().removeAllHighlights();
         removeMouseListener(listener);
 
         setLineWidth(computeLineWidth());


### PR DESCRIPTION
If the new sequent has a different height than the previous view, repaint is called twice. To fix overlapping highlights, remove all highlights when painting the sequent.