### PR TITLE
Fix for bug with effectless updates

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/LocationVariable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/LocationVariable.java
@@ -86,4 +86,29 @@ public final class LocationVariable extends ProgramVariable implements Updateabl
             argSorts(), name().toString(), arity(),
             whereToBind(), isRigid());
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof LocationVariable)) {
+            return false;
+        }
+        LocationVariable that = (LocationVariable) obj;
+        return Objects.equals(getKeYJavaType(), that.getKeYJavaType())
+            && isStatic() == that.isStatic()
+            && isModel() == that.isModel()
+            && isGhost() == that.isGhost()
+            && isFinal() == that.isFinal()
+            && sort().equals(that.sort())
+            && Objects.equals(argSorts(), that.argSorts())
+            && name().toString().equals(that.name().toString())
+            && arity() == that.arity()
+            && Objects.equals(whereToBind(), that.whereToBind())
+            && isRigid() == that.isRigid();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKeYJavaType(), isStatic(), isModel(), isGhost(), isFinal(), sort(),
+            argSorts(), name().toString(), arity(), whereToBind(), isRigid());
+    }
 }


### PR DESCRIPTION
This draft PR fixes a bug where updates are dropped even though they would have an effect. This happens since the DropEffectlessElementariesCondition performs the check using a LinkedHashSet, which relies on equals of LocationVariable. However, this is not implemented and defaults to equals of Object.

At the moment, I do not know why this bug only appears after pruning in the proof. Directly after opening/loading the instances of LocationVariable are the same, thus the check succeeds and the update is not dropped ...

Since the change might have a big impact, let's see if the tests run successfully.
