### PR TITLE
Reduce logging in slicing extension

### DIFF
--- a/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
@@ -532,7 +532,7 @@ public final class DependencyAnalyzer {
                             canMergeStepsInto(apps, idxA, stepA, stepB, locA, locB, mergeBase);
                         if (canMerge) {
                             // merge step B into step A
-                            LOGGER.info("merging {} and {}", stepA.serialNr(), stepB.serialNr());
+                            LOGGER.trace("merging {} and {}", stepA.serialNr(), stepB.serialNr());
                             locs.set(idxA, mergeBase);
                             alreadyRebasedSerialNrs.add(stepA.serialNr());
                             apps.set(idxB, null);

--- a/keyext.slicing/src/test/java/org/key_project/slicing/EndToEndTests.java
+++ b/keyext.slicing/src/test/java/org/key_project/slicing/EndToEndTests.java
@@ -249,7 +249,7 @@ class EndToEndTests {
         // load proof
         Assertions.assertTrue(proofFile.exists());
         AtomicReference<DependencyTracker> tracker = new AtomicReference<>();
-        LOGGER.info("Loading " + proofFile.getAbsolutePath());
+        LOGGER.trace("Loading " + proofFile.getAbsolutePath());
         KeYEnvironment<?> environment =
             KeYEnvironment.load(JavaProfile.getDefaultInstance(), proofFile, null, null, null, null,
                 null, proof -> {


### PR DESCRIPTION
This might fix #3176, we'll see..

Edit: testing on my machine creates a 30 KB `TEST-org.key_project.slicing.EndToEndTests.xml`.