### PR TITLE
Test parsing exceptions in JML and Java parsing 

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
@@ -1255,7 +1255,7 @@ public class Recoder2KeY implements JavaReader {
         }
 
         Pair<String, Position> pos = extractPositionInfo(cause.toString());
-        if(pos != null) {
+        if (pos != null) {
             reportErrorWithPositionInFile(message, cause, pos.second, pos.first);
         } else {
             reportErrorWithPositionInFile(message, cause, null, null);

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeY.java
@@ -1254,8 +1254,12 @@ public class Recoder2KeY implements JavaReader {
             throw (PosConvertException) cause;
         }
 
-        var pos = extractPositionInfo(cause.toString());
-        reportErrorWithPositionInFile(message, cause, pos.second, pos.first);
+        Pair<String, Position> pos = extractPositionInfo(cause.toString());
+        if(pos != null) {
+            reportErrorWithPositionInFile(message, cause, pos.second, pos.first);
+        } else {
+            reportErrorWithPositionInFile(message, cause, null, null);
+        }
     }
 
     public static void reportErrorWithPositionInFile(String message, Throwable cause,

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
@@ -72,7 +72,6 @@ public class JMLParserExceptionTest {
 
     // This method does not depend on anything can also be called from other test cases.
     public static void parseAndInterpret(Path file) throws Exception {
-
         List<String> lines = Files.readAllLines(file);
         Properties props = new Properties();
         for (String line : lines) {
@@ -102,7 +101,7 @@ public class JMLParserExceptionTest {
 
         } catch (Throwable e) {
             if ("true".equals(props.getProperty("verbose"))) {
-                LOGGER.info("Exception raised while parsing " + file.getFileName(), e);
+                LOGGER.info("Exception raised while parsing {}", file.getFileName(), e);
             }
 
             try {
@@ -144,8 +143,7 @@ public class JMLParserExceptionTest {
                 }
             } catch (AssertionFailedError assertionFailedError) {
                 // in case of a failed assertion log the stacktrace
-                LOGGER.debug("Original stacktrace leading to failed junit assertion in "
-                    + file.getFileName(), e);
+                LOGGER.debug("Original stacktrace leading to failed junit assertion in {}", file.getFileName(), e);
                 throw assertionFailedError;
             }
         }

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
@@ -105,7 +105,8 @@ public class JMLParserExceptionTest {
 
     public static final boolean IGNORE_BROKEN = true;
 
-    private final static Pattern PROP_LINE = Pattern.compile("//\\s*(\\p{Alnum}+)\\s*[:=]\\s*(.*?)\\s*");
+    private final static Pattern PROP_LINE =
+        Pattern.compile("//\\s*(\\p{Alnum}+)\\s*[:=]\\s*(.*?)\\s*");
 
     public static Stream<Arguments> getFiles() throws URISyntaxException, IOException {
         URL fileURL = JMLParserExceptionTest.class.getResource("exceptional");

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
@@ -1,0 +1,99 @@
+package de.uka.ilkd.key.speclang.njml;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.UserInterfaceControl;
+import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Mattias Ulbrich
+ */
+public class JMLParserExceptionTest {
+
+    private final static Pattern PROP_LINE = Pattern.compile("// *(\\p{Alnum}+) *[:=] *(.*)");
+
+    public static Stream<Path> getFiles() throws URISyntaxException, IOException {
+        URL fileURL = JMLParserExceptionTest.class.getResource("exceptional");
+        assert fileURL != null : "Directory 'exceptional' not found";
+        assert fileURL.getProtocol().equals("file") : "Test resources must be in file system";
+        Path dir = Paths.get(fileURL.toURI());
+        return Files.list(dir);
+    }
+
+    @ParameterizedTest(name = "exceptional case {0}")
+    @MethodSource("getFiles")
+    public void testParseAndInterpret(Path file) throws Exception {
+        List<String> lines = Files.readAllLines(file);
+        Properties props = new Properties();
+        for (String line : lines) {
+            Matcher m = PROP_LINE.matcher(line);
+            if (m.matches()) {
+                props.put(m.group(1), m.group(2));
+            } else {
+                break;
+            }
+        }
+
+        if("true".equals(props.get("ignore"))) {
+            Assumptions.abort("This test case has been marked to be ignored");
+        }
+
+        try {
+            UserInterfaceControl ui = new DefaultUserInterfaceControl();
+            AbstractProblemLoader pl = ui.load(null, file.toFile(),
+                    null, null, null,
+                    null, false, null);
+
+            pl.setLoadSingleJavaFile(true);
+            pl.load();
+            // No exception encountered
+            assertEquals("true", props.get("noException"), "Unless 'noException: true' has been set, an exception is expected");
+
+        } catch (Throwable e) {
+            if("true".equals(props.getProperty("verbose"))) {
+                e.printStackTrace();
+            }
+
+            // We must use throwable here since there are some Errors around ...
+            String exc = props.getProperty("exceptionClass");
+            if (exc != null) {
+                if(exc.contains(".")) {
+                    assertEquals(exc, e.getClass().getName(), "Exception type expected");
+                } else {
+                    assertEquals(exc, e.getClass().getSimpleName(), "Exception type expected");
+                }
+            }
+
+            String msg = props.getProperty("msgContains");
+            if(msg != null) {
+                assertTrue(e.getMessage().contains(msg));
+            }
+
+            msg = props.getProperty("msgMatches");
+            if (msg != null) {
+                assertTrue(e.getMessage().matches(msg));
+            }
+
+            msg = props.getProperty("msgIs");
+            if (msg != null) {
+                assertEquals(msg, e.getMessage());
+            }
+        }
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
@@ -1,18 +1,5 @@
 package de.uka.ilkd.key.speclang.njml;
 
-import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
-import de.uka.ilkd.key.control.UserInterfaceControl;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.proof.init.AbstractProfile;
-import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
-import de.uka.ilkd.key.proof.io.ProblemLoaderControl;
-import de.uka.ilkd.key.proof.io.SingleThreadProblemLoader;
-import de.uka.ilkd.key.util.ExceptionTools;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -25,16 +12,100 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.parser.Location;
+import de.uka.ilkd.key.proof.init.AbstractProfile;
+import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
+import de.uka.ilkd.key.proof.io.ProblemLoaderControl;
+import de.uka.ilkd.key.proof.io.SingleThreadProblemLoader;
+import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.AssertionFailedError;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * This test case is used to ensure that errors in JML (and perhaps also in Java)
+ * are reported with a reasonable error message and the right position pointing
+ * into the file.
+ *
+ * To add a test case, locate the "exceptional" directory in the resources
+ * (below the directory for this package here) and add your single Java file
+ * that contains an error that should be presented to the user (like syntax
+ * error, unresolved names, ...)
+ *
+ * The first lines of the Java file may contain meta data on what to expect
+ * from the exception. Meta data are key-value pairs like
+ *
+ * <pre>
+ * // &lt;key&gt;: &lt;value&gt;
+ * </pre>
+ *
+ * The following keys are supported
+ * <table>
+ * <tr>
+ * <th>Key</th>
+ * <th>Description</th>
+ * </tr>
+ * <tr>
+ * <td>{@code noException}</td>
+ * <td>This particular file must
+ * <b>not</b> throw an exception. Default: false</td>
+ * </tr>
+ * <tr>
+ * <td>{@code exceptionClass}</td>
+ * <td>Either a fully qualified class name or
+ * a short classname (w/o package prefix) of the actual type of the
+ * exception. Optional.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code msgContains}</td>
+ * <td>A string which occur somewhere in the
+ * exception message (obtained via {@link Exception#getMessage()}). Optional</td>
+ * </tr>
+ * <tr>
+ * <td>{@code msgMatches}</td>
+ * <td>A regular expression that must match the exception message (obtained via
+ * {@link Exception#getMessage()}). Optional</td>
+ * </tr>
+ * <tr>
+ * <td>{@code msgIs}</td>
+ * <td>A string to which the exception message (obtained via {@link Exception#getMessage()}) must be
+ * equal. Optional</td>
+ * </tr>
+ * <tr>
+ * <td>{@code position}</td>
+ * <td>A tuple in form {@code <line>/<col>} describing the position within this file. Both line and
+ * column are 1-based.
+ * It is also checked that the URL of the location points to the file under test. Optional</td>
+ * </tr>
+ * <tr>
+ * <td>{@code ignore}</td>
+ * <td>Ignore this test case if set to true. Default is false.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code broken}</td>
+ * <td>If broken tests are disabled, ignore this test case if set to true. Indicates that this needs
+ * to be fixed! Default is false.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code verbose}</td>
+ * <td>Print the stacktrace if set to true. Default is false.</td>
+ * </tr>
+ * </table>
+ *
+ *
  * @author Mattias Ulbrich
  */
 public class JMLParserExceptionTest {
 
     public static final boolean IGNORE_BROKEN = true;
 
-    private final static Pattern PROP_LINE = Pattern.compile("// *(\\p{Alnum}+) *[:=] *(.*)");
+    private final static Pattern PROP_LINE = Pattern.compile("//\\s*(\\p{Alnum}+)\\s*[:=]\\s*(.*?)\\s*");
 
     public static Stream<Arguments> getFiles() throws URISyntaxException, IOException {
         URL fileURL = JMLParserExceptionTest.class.getResource("exceptional");
@@ -58,55 +129,69 @@ public class JMLParserExceptionTest {
             }
         }
 
-        if("true".equals(props.get("ignore")) || IGNORE_BROKEN && "true".equals(props.get("broken"))) {
+        if ("true".equals(props.get("ignore"))
+                || IGNORE_BROKEN && "true".equals(props.get("broken"))) {
             Assumptions.abort("This test case has been marked to be ignored");
         }
 
         try {
             ProblemLoaderControl control = new DefaultUserInterfaceControl(null);
-            AbstractProblemLoader pl = new SingleThreadProblemLoader(file.toFile(), null, null, null, AbstractProfile.getDefaultProfile(), false,
-                    control, false, new Properties());
+            AbstractProblemLoader pl = new SingleThreadProblemLoader(file.toFile(), null, null,
+                null, AbstractProfile.getDefaultProfile(), false,
+                control, false, new Properties());
             pl.setLoadSingleJavaFile(true);
             pl.load();
             // No exception encountered
-            assertEquals("true", props.get("noException"), "Unless 'noException: true' has been set, an exception is expected");
+            assertEquals("true", props.get("noException"),
+                "Unless 'noException: true' has been set, an exception is expected");
 
         } catch (Throwable e) {
-            if("true".equals(props.getProperty("verbose"))) {
+            if ("true".equals(props.getProperty("verbose"))) {
                 e.printStackTrace();
             }
 
-            // We must use throwable here since there are some Errors around ...
-            String exc = props.getProperty("exceptionClass");
-            if (exc != null) {
-                if(exc.contains(".")) {
-                    assertEquals(exc, e.getClass().getName(), "Exception type expected");
-                } else {
-                    assertEquals(exc, e.getClass().getSimpleName(), "Exception type expected");
+            try {
+                assertNotEquals("true", props.get("noException"),
+                    "'noException: true' has been set: no exception expected");
+
+                // We must use throwable here since there are some Errors around ...
+                String exc = props.getProperty("exceptionClass");
+                if (exc != null) {
+                    if (exc.contains(".")) {
+                        assertEquals(exc, e.getClass().getName(), "Exception type expected");
+                    } else {
+                        assertEquals(exc, e.getClass().getSimpleName(), "Exception type expected");
+                    }
                 }
-            }
 
-            String msg = props.getProperty("msgContains");
-            if(msg != null) {
-                assertTrue(e.getMessage().contains(msg));
-            }
+                String msg = props.getProperty("msgContains");
+                if (msg != null) {
+                    assertTrue(e.getMessage().contains(msg));
+                }
 
-            msg = props.getProperty("msgMatches");
-            if (msg != null) {
-                assertTrue(e.getMessage().matches(msg));
-            }
+                msg = props.getProperty("msgMatches");
+                if (msg != null) {
+                    assertTrue(e.getMessage().matches(msg));
+                }
 
-            msg = props.getProperty("msgIs");
-            if (msg != null) {
-                assertEquals(msg, e.getMessage());
-            }
+                msg = props.getProperty("msgIs");
+                if (msg != null) {
+                    assertEquals(msg, e.getMessage());
+                }
 
-            String loc = props.getProperty("position");
-            if (loc != null) {
-                Location actLoc = ExceptionTools.getLocation(e);
-                assertNotNull(actLoc, "Exception location must not be null");
-                assertEquals(file.toUri().toURL(), actLoc.getFileURL(), "Exception location must point to file under test");
-                assertEquals(loc, actLoc.getPosition().toString());
+                String loc = props.getProperty("position");
+                if (loc != null) {
+                    Location actLoc = ExceptionTools.getLocation(e);
+                    assertNotNull(actLoc, "Exception location must not be null");
+                    assertEquals(file.toUri().toURL(), actLoc.getFileURL(),
+                        "Exception location must point to file under test");
+                    assertEquals(loc, actLoc.getPosition().toString());
+                }
+            } catch (AssertionFailedError assertionFailedError) {
+                // in case of a failed assertion print the stacktrace
+                System.err.println("Original stacktrace:");
+                e.printStackTrace();
+                throw assertionFailedError;
             }
         }
     }

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/JMLParserExceptionTest.java
@@ -96,16 +96,18 @@ public class JMLParserExceptionTest {
             pl.setLoadSingleJavaFile(true);
             pl.load();
             // No exception encountered
-            assertEquals("true", props.get("noException"),
+            assertEquals("true", props.getProperty("noException"),
                 "Unless 'noException: true' has been set, an exception is expected");
 
+        } catch (AssertionFailedError ae) {
+            throw ae;
         } catch (Throwable e) {
             if ("true".equals(props.getProperty("verbose"))) {
                 LOGGER.info("Exception raised while parsing {}", file.getFileName(), e);
             }
 
             try {
-                assertNotEquals("true", props.get("noException"),
+                assertNotEquals("true", props.getProperty("noException"),
                     "'noException: true' has been set: no exception expected");
 
                 // We must use throwable here since there are some Errors around ...
@@ -143,7 +145,8 @@ public class JMLParserExceptionTest {
                 }
             } catch (AssertionFailedError assertionFailedError) {
                 // in case of a failed assertion log the stacktrace
-                LOGGER.debug("Original stacktrace leading to failed junit assertion in {}", file.getFileName(), e);
+                LOGGER.debug("Original stacktrace leading to failed junit assertion in {}",
+                    file.getFileName(), e);
                 throw assertionFailedError;
             }
         }

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/Bevhavioural.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/Bevhavioural.java
@@ -1,10 +1,10 @@
-// exceptionClass: Something
-// msgContains: Unexepected
-// location: xxxx
+// exceptionClass: ConvertException
+// msgContains: no viable alternative at input 'normal_bevhaviour
+// position: 14/16
 // verbose: true
-// ignore: true
+// broken: true
 
-// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+// This is broken since it currently reports the wrong location
 
 // There used to be an NPE
 //   Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/Bevhavioural.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/Bevhavioural.java
@@ -1,0 +1,18 @@
+// exceptionClass: Something
+// msgContains: Unexepected
+// location: xxxx
+// verbose: true
+// ignore: true
+
+// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+
+// There used to be an NPE
+//   Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null
+
+class Bevhavioural {
+
+    /*@ public normal_bevhaviour
+      @  ensures true;
+      @*/
+    public void m() {}
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
@@ -1,0 +1,17 @@
+// exceptionClass: Something
+// msgContains: Unexepected
+// location: xxxx
+// verbose: true
+
+// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+
+/* Used to be an NPE 
+Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null
+	at de.uka.ilkd.key.java.Recoder2KeY.reportError(Recoder2KeY.java:1258)
+	at de.uka.ilkd.key.java.Recoder2KeY.recoderCompilationUnitsAsFiles(Recoder2KeY.java:401)
+	at de.uka.ilkd.key.java.Recoder2KeY.readCompilationUnitsAsFiles(Recoder2KeY.java:299)
+*/
+
+class IllegalInv {
+    /*@ invariant ;*/
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
@@ -1,11 +1,12 @@
-// exceptionClass: Something
-// msgContains: Unexepected
-// location: xxxx
+// exceptionClass: ConvertException
+// msgContains: mismatched input ';'
+// position: 17/19
 // verbose: true
+// broken: true
 
-// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+// currently reports the wrong position
 
-/* Used to be an NPE 
+/* Used to be an NPE
 Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null
 	at de.uka.ilkd.key.java.Recoder2KeY.reportError(Recoder2KeY.java:1258)
 	at de.uka.ilkd.key.java.Recoder2KeY.recoderCompilationUnitsAsFiles(Recoder2KeY.java:401)

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/README.md
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/README.md
@@ -1,0 +1,31 @@
+
+This directory contains test cases for the class 
+`de.uka.ilkd.key.speclang.njml.JMLParserExceptionTest`.
+
+To add a test case add your single Java file that contains an error
+that should be presented to the user (like syntax error, unresolved
+names, ...)
+
+The first lines of the Java file may contain meta data on what to
+expect from the exception. Meta data are key-value pairs like
+
+    // <key>: <value>
+    
+
+The following keys are supported
+
+| Key              | Description |
+| ---              | --- |
+| `noException`    | This particular file must **not** throw an exception. Default: false |
+| `exceptionClass` | Either a fully qualified class name or a short classname (w/o package prefix) of the actual type of the exception. Optional. |
+| `msgContains`    | A string which occur somewhere in the exception message (obtained via {@link Exception#getMessage()}). Optional |
+| `msgMatches`     | A regular expression that must match the exception message (obtained via {@link Exception#getMessage()}). Optional |
+| `msgIs`          | A string to which the exception message (obtained via {@link Exception#getMessage()}) must be equal. Optional |
+| `position`       | A tuple in form `line`/`column` describing the position within this file. Both line and column are 1-based. It is also checked that the URL of the location points to the file under test. Optional |
+| `ignore`         | Ignore this test case if set to true. Default is false. |
+| `broken`         | If broken tests are disabled, ignore this test case if set to true. Indicates that this needs to be fixed! Default is false. |
+| `verbose`        | Logs the stacktrace if set to true. Default is false. |
+
+
+\@author Mattias Ulbrich
+

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
@@ -1,10 +1,10 @@
-// exceptionClass: Something
-// msgContains: Unexepected
-// location: xxxx
+// exceptionClass: ConvertException
+// msgContains: XXXX
+// positiion: 19/xxx
 // verbose: true
-// ignore: true
+// broken: true
 
-// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+// This is broken since it exposes an IllegalArgumentException
 
 /* Used to be an NPE 
 Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null
@@ -15,7 +15,7 @@ Caused by: java.lang.NullPointerException: Cannot read field "second" because "p
 
 class TypeError {
 
-    /*@ public normal_bevhaviour
+    /*@ public normal_behaviour
       @  ensures 1 + 1 == true;
       @*/
     public void m() {}

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
@@ -1,0 +1,22 @@
+// exceptionClass: Something
+// msgContains: Unexepected
+// location: xxxx
+// verbose: true
+// ignore: true
+
+// This is ignored for the moment to allow the testing infrastructure to reach main. ...
+
+/* Used to be an NPE 
+Caused by: java.lang.NullPointerException: Cannot read field "second" because "pos" is null
+	at de.uka.ilkd.key.java.Recoder2KeY.reportError(Recoder2KeY.java:1258)
+	at de.uka.ilkd.key.java.Recoder2KeY.recoderCompilationUnitsAsFiles(Recoder2KeY.java:401)
+	at de.uka.ilkd.key.java.Recoder2KeY.readCompilationUnitsAsFiles(Recoder2KeY.java:299)
+*/
+
+class TypeError {
+
+    /*@ public normal_bevhaviour
+      @  ensures 1 + 1 == true;
+      @*/
+    public void m() {}
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVar.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVar.java
@@ -1,0 +1,14 @@
+// exceptionClass: PosConvertException
+// msgContains: Could not resolve FieldReference "unknownVar"
+// position: 12/9
+// verbose: true
+
+class UnknownVar {
+
+    /*@ public normal_bevhaviour
+      @  ensures true;
+      @*/
+    public void m() {
+        unknownVar = 42;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVar.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVar.java
@@ -1,7 +1,7 @@
 // exceptionClass: PosConvertException
 // msgContains: Could not resolve FieldReference "unknownVar"
 // position: 12/9
-// verbose: true
+
 
 class UnknownVar {
 

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVarInJML.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVarInJML.java
@@ -1,7 +1,7 @@
 // exceptionClass: BuildingException
 // msgContains: The fully qualified name 'unknownVar' could not be resolved.
 // position: 9/18
-// verbose: true
+
 
 class UnknownVar {
 

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVarInJML.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/UnknownVarInJML.java
@@ -1,0 +1,12 @@
+// exceptionClass: BuildingException
+// msgContains: The fully qualified name 'unknownVar' could not be resolved.
+// position: 9/18
+// verbose: true
+
+class UnknownVar {
+
+    /*@ public normal_behaviour
+      @  ensures unknownVar == 42;
+      @*/
+    public void m() {}
+}


### PR DESCRIPTION
JML parsing and error reporting is not yet ideal, we should fix these case.
They can also serve as valuable test cases for future replacement frameworks.

This also fixes a bug in the position treatement of Recoder2KeY.

From the javadoc:

This test case is used to ensure that errors in JML (and perhaps also in Java)
are reported with a reasonable error message and the right position pointing
into the file.
To add a test case, locate the "exceptional" directory in the resources
(below the directory for this package here) and add your single Java file
that contains an error that should be presented to the user (like syntax
error, unresolved names, ...)
The first lines of the Java file may contain meta data on what to expect
from the exception.

- introducing exceptional JML tests
- more test cases for exceptional jml cases
- fixing an NPE bug in the error reporting of Recoder2KeY
- spotless and documentation
