### PR TITLE
Add context menu to proofs in task tree

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -831,7 +831,7 @@ public final class MainWindow extends JFrame {
         JMenuBar menuBar = new JMenuBar();
         menuBar.add(createFileMenu());
         menuBar.add(createViewMenu());
-        menuBar.add(createProofMenu());
+        menuBar.add(createProofMenu(null));
         menuBar.add(createOptionsMenu());
         KeYGuiExtensionFacade.addExtensionsToMainMenu(this, menuBar);
         menuBar.add(Box.createHorizontalGlue());
@@ -915,40 +915,50 @@ public final class MainWindow extends JFrame {
         return goalSelection;
     }
 
-    JMenu createProofMenu() {
+    /**
+     * Create the proof menu.
+     *
+     * @param proof a specific proof that the menu should work on, may be null
+     * @return the menu
+     */
+    public JMenu createProofMenu(Proof selected) {
         JMenu proof = new JMenu("Proof");
         proof.setMnemonic(KeyEvent.VK_P);
 
-        proof.add(autoModeAction);
-        GoalBackAction goalBack = new GoalBackAction(this, true);
-        proof.addMenuListener(new MenuListener() {
-            @Override
-            public void menuSelected(MenuEvent e) {
-                /*
-                 * we use this MenuListener to update the name only if the menu is shown since it
-                 * would be slower to update the name (which means scanning all open and closed
-                 * goals) at every selection change (via the KeYSelectionListener in GoalBackAction)
-                 */
-                goalBack.updateName();
-            }
+        if (selected == null) {
+            proof.add(autoModeAction);
+            GoalBackAction goalBack = new GoalBackAction(this, true);
+            proof.addMenuListener(new MenuListener() {
+                @Override
+                public void menuSelected(MenuEvent e) {
+                    /*
+                     * we use this MenuListener to update the name only if the menu is shown since
+                     * it
+                     * would be slower to update the name (which means scanning all open and closed
+                     * goals) at every selection change (via the KeYSelectionListener in
+                     * GoalBackAction)
+                     */
+                    goalBack.updateName();
+                }
 
-            @Override
-            public void menuDeselected(MenuEvent e) {
-            }
+                @Override
+                public void menuDeselected(MenuEvent e) {
+                }
 
-            @Override
-            public void menuCanceled(MenuEvent e) {
-            }
-        });
-        proof.add(goalBack);
-        proof.add(new PruneProofAction(this));
-        proof.add(new AbandonTaskAction(this));
-        proof.addSeparator();
-        proof.add(new SearchInProofTreeAction(this));
-        proof.add(new SearchInSequentAction(this, sequentViewSearchBar));
-        proof.add(new SearchNextAction(this, sequentViewSearchBar));
-        proof.add(new SearchPreviousAction(this, sequentViewSearchBar));
-        {
+                @Override
+                public void menuCanceled(MenuEvent e) {
+                }
+            });
+            proof.add(goalBack);
+            proof.add(new PruneProofAction(this));
+        }
+        proof.add(new AbandonTaskAction(this, selected));
+        if (selected == null) {
+            proof.addSeparator();
+            proof.add(new SearchInProofTreeAction(this));
+            proof.add(new SearchInSequentAction(this, sequentViewSearchBar));
+            proof.add(new SearchNextAction(this, sequentViewSearchBar));
+            proof.add(new SearchPreviousAction(this, sequentViewSearchBar));
             JMenu searchModeMenu = new JMenu("Search Mode");
 
             for (SequentViewSearchBar.SearchMode mode : SequentViewSearchBar.SearchMode.values()) {
@@ -958,11 +968,11 @@ public final class MainWindow extends JFrame {
             proof.add(searchModeMenu);
         }
         proof.addSeparator();
-        proof.add(new ShowUsedContractsAction(this));
-        proof.add(new ShowActiveTactletOptionsAction(this));
+        proof.add(new ShowUsedContractsAction(this, selected));
+        proof.add(new ShowActiveTactletOptionsAction(this, selected));
         proof.add(showActiveSettingsAction);
-        proof.add(new ShowProofStatistics(this));
-        proof.add(new ShowKnownTypesAction(this));
+        proof.add(new ShowProofStatistics(this, selected));
+        proof.add(new ShowKnownTypesAction(this, selected));
         return proof;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -918,7 +918,7 @@ public final class MainWindow extends JFrame {
     /**
      * Create the proof menu.
      *
-     * @param proof a specific proof that the menu should work on, may be null
+     * @param selected a specific proof that the menu should work on, may be null
      * @return the menu
      */
     public JMenu createProofMenu(Proof selected) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -913,7 +913,7 @@ public final class MainWindow extends JFrame {
         return goalSelection;
     }
 
-    private JMenu createProofMenu() {
+    JMenu createProofMenu() {
         JMenu proof = new JMenu("Proof");
         proof.setMnemonic(KeyEvent.VK_P);
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -237,6 +237,7 @@ public class TaskTree extends JPanel {
      */
     class TaskTreeMouseListener extends MouseAdapter {
 
+        @Override
         public void mouseClicked(MouseEvent e) {
             problemChosen();
             checkPopup(e);
@@ -247,6 +248,21 @@ public class TaskTree extends JPanel {
             checkPopup(e);
         }
 
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            checkPopup(e);
+        }
+
+        /**
+         * Checks whether the popup menu should be shown and does so if necessary.
+         * <br>
+         * <b>Important:</b><br>
+         * For the platform specific popup trigger to work, we need to check the popup in pressed,
+         * released, and clicked event. For example, on Windows the e.isPopupTrigger() information
+         * is only available in the released event.
+         *
+         * @param e the mouse event that may create the popup
+         */
         private void checkPopup(MouseEvent e) {
             if (e.isPopupTrigger()) {
                 TreePath selPath = delegateView.getPathForLocation(e.getX(), e.getY());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -74,15 +74,17 @@ public class TaskTree extends JPanel {
         delegateView.setRootVisible(false);
         delegateView.putClientProperty("JTree.lineStyle", "Horizontal");
 
+        // create a context menu on demand
         MouseListener ml = new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
                 if (e.isPopupTrigger()) {
                     TreePath selPath = delegateView.getPathForLocation(e.getX(), e.getY());
                     if (selPath != null && selPath.getLastPathComponent() instanceof BasicTask) {
+                        BasicTask task = (BasicTask) selPath.getLastPathComponent();
                         delegateView.setSelectionPath(selPath);
                         JPopupMenu popup = new JPopupMenu();
-                        for (Component comp : MainWindow.getInstance().createProofMenu()
+                        for (Component comp : MainWindow.getInstance().createProofMenu(task.proof())
                                 .getMenuComponents()) {
                             popup.add(comp);
                         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -73,10 +73,31 @@ public class TaskTree extends JPanel {
         delegateView.setShowsRootHandles(false);
         delegateView.setRootVisible(false);
         delegateView.putClientProperty("JTree.lineStyle", "Horizontal");
-    }
 
-    JTree jtree() {
-        return delegateView;
+        MouseListener ml = new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    TreePath selPath = delegateView.getPathForLocation(e.getX(), e.getY());
+                    if (selPath != null && selPath.getLastPathComponent() instanceof BasicTask) {
+                        delegateView.setSelectionPath(selPath);
+                        JPopupMenu popup = new JPopupMenu();
+                        for (Component comp : MainWindow.getInstance().createProofMenu()
+                                .getMenuComponents()) {
+                            popup.add(comp);
+                        }
+                        popup.show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                mousePressed(e);
+            }
+        };
+
+        delegateView.addMouseListener(ml);
     }
 
     public void addProof(de.uka.ilkd.key.proof.ProofAggregate plist) {
@@ -349,7 +370,7 @@ public class TaskTree extends JPanel {
                 return;
             }
             TaskTreeNode ttn = model.getTaskForProof(e.getSource().getSelectedProof());
-            jtree().setSelectionPath(new TreePath(ttn.getPath()));
+            delegateView.setSelectionPath(new TreePath(ttn.getPath()));
             validate();
         }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
@@ -5,6 +5,7 @@ import java.awt.event.KeyEvent;
 
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
+import de.uka.ilkd.key.proof.Proof;
 
 public final class AbandonTaskAction extends MainWindowAction {
 
@@ -13,7 +14,9 @@ public final class AbandonTaskAction extends MainWindowAction {
      */
     private static final long serialVersionUID = 915588190956945751L;
 
-    public AbandonTaskAction(MainWindow mainWindow) {
+    private final Proof proof;
+
+    public AbandonTaskAction(MainWindow mainWindow, Proof proof) {
         super(mainWindow);
         setName("Abandon Proof");
         setIcon(IconFactory.abandon(16));
@@ -22,12 +25,18 @@ public final class AbandonTaskAction extends MainWindowAction {
 
         getMediator().enableWhenProofLoaded(this);
         lookupAcceleratorKey();
+
+        this.proof = proof;
     }
 
     public synchronized void actionPerformed(ActionEvent e) {
         boolean removalConfirmed = getMediator().getUI().confirmTaskRemoval("Are you sure?");
         if (removalConfirmed) {
-            getMediator().getSelectedProof().dispose();
+            if (proof == null) {
+                getMediator().getSelectedProof().dispose();
+            } else {
+                proof.dispose();
+            }
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveTactletOptionsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveTactletOptionsAction.java
@@ -16,12 +16,15 @@ public class ShowActiveTactletOptionsAction extends MainWindowAction {
      */
     private static final long serialVersionUID = -7012564698194718532L;
 
-    public ShowActiveTactletOptionsAction(MainWindow mainWindow) {
+    private final Proof proof;
+
+    public ShowActiveTactletOptionsAction(MainWindow mainWindow, Proof proof) {
         super(mainWindow);
         setName("Show Active Taclet Options");
 
         getMediator().enableWhenProofLoaded(this);
 
+        this.proof = proof;
     }
 
     @Override
@@ -30,7 +33,7 @@ public class ShowActiveTactletOptionsAction extends MainWindowAction {
     }
 
     private void showActivatedChoices() {
-        Proof currentProof = getMediator().getSelectedProof();
+        Proof currentProof = proof == null ? getMediator().getSelectedProof() : proof;
         if (currentProof == null) {
             mainWindow.notify(new GeneralInformationEvent("No Options available.",
                 "If you wish to see Taclet Options " + "for a proof you have to load one first"));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowKnownTypesAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowKnownTypesAction.java
@@ -24,11 +24,15 @@ public class ShowKnownTypesAction extends MainWindowAction {
      */
     private static final long serialVersionUID = 4368162229726580799L;
 
-    public ShowKnownTypesAction(MainWindow mainWindow) {
+    private final Proof proof;
+
+    public ShowKnownTypesAction(MainWindow mainWindow, Proof proof) {
         super(mainWindow);
         setName("Show Known Types");
 
         getMediator().enableWhenProofLoaded(this);
+
+        this.proof = proof;
     }
 
     @Override
@@ -37,7 +41,7 @@ public class ShowKnownTypesAction extends MainWindowAction {
     }
 
     private void showTypeHierarchy() {
-        Proof currentProof = getMediator().getSelectedProof();
+        Proof currentProof = proof == null ? getMediator().getSelectedProof() : proof;
         if (currentProof == null) {
             mainWindow.notify(new GeneralInformationEvent("No Type Hierarchy available.",
                 "If you wish to see the types " + "for a proof you have to load one first"));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
@@ -32,17 +32,21 @@ public class ShowProofStatistics extends MainWindowAction {
      */
     private static final long serialVersionUID = -8814798230037775905L;
 
-    public ShowProofStatistics(MainWindow mainWindow) {
+    private final Proof proof;
+
+    public ShowProofStatistics(MainWindow mainWindow, Proof proof) {
         super(mainWindow);
         setName("Show Proof Statistics");
         setIcon(IconFactory.statistics(16));
         getMediator().enableWhenProofLoaded(this);
         lookupAcceleratorKey();
+
+        this.proof = proof;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final Proof proof = getMediator().getSelectedProof();
+        final Proof proof = this.proof == null ? getMediator().getSelectedProof() : this.proof;
         if (proof == null) {
             mainWindow.notify(new GeneralInformationEvent("No statistics available.",
                 "If you wish to see the statistics " + "for a proof you have to load one first"));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowUsedContractsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowUsedContractsAction.java
@@ -14,12 +14,15 @@ public class ShowUsedContractsAction extends MainWindowAction {
      */
     private static final long serialVersionUID = 2680058046414747256L;
 
-    public ShowUsedContractsAction(MainWindow mainWindow) {
+    private final Proof proof;
+
+    public ShowUsedContractsAction(MainWindow mainWindow, Proof proof) {
         super(mainWindow);
         setName("Show Used Contracts");
 
         getMediator().enableWhenProofLoaded(this);
 
+        this.proof = proof;
     }
 
     @Override
@@ -28,7 +31,7 @@ public class ShowUsedContractsAction extends MainWindowAction {
     }
 
     private void showUsedContracts() {
-        Proof currentProof = getMediator().getSelectedProof();
+        Proof currentProof = proof == null ? getMediator().getSelectedProof() : proof;
         if (currentProof == null) {
             mainWindow.notify(new GeneralInformationEvent("No contracts available.",
                 "If you wish to see the used contracts "

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
@@ -16,6 +16,7 @@ import de.uka.ilkd.key.gui.extension.api.ContextMenuKind;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
 import de.uka.ilkd.key.gui.extension.api.TabPanel;
 import de.uka.ilkd.key.pp.PosInSequent;
+import de.uka.ilkd.key.proof.Proof;
 
 /**
  * Facade for retrieving the GUI extensions.
@@ -235,6 +236,12 @@ public final class KeYGuiExtensionFacade {
     public static JPopupMenu createContextMenu(ContextMenuKind kind, Object underlyingObject,
             KeYMediator mediator) {
         JPopupMenu menu = new JPopupMenu();
+        if (underlyingObject instanceof Proof) {
+            for (Component comp : MainWindow.getInstance().createProofMenu((Proof) underlyingObject)
+                    .getMenuComponents()) {
+                menu.add(comp);
+            }
+        }
         List<Action> content = getContextMenuItems(kind, underlyingObject, mediator);
         content.forEach(menu::add);
         return menu;


### PR DESCRIPTION
This PR adds a context menu to proof entries in the task tree. Entries are equal to the proof menu in the menu bar.