### PR TITLE
Make assignable predicate available in JML

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heap.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heap.key
@@ -40,6 +40,9 @@
     wellFormed(Heap);
     arrayStoreValid(any, any);
     nonNull(Heap, Object, int);
+
+    // can be used to formulate assignable proof obligations in JML assert statements (via \dl_ escapes)
+    assignable(Heap, Heap, LocSet);
 }
 
 \programVariables {

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heapRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heapRules.key
@@ -4,6 +4,28 @@
 
 \rules(programRules:Java) {
 
+    /*! Unrolls the definition of the assignable predicate. */
+    assignableDefinition {
+        \schemaVar \term Heap heapOld;
+        \schemaVar \term Heap heapNew;
+        \schemaVar \term LocSet locs;
+
+        \schemaVar \variables Field f;
+        \schemaVar \variables java.lang.Object o;
+
+        \find(assignable(heapNew, heapOld, locs))
+        \varcond(\notFreeIn(o, locs, heapOld, heapNew),
+                 \notFreeIn(f, locs, heapOld, heapNew))
+
+        \replacewith(\forall f;
+                       (\forall o;
+                         (  elementOf(o, f, locs)
+                          | !o = null
+                          & !boolean::select(heapOld, o, java.lang.Object::<created>) = TRUE
+                          | any::select(heapNew, o, f) = any::select(heapOld, o, f))))
+        \heuristics(delayedExpansion)
+    };
+
     // --------------------------------------------------------------------------
     // axioms for select/store (here for manual use only)
     // --------------------------------------------------------------------------


### PR DESCRIPTION
In JML, at the moment it is not possible to write down **as assertion** which heap locations (may) have been altered by the program up to the current location in code. The reason for this is that the sort Field is not available. The clause `assignable <locs>` in a method contract is encoded in JavaDL as follows:
```math
\begin{align}
\forall\ \text{Field}\ f. \forall\ \text{java.lang.Object}\ o&.\ (o,f) \in locs\\
&\vee o \neq \text{null} \wedge \neg o.< created>\ = TRUE\\
&\vee o.f@newHeap = o.f@oldHeap
\end{align}
```
This PR adds a predicate `assignable(Heap, Heap, LocSet)` that has a single taclet that rewrites it exactly into the above expression. The first parameter is the new heap, the second one the old heap. The taclet has a heuristic to be applied by automatic strategy after symbolic execution.

In JML, the predicate can be accessed via dl_ escapes. Note that the first heap parameter can be omitted, as KeY automatically adds the heap at the current location (line of the assertion) to it. 

As an example, consider the following source code:
```java
class Assignable {
    int f1, f2;

    //@ ensures true;
    void m() {
        f1 = 5;
        //@ ghost \dl_Heap h;
        // @ set h = \dl_heap();                // this gives a parser error: "heap is not a known function"
        //@ assume h == \dl_heap();             // workaround for testing the assertions below

        //@ assert \dl_assignable(\old(\dl_heap()), \singleton(f1));
        // equivalent to assertion above, first parameter is automatically added by KeY if missing:
        // @ assert \dl_assignable(\dl_heap(), \old(\dl_heap(h)), \singleton(f1));

        f2 = 7;
        //@ assert \dl_assignable(h, \singleton(f2));

        // equivalent to "normal" method assignable clause with "assignable f1, f2":
        //@ assert \dl_assignable(\old(\dl_heap()), \set_union(\singleton(f1), \singleton(f2)));
    }
}
```

All the assertions are provable. However, the automatic strategy is not able to prove the first one, `selectOfStore resp. selectOfStoreEQ` is not applied to o.f@h, I don't know why. If you do this manually, the proof can easily be closed by KeY. I am quite sure that it has nothing to do with this PR, but rather might be a general problem with the strategy ...
