### PR TITLE
fixes #3149

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlTermFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlTermFactory.java
@@ -546,12 +546,13 @@ public final class JmlTermFactory {
 
         Term ife = tb.ife(tb.convertToFormula(result.getTerm()), aTerm, bTerm);
         if (a.getType() != null && b.getType() != null) {
-            if(a.getType().equals(b.getType())) {
+            if (a.getType().equals(b.getType())) {
                 // same type: obvious case
                 result = new SLExpression(ife, a.getType());
             } else {
-                KeYJavaType promotedType = services.getTypeConverter().getPromotedType(a.getType(), b.getType());
-                if(promotedType != null) {
+                KeYJavaType promotedType =
+                    services.getTypeConverter().getPromotedType(a.getType(), b.getType());
+                if (promotedType != null) {
                     // different, put compatible types: add a cast to make sure that
                     // an int is cast to a float e.g.
                     result = new SLExpression(tb.cast(promotedType.getSort(), ife), promotedType);


### PR DESCRIPTION
Ternary operators would not have a type unless the arguments have identical types. This fix takes the promoted common type as result type. This works in particular if \bigint and int are combined.