### PR TITLE
Checkstyle: ignore Javadoc warning on logger variables

### DIFF
--- a/gradle/key_checks.xml
+++ b/gradle/key_checks.xml
@@ -70,7 +70,9 @@
 	<property name="authorFormat" value="\S"/>
       </module>
 
-      <module name="JavadocVariable"/>
+      <module name="JavadocVariable">
+        <property name="ignoreNamePattern" value="LOGGER"/>
+      </module>
       <module name="JavadocStyle">
 	<property name="checkFirstSentence" value="false" />
       </module>

--- a/scripts/tools/checkstyle/key_checks.xml
+++ b/scripts/tools/checkstyle/key_checks.xml
@@ -80,7 +80,9 @@
             <property name="authorFormat" value="\S"/>
         </module>
 
-        <module name="JavadocVariable"/>
+        <module name="JavadocVariable">
+            <property name="ignoreNamePattern" value="LOGGER"/>
+        </module>
         <module name="JavadocStyle">
             <property name="checkFirstSentence" value="false"/>
         </module>


### PR DESCRIPTION
There were two checkstyle files, not sure which is actually used so I changed both.