### PR TITLE
Remove sonarqube

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ cache:
 variables:
   GRADLE_OPTS:  "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2 -Dorg.gradle.configureondemand=true"
   GIT_DEPTH: 0
-  SONAR_SCANNER_OPTS: -Xmx8G
 
 before_script:
   #  - echo `pwd` # debug

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@ plugins {
     //Some Licenses requires an entry in the credits (MIT, BSD)
     id "com.github.hierynomus.license-report" version "0.16.1"
 
-    id "org.sonarqube" version "4.1.0.3113"
-
     // Gives `gradle dependencyUpdate` to show which dependency has a newer version
     // id "com.github.ben-manes.versions" version "0.39.0"
 
@@ -53,14 +51,6 @@ def build = System.env.BUILD_NUMBER == null ? "" : "-${System.env.BUILD_NUMBER}"
 
 group = "org.key_project"
 version = "2.11.0$build"
-
-sonarqube {
-    properties {
-        property "sonar.projectKey", "key-main"
-        property "sonar.organization", "keyproject"
-        property "sonar.host.url", "https://sonarcloud.io"
-    }
-}
 
 subprojects {
     apply plugin: "java"


### PR DESCRIPTION
This PR removes sonarqube from `build.gradle` as it is not used anymore by our workflows. 