### PR TITLE
Fix InvariantConfigurator

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
@@ -181,8 +181,10 @@ public class InvariantConfigurator {
 
                 final NamespaceSet nss = services.getNamespaces().copyWithParent();
                 Term self = loopInv.getInternalSelfTerm();
-                nss.programVariables()
-                        .add(new LocationVariable(new ProgramElementName("self"), self.sort()));
+                if (self != null) {
+                    nss.programVariables()
+                            .add(new LocationVariable(new ProgramElementName("self"), self.sort()));
+                }
                 parser = new KeyIO(services, nss);
                 parser.setAbbrevMap(getAbbrevMap());
 


### PR DESCRIPTION
When using a loop in a `.key` file without a Java source like this:
```java
\programVariables{
	int i, n;
}

\problem {
	 n >= 0 & wellFormed(heap) ->
           { i:=0 } \[{
	   /*@ loop_invariant i <= n;
	     @ assignable \nothing; @*/
	     while (i < n) {
	       i = i + 1;
	     }
	   }\] (i = n)
}
```

using the loop invariant rule would result in a NullPointerException. This PR fixes this with an additional null check.