### PR TITLE
Optime OSS replaceKnown and cycle check

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Statistics.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Statistics.java
@@ -179,6 +179,10 @@ public class Statistics {
         summaryList.add(new Pair<>("Merge Rule apps", String.valueOf(stat.mergeRuleApps)));
         summaryList.add(new Pair<>("Total rule apps",
             EnhancedStringBuffer.format(stat.totalRuleApps).toString()));
+        if (stat.totalRuleApps > 0) {
+            String avgTime = String.valueOf((time * 1000) / stat.totalRuleApps);
+            summaryList.add(new Pair<>("Avg. time per app", avgTime + "μs"));
+        }
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
@@ -4,10 +4,12 @@
 package de.uka.ilkd.key.rule;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -478,13 +480,15 @@ public final class OneStepSimplifier implements BuiltInRule {
         final List<PosInOccurrence> ifInsts = new ArrayList<>(seq.size());
 
         // simplify as long as possible
-        ImmutableList<SequentFormula> list = ImmutableSLList.nil();
+        Set<SequentFormula> list = new HashSet<>();
         SequentFormula simplifiedCf = cf;
+        SequentFormula lastCf = null;
         while (true) {
             simplifiedCf = simplifyConstrainedFormula(services, simplifiedCf, ossPIO.isInAntec(),
                 context, ifInsts, protocol, goal, ruleApp);
             if (simplifiedCf != null && !list.contains(simplifiedCf)) {
-                list = list.prepend(simplifiedCf);
+                list.add(simplifiedCf);
+                lastCf = simplifiedCf;
             } else {
                 break;
             }
@@ -494,7 +498,7 @@ public final class OneStepSimplifier implements BuiltInRule {
         PosInOccurrence[] ifInstsArr = ifInsts.toArray(new PosInOccurrence[0]);
         ImmutableList<PosInOccurrence> immutableIfInsts =
             ImmutableSLList.<PosInOccurrence>nil().append(ifInstsArr);
-        return new Instantiation(list.head(), list.size(), immutableIfInsts);
+        return new Instantiation(lastCf, list.size(), immutableIfInsts);
     }
 
 
@@ -737,8 +741,8 @@ public final class OneStepSimplifier implements BuiltInRule {
          */
         @Override
         public int hashCode() {
-            return term.op().hashCode(); // Allow more conflicts to ensure that naming and term
-                                         // labels are ignored.
+            // intentionally generate hash collisions to ensure equalsModRenaming is used
+            return Objects.hash(term.op(), term.depth());
         }
 
         /**


### PR DESCRIPTION
See #3248.

I only checked a small benchmark where these changes lead to a small reduction in average time per app: 2502μs (new) vs. 2547μs (old). Have to check on a larger proof later.