### PR TITLE
Set location of all dialogs relative to parent

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveSettingsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveSettingsAction.java
@@ -72,7 +72,7 @@ public class ShowActiveSettingsAction extends MainWindowAction {
 
             this.getOptionTree().getParent().setMinimumSize(getOptionTree().getPreferredSize());
             this.getContentPane().setPreferredSize(computePreferredSize(model));
-            this.setLocationByPlatform(true);
+            this.setLocationRelativeTo(MainWindow.getInstance());
             this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
             setIconImage(IconFactory.keyLogo());
             this.pack();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/lemmatagenerator/LemmaSelectionDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/lemmatagenerator/LemmaSelectionDialog.java
@@ -48,7 +48,7 @@ public class LemmaSelectionDialog extends JDialog implements TacletFilter {
         this.getContentPane().add(getContentPanel());
         this.getContentPane().add(Box.createHorizontalStrut(10));
         this.setMinimumSize(new Dimension(300, 300));
-        this.setLocationByPlatform(true);
+        this.setLocationRelativeTo(MainWindow.getInstance());
 
         this.pack();
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/lemmatagenerator/LoadUserTacletsDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/lemmatagenerator/LoadUserTacletsDialog.java
@@ -263,7 +263,7 @@ public class LoadUserTacletsDialog extends JPanel {
             textArea.setEditable(false);
             helpWindow.getContentPane().add(new JScrollPane(textArea));
             helpWindow.setMinimumSize(new Dimension(400, 200));
-            helpWindow.setLocationByPlatform(true);
+            helpWindow.setLocationRelativeTo(MainWindow.getInstance());
             helpWindow.setTitle("Help");
             helpWindow.pack();
 
@@ -448,7 +448,7 @@ public class LoadUserTacletsDialog extends JPanel {
             buttonPane.add(Box.createHorizontalStrut(5));
             buttonPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
             pane.add(buttonPane);
-            dialog.setLocationByPlatform(true);
+            dialog.setLocationRelativeTo(MainWindow.getInstance());
             dialog.pack();
         }
         return dialog;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SettingsManager.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SettingsManager.java
@@ -121,7 +121,7 @@ public class SettingsManager {
         dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         dialog.setIconImage(IconFactory.keyLogo());
         dialog.setSize(800, 600);
-        dialog.setLocationByPlatform(true);
+        dialog.setLocationRelativeTo(mainWindow);
         return dialog;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/InformationWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/InformationWindow.java
@@ -80,7 +80,7 @@ public class InformationWindow extends JDialog {
         this.getContentPane().add(getTabbedPane());
         this.setModalExclusionType(ModalExclusionType.APPLICATION_EXCLUDE);
         this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-        this.setLocationByPlatform(true);
+        this.setLocationRelativeTo(parent);
         this.setVisible(true);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/ProgressDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/ProgressDialog.java
@@ -87,7 +87,7 @@ public class ProgressDialog extends JDialog {
         table.getTableHeader().setReorderingAllowed(false);
         table.setModel(model, titles);
         this.listener = listener;
-        this.setLocationByPlatform(true);
+        setLocationRelativeTo(MainWindow.getInstance());
         if (counterexample) {
             this.setTitle("SMT Counterexample Search");
         } else {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/StdDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/StdDialog.java
@@ -6,6 +6,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.*;
 
+import de.uka.ilkd.key.gui.MainWindow;
+
 
 /**
  * A dialog offering three buttons at the lower border: Help (optional), Okay and Cancel. The
@@ -32,7 +34,7 @@ public class StdDialog extends JDialog {
     }
 
     public StdDialog(String title, JComponent content, int strut, boolean helpButton) {
-        this.setLocationByPlatform(true);
+        this.setLocationRelativeTo(MainWindow.getInstance());
         this.setTitle(title);
         this.setModal(true);
         // content.setMaximumSize(new Dimension(Integer.MAX_VALUE,Integer.MAX_VALUE));


### PR DESCRIPTION
This fixes the issue where some dialogs may appear in the wrong location if multiple displays are connected.