### PR TITLE
Reduce clutter in toolbar

### DIFF
--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     api 'org.dockingframes:docking-frames-core:1.1.3p1'
 
     runtimeOnly project(":keyext.ui.testgen")
-    runtimeOnly project(":keyext.action_history")
     runtimeOnly project(":keyext.exploration")
     runtimeOnly project(":keyext.slicing")
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -622,6 +622,7 @@ public final class MainWindow extends JFrame {
 
     private JToolBar createFileOpsToolBar() {
         JToolBar fileOperations = new JToolBar("File Operations");
+        fileOperations.setFloatable(false);
         fileOperations.add(openFileAction);
         fileOperations.add(openMostRecentFileAction);
         fileOperations.add(editMostRecentFileAction);
@@ -635,7 +636,7 @@ public final class MainWindow extends JFrame {
 
     private JToolBar createProofControlToolBar() {
         JToolBar toolBar = new JToolBar("Proof Control");
-        toolBar.setFloatable(true);
+        toolBar.setFloatable(false);
         toolBar.setRollover(true);
 
         toolBar.add(createWiderAutoModeButton());
@@ -660,7 +661,7 @@ public final class MainWindow extends JFrame {
 
     private JToolBar createNavigationToolBar() {
         JToolBar toolBar = new JToolBar("Selection Navigation");
-        toolBar.setFloatable(true);
+        toolBar.setFloatable(false);
         toolBar.setRollover(true);
 
         SelectionHistory history = new SelectionHistory(mediator);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -43,6 +43,7 @@ import de.uka.ilkd.key.gui.nodeviews.*;
 import de.uka.ilkd.key.gui.notification.NotificationManager;
 import de.uka.ilkd.key.gui.notification.events.ExitKeYEvent;
 import de.uka.ilkd.key.gui.notification.events.NotificationEvent;
+import de.uka.ilkd.key.gui.plugins.action_history.ActionHistoryExtension;
 import de.uka.ilkd.key.gui.proofdiff.ProofDiffFrame;
 import de.uka.ilkd.key.gui.prooftree.ProofTreeView;
 import de.uka.ilkd.key.gui.settings.SettingsManager;
@@ -647,6 +648,9 @@ public final class MainWindow extends JFrame {
         toolBar.addSeparator();
         toolBar.add(new GoalBackAction(this, false));
         toolBar.add(new PruneProofAction(this));
+        var act = new ActionHistoryExtension(this, mediator);
+        toolBar.add(act.getUndoButton().getAction());
+        toolBar.add(act.getUndoUptoButton());
         toolBar.addSeparator();
         // toolBar.add(createHeatmapToggle());
         // toolBar.add(createHeatmapMenuOpener());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
@@ -152,6 +152,11 @@ public abstract class KeyAction extends AbstractAction {
         return i == null ? 0 : i;
     }
 
+    /**
+     * Set the priority of this action. Actions are sorted from low priority to high priority.
+     *
+     * @param priority integer value
+     */
     protected void setPriority(int priority) {
         putValue(PRIORITY, priority);
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.swing.*;
 
 import de.uka.ilkd.key.core.KeYMediator;
@@ -40,10 +41,10 @@ public final class DockingLayout implements KeYGuiExtension, KeYGuiExtension.Sta
         KeYGuiExtension.MainMenu {
     private static final Logger LOGGER = LoggerFactory.getLogger(DockingLayout.class);
 
-    public static final float SIZE_ICON_DOCK = 12f;
-    public static final File LAYOUT_FILE = new File(PathConfig.getKeyConfigDir(), "layout.xml");
-    public static final String[] LAYOUT_NAMES = new String[] { "Default", "Slot 1", "Slot 2" };
-    public static final int[] LAYOUT_KEYS =
+    private static final float SIZE_ICON_DOCK = 12f;
+    private static final File LAYOUT_FILE = new File(PathConfig.getKeyConfigDir(), "layout.xml");
+    private static final String[] LAYOUT_NAMES = new String[] { "Default", "Slot 1", "Slot 2" };
+    private static final int[] LAYOUT_KEYS =
         new int[] { KeyEvent.VK_F10, KeyEvent.VK_F11, KeyEvent.VK_F12 };
 
     private MainWindow window;
@@ -126,13 +127,19 @@ public final class DockingLayout implements KeYGuiExtension, KeYGuiExtension.Sta
         DockingHelper.restoreMissingPanels(window);
     }
 
+    @Nonnull
     @Override
-    public List<Action> getMainMenuActions(MainWindow mainWindow) {
+    public List<Action> getMainMenuActions(@Nonnull MainWindow mainWindow) {
         List<Action> actions = new ArrayList<>();
         int keypos = 0;
         for (String layout : LAYOUT_NAMES) {
             Integer key = keypos < LAYOUT_KEYS.length ? LAYOUT_KEYS[keypos] : null;
             actions.add(new LoadLayoutAction(mainWindow, layout, key));
+            keypos++;
+        }
+        keypos = 0;
+        for (String layout : LAYOUT_NAMES) {
+            Integer key = keypos < LAYOUT_KEYS.length ? LAYOUT_KEYS[keypos] : null;
             actions.add(new SaveLayoutAction(mainWindow, layout, key));
             keypos++;
         }
@@ -149,7 +156,7 @@ final class SaveLayoutAction extends MainWindowAction {
     SaveLayoutAction(MainWindow mainWindow, String name, Integer key) {
         super(mainWindow);
         this.layoutName = name;
-        setName("Save as " + name);
+        setName("Save " + name);
         setIcon(IconFactory.saveFile(MainWindow.TOOLBAR_ICON_SIZE));
         setMenuPath("View.Layout");
         if (key != null) {
@@ -162,7 +169,7 @@ final class SaveLayoutAction extends MainWindowAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         mainWindow.getDockControl().save(layoutName);
-        mainWindow.setStatusLine("Save layout as " + layoutName);
+        mainWindow.setStatusLine("Layout saved to " + layoutName);
     }
 }
 
@@ -189,7 +196,7 @@ final class LoadLayoutAction extends MainWindowAction {
             Arrays.asList(mainWindow.getDockControl().layouts()).contains(layoutName);
         if (defaultLayoutDefined) {
             mainWindow.getDockControl().load(layoutName);
-            mainWindow.setStatusLine("Layout " + layoutName + " loaded");
+            mainWindow.setStatusLine("Layout loaded from " + layoutName);
         } else {
             mainWindow.setStatusLine("Layout " + layoutName + " could not be found.");
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
@@ -151,7 +151,7 @@ final class SaveLayoutAction extends MainWindowAction {
         this.layoutName = name;
         setName("Save as " + name);
         setIcon(IconFactory.saveFile(MainWindow.TOOLBAR_ICON_SIZE));
-        setMenuPath("View.Layout.Save");
+        setMenuPath("View.Layout");
         if (key != null) {
             setAcceleratorKey(KeyStroke.getKeyStroke(key,
                 InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
@@ -180,7 +180,7 @@ final class LoadLayoutAction extends MainWindowAction {
             setAcceleratorKey(KeyStroke.getKeyStroke(key, InputEvent.CTRL_DOWN_MASK));
         }
         KeyStrokeManager.lookupAndOverride(this, getClass().getName() + "$" + layoutName);
-        setMenuPath("View.Layout.Load");
+        setMenuPath("View.Layout");
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
@@ -123,8 +123,8 @@ public final class DockingLayout implements KeYGuiExtension, KeYGuiExtension.Sta
         boolean defaultLayoutDefined = Arrays.asList(globalPort.layouts()).contains(layout);
         if (defaultLayoutDefined) {
             globalPort.load(layout);
-            DockingHelper.restoreMissingPanels(window);
         }
+        DockingHelper.restoreMissingPanels(window);
     }
 
     @Nonnull

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/docking/DockingLayout.java
@@ -43,7 +43,8 @@ public final class DockingLayout implements KeYGuiExtension, KeYGuiExtension.Sta
     public static final float SIZE_ICON_DOCK = 12f;
     public static final File LAYOUT_FILE = new File(PathConfig.getKeyConfigDir(), "layout.xml");
     public static final String[] LAYOUT_NAMES = new String[] { "Default", "Slot 1", "Slot 2" };
-    public static final int[] LAYOUT_KEYS = new int[] { KeyEvent.VK_F11, KeyEvent.VK_F12 };
+    public static final int[] LAYOUT_KEYS =
+        new int[] { KeyEvent.VK_F10, KeyEvent.VK_F11, KeyEvent.VK_F12 };
 
     private MainWindow window;
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/api/KeYGuiExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/api/KeYGuiExtension.java
@@ -3,10 +3,12 @@ package de.uka.ilkd.key.gui.extension.api;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
-import javax.swing.*;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JMenu;
+import javax.swing.JToolBar;
 
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.GoalList;
@@ -98,19 +100,6 @@ public interface KeYGuiExtension {
          */
         @Nonnull
         List<Action> getMainMenuActions(@Nonnull MainWindow mainWindow);
-
-        /**
-         * A list of menu items which should be added to the main menu.
-         * These will be added before the actions returned by
-         * {@link #getMainMenuActions(MainWindow)} are added.
-         *
-         * @param mainWindow the main window
-         * @return list of menu items
-         */
-        @Nonnull
-        default List<JMenuItem> getMainMenuItems(@Nonnull MainWindow mainWindow) {
-            return Collections.emptyList();
-        }
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/api/KeYGuiExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/api/KeYGuiExtension.java
@@ -3,12 +3,10 @@ package de.uka.ilkd.key.gui.extension.api;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
-import javax.swing.Action;
-import javax.swing.JComponent;
-import javax.swing.JMenu;
-import javax.swing.JToolBar;
+import javax.swing.*;
 
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.GoalList;
@@ -100,6 +98,19 @@ public interface KeYGuiExtension {
          */
         @Nonnull
         List<Action> getMainMenuActions(@Nonnull MainWindow mainWindow);
+
+        /**
+         * A list of menu items which should be added to the main menu.
+         * These will be added before the actions returned by
+         * {@link #getMainMenuActions(MainWindow)} are added.
+         *
+         * @param mainWindow the main window
+         * @return list of menu items
+         */
+        @Nonnull
+        default List<JMenuItem> getMainMenuItems(@Nonnull MainWindow mainWindow) {
+            return Collections.emptyList();
+        }
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
@@ -68,12 +68,11 @@ public final class KeYGuiExtensionFacade {
 
     /**
      * Adds all registered and activated {@link KeYGuiExtension.MainMenu} to the given menuBar.
+     *
+     * @return a menu
      */
     public static void addExtensionsToMainMenu(MainWindow mainWindow, JMenuBar menuBar) {
         JMenu menu = new JMenu("Extensions");
-        KeYGuiExtensionFacade.getMainMenuExtensions().stream()
-                .flatMap(it -> it.getMainMenuItems(mainWindow).stream())
-                .forEach(it -> sortItemIntoMenu(it, menuBar, menu));
         getMainMenuActions(mainWindow).forEach(it -> sortActionIntoMenu(it, menuBar, menu));
 
         if (menu.getMenuComponents().length > 0) {
@@ -81,6 +80,14 @@ public final class KeYGuiExtensionFacade {
         }
 
     }
+
+    /*
+     * public static Optional<Action> getMainMenuExtensions(String name) {
+     * Spliterator<KeYGuiExtension.MainMenu> iter =
+     * ServiceLoader.load(KeYGuiExtension.MainMenu.class).spliterator(); return
+     * StreamSupport.stream(iter, false) .flatMap(it -> it.getMainMenuActions(mainWindow).stream())
+     * .filter(Objects::nonNull) .filter(it -> it.getValue(Action.NAME).equals(name)) .findAny(); }
+     */
 
     // region Menu Helper
     private static void sortActionsIntoMenu(List<Action> actions, JMenuBar menuBar) {
@@ -96,10 +103,6 @@ public final class KeYGuiExtensionFacade {
             spath = path.toString();
         }
         return Pattern.compile(Pattern.quote(".")).splitAsStream(spath).iterator();
-    }
-
-    private static Iterator<String> getMenuPath(JMenuItem item) {
-        return getMenuPath(item.getAction());
     }
 
     private static void sortActionIntoMenu(Action act, JMenu menu) {
@@ -130,12 +133,6 @@ public final class KeYGuiExtensionFacade {
                 a.add(act);
             }
         }
-    }
-
-    private static void sortItemIntoMenu(JMenuItem item, JMenuBar menuBar, JMenu defaultMenu) {
-        Iterator<String> mpath = getMenuPath(item);
-        JMenu a = findMenu(menuBar, mpath, defaultMenu);
-        a.add(item);
     }
 
     private static void sortActionIntoMenu(Action act, JMenuBar menuBar, JMenu defaultMenu) {
@@ -377,7 +374,9 @@ public final class KeYGuiExtensionFacade {
     // region Term tool tip
 
     /**
-     * @return all known implementations of the {@link KeYGuiExtension.Tooltip}
+     * Retrieves all known implementations of the {@link KeYGuiExtension.Tooltip}.
+     *
+     * @return all known implementations of the {@link KeYGuiExtension.Tooltip}.
      */
     public static List<KeYGuiExtension.Tooltip> getTooltipExtensions() {
         return getExtensionInstances(KeYGuiExtension.Tooltip.class);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
@@ -223,6 +223,7 @@ public final class KeYGuiExtensionFacade {
      */
     public static List<JToolBar> createToolbars(MainWindow mainWindow) {
         return getToolbarExtensions().stream().map(it -> it.getToolbar(mainWindow))
+                .peek(x -> x.setFloatable(false))
                 .collect(Collectors.toList());
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
@@ -81,18 +81,7 @@ public final class KeYGuiExtensionFacade {
 
     }
 
-    /*
-     * public static Optional<Action> getMainMenuExtensions(String name) {
-     * Spliterator<KeYGuiExtension.MainMenu> iter =
-     * ServiceLoader.load(KeYGuiExtension.MainMenu.class).spliterator(); return
-     * StreamSupport.stream(iter, false) .flatMap(it -> it.getMainMenuActions(mainWindow).stream())
-     * .filter(Objects::nonNull) .filter(it -> it.getValue(Action.NAME).equals(name)) .findAny(); }
-     */
-
     // region Menu Helper
-    private static void sortActionsIntoMenu(List<Action> actions, JMenuBar menuBar) {
-        actions.forEach(act -> sortActionIntoMenu(act, menuBar, new JMenu()));
-    }
 
     private static Iterator<String> getMenuPath(Action act) {
         Object path = act.getValue(KeyAction.PATH);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/StateChangeListener.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/StateChangeListener.java
@@ -1,4 +1,4 @@
-package org.key_project.action_history;
+package de.uka.ilkd.key.gui.plugins.action_history;
 
 import java.util.List;
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/UndoHistoryButton.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/UndoHistoryButton.java
@@ -1,4 +1,4 @@
-package org.key_project.action_history;
+package de.uka.ilkd.key.gui.plugins.action_history;
 
 import java.awt.event.*;
 import java.util.*;
@@ -171,7 +171,7 @@ public class UndoHistoryButton {
      *
      * @return the action
      */
-    protected MainWindowAction getAction() {
+    public MainWindowAction getAction() {
         return action;
     }
 

--- a/keyext.action_history/build.gradle
+++ b/keyext.action_history/build.gradle
@@ -1,4 +1,0 @@
-dependencies {
-    implementation project(":key.core")
-    implementation project(":key.ui")
-}

--- a/keyext.action_history/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
+++ b/keyext.action_history/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
@@ -1,1 +1,0 @@
-org.key_project.action_history.ActionHistoryExtension

--- a/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
@@ -39,7 +39,7 @@ import org.key_project.exploration.ui.ExplorationStepsList;
  */
 @KeYGuiExtension.Info(name = "Exploration",
     description = "Author: Sarah Grebing <grebing@ira.uka.de>, Alexander Weigl <weigl@ira.uka.de>",
-    experimental = false, optional = true, priority = 10000)
+    experimental = true, optional = true, priority = 10000)
 public class ExplorationExtension implements KeYGuiExtension, KeYGuiExtension.ContextMenu,
         KeYGuiExtension.Startup, KeYGuiExtension.Toolbar, KeYGuiExtension.MainMenu,
         KeYGuiExtension.LeftPanel, KeYGuiExtension.StatusLine, ProofDisposedListener {

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,5 @@ include "key.core.example"
 include "key.core.symbolic_execution.example"
 include 'recoder'
 include 'keyext.ui.testgen'
-include 'keyext.action_history'
 include 'keyext.exploration'
 include 'keyext.slicing'


### PR DESCRIPTION
![image](https://github.com/KeYProject/key/assets/12560461/47284086-31cd-453d-8eb0-e5218b68b402)
View menu:
![image](https://github.com/KeYProject/key/assets/12560461/db0b5559-6f56-41da-90ce-716c337bf106)

This reduces clutter in the main toolbar by:
- moving the action history next to the other undo buttons
- moving the layout controls to a menu (View -> Layout)
- marking the exploration extension as experimental (as documented)
- disabling the functionality to reorder toolbars (only ever used by accident)

As a bonus, the bug that extension panels sometimes fail to show up should also be fixed.