### PR TITLE
Fix default look-and-feel in settings dialog

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
@@ -28,12 +28,12 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
     /**
      * Labels for the selectable look and feels. Must be kept in sync with {@link #LAF_CLASSES}.
      */
-    private static final List<String> LAF_LABELS = new ArrayList<>(List.of("System"));
+    private static final List<String> LAF_LABELS = new ArrayList<>(List.of("Metal"));
     /**
      * Classnames corresponding to the labels in {@link #LAF_LABELS}.
      */
     private static final List<String> LAF_CLASSES =
-        new ArrayList<>(List.of(UIManager.getSystemLookAndFeelClassName()));
+        new ArrayList<>(List.of(UIManager.getCrossPlatformLookAndFeelClassName()));
 
     private final JComboBox<String> lookAndFeel;
     private final JSpinner spFontSizeGlobal;
@@ -60,8 +60,10 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         // load all available look and feels
         if (LAF_LABELS.size() == 1) {
             for (UIManager.LookAndFeelInfo it : UIManager.getInstalledLookAndFeels()) {
-                LAF_LABELS.add(it.getName());
-                LAF_CLASSES.add(it.getClassName());
+                if (!LAF_LABELS.contains(it.getName())) {
+                    LAF_LABELS.add(it.getName());
+                    LAF_CLASSES.add(it.getClassName());
+                }
             }
         }
 


### PR DESCRIPTION
When first started, KeY uses the Java cross-platform look-and-feel called Metal. But opening the settings dialog automatically selects the System look-and-feel as default.

Thus, when installing KeY on a platform that provides a system look-and-feel, you will see the Metal LnF at first, but as soon as you generate a settings file by opening the settings dialog, KeY will switch to the System LnF even if you don't select anything.

This PR fixes this by always applying Metal as the default.