### PR TITLE
Fix infinite loop in MainWindow construction

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -290,7 +290,7 @@ public final class MainWindow extends JFrame {
         KeYGuiExtensionFacade.getStartupExtensions().forEach(it -> it.preInit(this, mediator));
 
         ViewSettings vs = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
-        FontSizeFacade.resizeFonts(vs.getUIFontSizeFactor());
+        FontSizeFacade.resizeFonts(this, vs.getUIFontSizeFactor());
 
         termLabelMenu = new TermLabelMenu(this);
         currentGoalView = new CurrentGoalView(this);
@@ -377,6 +377,15 @@ public final class MainWindow extends JFrame {
             LOGGER.error("Please use the --auto option to start KeY in batch mode.");
             LOGGER.error("Use the --help option for more command line options.");
             System.exit(-1);
+        }
+        // always construct MainWindow on event dispatch thread
+        if (!EventQueue.isDispatchThread()) {
+            try {
+                SwingUtilities.invokeAndWait(MainWindow::getInstance);
+            } catch (InterruptedException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+            return instance;
         }
         if (instance == null) {
             instance = new MainWindow();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/FontSizeFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/FontSizeFacade.java
@@ -39,10 +39,13 @@ public class FontSizeFacade {
     }
 
     /**
-     * @param factor
+     * Scale all managed fonts by the provided factor. Then attempts to redraw all components.
+     *
+     * @param window the main window
+     * @param factor the factor
      * @see SwingUtilities#updateComponentTreeUI(Component)
      */
-    public static void resizeFonts(double factor) {
+    public static void resizeFonts(MainWindow window, double factor) {
         if (Math.abs(currentFactor - factor) <= 0.1) {
             return;
         }
@@ -61,8 +64,7 @@ public class FontSizeFacade {
         });
 
         // for some reason, the menu bar does not update its font on its own
-        SwingUtil.setFont(MainWindow.getInstance().getJMenuBar(),
-            UIManager.getDefaults().getFont("Menu.font"));
+        SwingUtil.setFont(window.getJMenuBar(), UIManager.getDefaults().getFont("Menu.font"));
 
         // redraw all frames and dialogs
         for (Window w : Window.getWindows()) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
@@ -189,7 +189,7 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         gs.setAutoSave((Integer) spAutoSaveProof.getValue());
         gs.setTacletFilter(chkMinimizeInteraction.isSelected());
         vs.setFontIndex(spFontSizeTreeSequent.getSelectedIndex());
-        FontSizeFacade.resizeFonts(vs.getUIFontSizeFactor());
+        FontSizeFacade.resizeFonts(MainWindow.getInstance(), vs.getUIFontSizeFactor());
         Config.DEFAULT.setDefaultFonts();
         Config.DEFAULT.fireConfigChange();
     }

--- a/key.ui/src/main/java/org/key_project/util/java/SwingUtil.java
+++ b/key.ui/src/main/java/org/key_project/util/java/SwingUtil.java
@@ -157,6 +157,9 @@ public final class SwingUtil {
      * @param font the font
      */
     public static void setFont(JComponent component, Font font) {
+        if (component == null) {
+            return;
+        }
         component.setFont(font);
         for (int i = 0; i < component.getComponentCount(); i++) {
             Component c = component.getComponent(i);


### PR DESCRIPTION
Fixes #3234. The reason for the exceptions was a cycle in the main window construction (getInstance called in resizeFonts).

cc @WolframPfeifer 