### PR TITLE
Linearized proof tree

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIAbstractTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIAbstractTreeNode.java
@@ -2,8 +2,10 @@ package de.uka.ilkd.key.gui.prooftree;
 
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.LinkedList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.swing.tree.TreeNode;
 
@@ -18,6 +20,8 @@ public abstract class GUIAbstractTreeNode implements TreeNode {
     // and ProofTreeView.delegateView.lastPathComponent
     private final WeakReference<Node> noderef;
 
+    private TreeNode parent;
+
     protected GUIProofTreeModel getProofTreeModel() {
         return tree;
     }
@@ -31,7 +35,9 @@ public abstract class GUIAbstractTreeNode implements TreeNode {
 
     public abstract int getChildCount();
 
-    public abstract TreeNode getParent();
+    public TreeNode getParent() {
+        return parent;
+    }
 
     public abstract boolean isLeaf();
 
@@ -67,10 +73,10 @@ public abstract class GUIAbstractTreeNode implements TreeNode {
         return path.toArray(new TreeNode[0]);
     }
 
-    protected TreeNode findBranch(Node p_node) {
+    protected GUIAbstractTreeNode findBranch(Node p_node) {
         TreeNode res = getProofTreeModel().findBranch(p_node);
         if (res != null) {
-            return res;
+            return (GUIAbstractTreeNode) res;
         }
 
         String label = ensureBranchLabelIsSet(p_node);
@@ -111,25 +117,28 @@ public abstract class GUIAbstractTreeNode implements TreeNode {
         return noderef.get();
     }
 
-    protected Node findChild(Node n) {
+    protected List<Node> findChild(Node n) {
         if (n.childrenCount() == 1) {
-            return n.child(0);
+            return List.of(n.child(0));
         }
 
-        if (!getProofTreeModel().globalFilterActive()) {
-            return null;
-        }
+        /*
+         * if (!getProofTreeModel().globalFilterActive()) {
+         * return List.of();
+         * }
+         */
 
-        Node nextN = null;
+        List<Node> nextN = new ArrayList<>();
         for (int i = 0; i != n.childrenCount(); ++i) {
             if (!ProofTreeViewFilter.hiddenByGlobalFilters(n.child(i))) {
-                if (nextN != null) {
-                    return null;
-                }
-                nextN = n.child(i);
+                nextN.add(n.child(i));
             }
         }
 
         return nextN;
+    }
+
+    protected void setParent(TreeNode parent) {
+        this.parent = parent;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -422,7 +422,8 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
             }
             treeNode.flushCache();
             while (true) {
-                final Node nextN = treeNode.findChild(node);
+                List<Node> nextList = treeNode.findChild(node);
+                Node nextN = nextList.size() == 1 ? nextList.get(0) : null;
                 if (nextN == null) {
                     break;
                 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeNode.java
@@ -28,17 +28,6 @@ class GUIProofTreeNode extends GUIAbstractTreeNode {
         return children.length;
     }
 
-    public TreeNode getParent() {
-        Node n = getNode();
-        if (n == null) {
-            return null;
-        }
-        while (n.parent() != null && findChild(n.parent()) != null) {
-            n = n.parent();
-        }
-        return findBranch(n);
-    }
-
     public boolean isLeaf() {
         return getChildCount() == 0;
     }
@@ -72,6 +61,7 @@ class GUIProofTreeNode extends GUIAbstractTreeNode {
                         children[i] =
                             new GUIOneStepChildTreeNode(getProofTreeModel(), this, protocol.get(i),
                                 node.sequent().formulaNumberInSequent(ruleApp.posInOccurrence()));
+                        children[i].setParent(this);
                     }
                     return;
                 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1149,11 +1149,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
             }
 
             boolean isBranch = false;
-            final Node child = treeNode.findChild(node);
-            if (!(treeNode instanceof GUIOneStepChildTreeNode) && child != null
-                    && child.getNodeInfo().getBranchLabel() != null) {
+            List<Node> child = treeNode.findChild(node);
+            if (!(treeNode instanceof GUIOneStepChildTreeNode) && child.size() == 1
+                    && child.get(0).getNodeInfo().getBranchLabel() != null) {
                 isBranch = true;
-                style.text = style.text + ": " + child.getNodeInfo().getBranchLabel();
+                style.text = style.text + ": " + child.get(0).getNodeInfo().getBranchLabel();
             }
             if (isBranch && node.childrenCount() > 1) {
                 defaultIcon = getOpenIcon();


### PR DESCRIPTION
This PR changes the proof tree to be slightly more linear. In effect, the "Normal Execution" branch will (visually) continue on the parent branch.  See the screenshots below for what the new view filter would look like. If we agree to add this option, the implementation still needs to be changed before merging.

![linearTree3](https://github.com/KeYProject/key/assets/12560461/390b0e76-779a-4318-8c65-2f88465f08e0)
|previous|now|
:-------------------------:|:-------------------------:
![linearTree1](https://github.com/KeYProject/key/assets/12560461/d0f4ada4-1268-430e-8df4-c651cb7b4acd) | ![linearTree2](https://github.com/KeYProject/key/assets/12560461/1ca4b4e6-7a9b-49a1-b4ef-a9d5445d1537)
