### PR TITLE
Generate configuration file 'proof-settings.prop' if none exists

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -175,14 +175,19 @@ public class ProofSettings {
      * Loads the the former settings from configuration file.
      */
     public void loadSettings() {
-        try (FileReader in = new FileReader(PROVER_CONFIG_FILE, StandardCharsets.UTF_8)) {
-            if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
-                LOGGER.warn("The settings in {} are *not* read.", PROVER_CONFIG_FILE);
-            } else {
-                loadSettingsFromStream(in);
+        if (!PROVER_CONFIG_FILE.exists()) {
+            saveSettings();
+            LOGGER.info("No proof-settings exists. Generating default settings.");
+        } else {
+            try (FileReader in = new FileReader(PROVER_CONFIG_FILE, StandardCharsets.UTF_8)) {
+                if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
+                    LOGGER.warn("The settings in {} are *not* read.", PROVER_CONFIG_FILE);
+                } else {
+                    loadSettingsFromStream(in);
+                }
+            } catch (IOException e) {
+                LOGGER.warn("No proof-settings could be loaded, using defaults", e);
             }
-        } catch (IOException e) {
-            LOGGER.warn("No proof-settings could be loaded, using defaults", e);
         }
     }
 


### PR DESCRIPTION
This PR fixes issue #3228
