### PR TITLE
Update BSH dependency of recoder

### DIFF
--- a/recoder/build.gradle
+++ b/recoder/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'org.ow2.asm:asm:9.5'
-    implementation 'org.beanshell:bsh:1.3.0'
+    implementation 'org.beanshell:bsh:2.0b5'
     implementation 'net.sf.retrotranslator:retrotranslator-runtime:1.2.9'
     implementation 'net.sf.retrotranslator:retrotranslator-transformer:1.2.9'
 


### PR DESCRIPTION
One-liner fix: Update beanshell version in recoder's dependencies. 
The previous dependency version has a CVE.