### PR TITLE
Fixes a NullPointerException when the configuration files for the "Recent Files" feature is not yet created

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
@@ -242,12 +242,16 @@ public class RecentFileMenu {
      */
     public void store(String filename) {
         File localRecentFiles = new File(filename);
+        // creates a new file if it does not exist yet
+        try {
+            localRecentFiles.createNewFile();
+        } catch (IOException e) {
+            LOGGER.info("Could not create or access recent files", e);
+        }
 
         Properties p = new Properties();
         try (FileInputStream fin = new FileInputStream(localRecentFiles);
                 FileOutputStream fout = new FileOutputStream(localRecentFiles)) {
-            // creates a new file if it does not exist yet
-            localRecentFiles.createNewFile();
             p.load(fin);
             store(p);
             p.store(fout, "recent files");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
@@ -247,6 +247,7 @@ public class RecentFileMenu {
             localRecentFiles.createNewFile();
         } catch (IOException e) {
             LOGGER.info("Could not create or access recent files", e);
+            return;
         }
 
         Properties p = new Properties();


### PR DESCRIPTION
We must ensure to create the "recentFiles" configuration file before passing the File object to an InputStream.
