### PR TITLE
fixate bash as shell for dlsmt.sh

### DIFF
--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/bash
 
 ## Weigl's little helper to download SMT-solvers. 
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+# No shebang!
 
 ## Weigl's little helper to download SMT-solvers. 
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/
-            !jacocoTestReport.xml
+            !**/jacocoTestReport.xml
             
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,8 @@ jobs:
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/
+            !jacocoTestReport.xml
+            
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Install SMT-Solvers
         run: .github/dlsmt.sh
+        shell: bash
+
 
       - name: "Running tests: ${{ matrix.test }}"
         uses: gradle/gradle-build-action@v2.4.2

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v3.1.1
         if: success() || failure()        # run this step even if previous step failed
         with:
-          name: test-results
+          name: test-results-${{ matrix.os }}
           path: |
             **/build/test-results/*/*.xml
             key.core/build/reports/runallproofs/*

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest] # ubuntu-latest, windows-latest
+        os: [macos-latest, ubuntu-latest, windows-latest]
         java: [11, 17]
     continue-on-error: true
     runs-on: ${{ matrix.os }}
@@ -40,9 +40,8 @@ jobs:
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+            !**/jacocoTestReport.xml
+            
 
   integration-tests:
     env:
@@ -52,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [testProveRules, testRunAllFunProofs, testRunAllInfProofs]
-        os: [ macos-latest ] # ubuntu-latest, windows-latest,
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
         java: [11,17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -87,3 +86,5 @@ jobs:
             **/build/test-results/*/*.xml
             key.core/build/reports/runallproofs/*
             **/build/reports/
+            !**/jacocoTestReport.xml
+

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [macos-latest] # ubuntu-latest, windows-latest
         java: [11, 17]
     continue-on-error: true
     runs-on: ${{ matrix.os }}
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [testProveRules, testRunAllFunProofs, testRunAllInfProofs]
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ macos-latest ] # ubuntu-latest, windows-latest,
         java: [11,17]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The release tests had an error on non-linux environments s.t. `dlsmt.sh` breaks.

1. We fixed the shell to `bash` which repairs windows
2. We removed the shebang which fixes macos

Covert change: removal of `jacocoTestReport.xml` from the artifacts for unit-tests, which should decreases the huge size of `test-results`.
