### PR TITLE
Misc. UI fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,16 +32,6 @@ idea {
     }
 }
 
-// Helper function that calls "git rev-parse" to
-// find names/SHAs for commits
-static def gitRevParse(String args) {
-    try {
-        return "git rev-parse $args".execute().text.trim()
-    } catch (Exception e) {
-        return ""
-    }
-}
-
 static def getDate() {
     return new Date().format('yyyyMMdd')
 }

--- a/key.core/build.gradle
+++ b/key.core/build.gradle
@@ -172,6 +172,7 @@ task generateVersionFiles() {
     def branch = new File(outputFolder, "branch")
     def versionf = new File(outputFolder, "version")
 
+    inputs.files "$project.rootDir/.git/HEAD"
     outputs.files sha1, branch, versionf
 
     def gitRevision = gitRevParse('HEAD')
@@ -181,6 +182,16 @@ task generateVersionFiles() {
         sha1.text = gitRevision
         branch.text = gitBranch
         versionf.text = rootProject.version
+    }
+}
+
+// Helper function that calls "git rev-parse" to
+// find names/SHAs for commits
+static def gitRevParse(String args) {
+    try {
+        return "git rev-parse $args".execute().text.trim()
+    } catch (Exception e) {
+        return ""
     }
 }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/KeYEnvironment.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/KeYEnvironment.java
@@ -28,7 +28,7 @@ import de.uka.ilkd.key.util.Pair;
  *
  * @author Martin Hentschel
  */
-public class KeYEnvironment<U extends UserInterfaceControl> {
+public class KeYEnvironment<U extends UserInterfaceControl> implements AutoCloseable {
     /**
      * The {@link UserInterfaceControl} in which the {@link Proof} is loaded.
      */
@@ -319,4 +319,8 @@ public class KeYEnvironment<U extends UserInterfaceControl> {
         return proofScript;
     }
 
+    @Override
+    public void close() {
+        dispose();
+    }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/control/KeYEnvironment.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/KeYEnvironment.java
@@ -28,7 +28,7 @@ import de.uka.ilkd.key.util.Pair;
  *
  * @author Martin Hentschel
  */
-public class KeYEnvironment<U extends UserInterfaceControl> implements AutoCloseable {
+public class KeYEnvironment<U extends UserInterfaceControl> {
     /**
      * The {@link UserInterfaceControl} in which the {@link Proof} is loaded.
      */
@@ -317,10 +317,5 @@ public class KeYEnvironment<U extends UserInterfaceControl> implements AutoClose
 
     public Pair<String, Location> getProofScript() {
         return proofScript;
-    }
-
-    @Override
-    public void close() {
-        dispose();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -14,6 +14,7 @@ import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.proof.init.Profile;
 import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.Debug;
 import de.uka.ilkd.key.util.KeYRecoderExcHandler;
 
@@ -298,6 +299,10 @@ public class Services implements TermServices {
                 "Services are already owned by another proof:" + proof.name());
         }
         proof = p_proof;
+        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()
+                || !proof.getSettings().getTermLabelSettings().getUseOriginLabels()) {
+            profile.getTermLabelManager().disableOriginLabelRefactorings();
+        }
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.DefaultVisitor;
@@ -32,6 +33,7 @@ import de.uka.ilkd.key.proof.init.Profile;
 import de.uka.ilkd.key.rule.Rule;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.label.ChildTermLabelPolicy;
+import de.uka.ilkd.key.rule.label.OriginTermLabelRefactoring;
 import de.uka.ilkd.key.rule.label.TermLabelMerger;
 import de.uka.ilkd.key.rule.label.TermLabelPolicy;
 import de.uka.ilkd.key.rule.label.TermLabelRefactoring;
@@ -2259,5 +2261,15 @@ public class TermLabelManager {
                 }
             }
         }
+    }
+
+    /**
+     * Fully disable origin tracking. This will remove the {@link OriginTermLabelRefactoring} from
+     * the manager.
+     */
+    public void disableOriginLabelRefactorings() {
+        allRulesRefactorings = ImmutableList.fromList(
+            allRulesRefactorings.stream().filter(x -> !(x instanceof OriginTermLabelRefactoring))
+                    .collect(Collectors.toList()));
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
@@ -4,9 +4,11 @@
 package de.uka.ilkd.key.macros;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.Statistics;
 import de.uka.ilkd.key.prover.impl.ApplyStrategyInfo;
@@ -68,6 +70,12 @@ public class ProofMacroFinishedInfo extends DefaultTaskFinishedInfo {
 
     public ProofMacroFinishedInfo(ProofMacro macro, ImmutableList<Goal> goals) {
         this(macro, goals, goals.isEmpty() ? null : goals.head().proof(), false);
+    }
+
+    public ProofMacroFinishedInfo(ProofMacro macro, ImmutableList<Goal> goals,
+            List<Node> statisticNodes) {
+        this(macro, goals, goals.isEmpty() ? null : goals.head().proof(),
+            statisticNodes.isEmpty() ? null : new Statistics(statisticNodes));
     }
 
     public ProofMacroFinishedInfo(ProofMacro macro, Proof proof) {

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/StrategyProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/StrategyProofMacro.java
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.macros;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import de.uka.ilkd.key.control.UserInterfaceControl;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.prover.GoalChooser;
 import de.uka.ilkd.key.prover.ProverCore;
@@ -72,6 +76,7 @@ public abstract class StrategyProofMacro extends AbstractProofMacro {
             // false
             return null;
         }
+        List<Node> nodes = goals.stream().map(Goal::node).collect(Collectors.toList());
 
         final GoalChooser goalChooser =
             proof.getInitConfig().getProfile().getSelectedGoalChooserBuilder().create();
@@ -84,9 +89,9 @@ public abstract class StrategyProofMacro extends AbstractProofMacro {
             new ProgressBarListener(goals.size(), getMaxSteps(proof), listener);
         applyStrategy.addProverTaskObserver(pml);
         // add a focus manager if there is a focus
-        if (posInOcc != null && goals != null) {
-            AutomatedRuleApplicationManager realManager = null;
-            FocussedRuleApplicationManager manager = null;
+        if (posInOcc != null) {
+            AutomatedRuleApplicationManager realManager;
+            FocussedRuleApplicationManager manager;
             for (Goal goal : goals) {
                 realManager = goal.getRuleAppManager();
                 realManager.clearCache();
@@ -99,7 +104,7 @@ public abstract class StrategyProofMacro extends AbstractProofMacro {
         Strategy oldStrategy = proof.getActiveStrategy();
         proof.setActiveStrategy(createStrategy(proof, posInOcc));
 
-        ProofMacroFinishedInfo info = new ProofMacroFinishedInfo(this, goals, proof, false);
+        ProofMacroFinishedInfo info;
         try {
             // find the relevant goals
             // and start
@@ -125,7 +130,8 @@ public abstract class StrategyProofMacro extends AbstractProofMacro {
             }
             final ImmutableList<Goal> resultingGoals =
                 setDifference(proof.openGoals(), ignoredOpenGoals);
-            info = new ProofMacroFinishedInfo(this, resultingGoals);
+            info = new ProofMacroFinishedInfo(this, resultingGoals,
+                nodes);
             proof.setActiveStrategy(oldStrategy);
             doPostProcessing(proof);
             applyStrategy.removeProverTaskObserver(pml);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Statistics.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Statistics.java
@@ -73,6 +73,78 @@ public class Statistics {
         this.timePerStepInMillis = timePerStepInMillis;
     }
 
+    public Statistics(List<Node> startNodes) {
+        if (startNodes.isEmpty()) {
+            throw new IllegalArgumentException("can't generate statistics on zero nodes");
+        }
+
+        int nodes = 0;
+        int branches = 0;
+        int cachedBranches = 0;
+        int interactiveSteps = 0;
+        int symbExApps = 0;
+        int quantifierInstantiations = 0;
+        int ossApps = 0;
+        int mergeRuleApps = 0;
+        int totalRuleApps = 0;
+        int smtSolverApps = 0;
+        int dependencyContractApps = 0;
+        int operationContractApps = 0;
+        int blockLoopContractApps = 0;
+        int loopInvApps = 0;
+        long autoModeTimeInMillis = 0;
+        long timeInMillis = 0;
+
+        for (Node startNode : startNodes) {
+            final Iterator<Node> it = startNode.subtreeIterator();
+
+            TemporaryStatistics tmp = new TemporaryStatistics();
+
+            Node node;
+            while (it.hasNext()) {
+                node = it.next();
+                tmp.changeOnNode(node, interactiveAppsDetails);
+            }
+
+            nodes += tmp.nodes;
+            branches = tmp.branches;
+            cachedBranches = tmp.cachedBranches;
+            interactiveSteps = tmp.interactive;
+            symbExApps = tmp.symbExApps;
+            quantifierInstantiations = tmp.quant;
+            ossApps = tmp.oss;
+            mergeRuleApps = tmp.mergeApps;
+            totalRuleApps = tmp.nodes + tmp.ossCaptured - 1;
+            smtSolverApps = tmp.smt;
+            dependencyContractApps = tmp.dep;
+            operationContractApps = tmp.contr;
+            blockLoopContractApps = tmp.block;
+            loopInvApps = tmp.inv;
+            autoModeTimeInMillis = startNode.proof().getAutoModeTime();
+            timeInMillis = (System.currentTimeMillis() - startNode.proof().creationTime);
+        }
+
+        this.nodes = nodes;
+        this.branches = branches;
+        this.cachedBranches = cachedBranches;
+        this.interactiveSteps = interactiveSteps;
+        this.symbExApps = symbExApps;
+        this.quantifierInstantiations = quantifierInstantiations;
+        this.ossApps = ossApps;
+        this.mergeRuleApps = mergeRuleApps;
+        this.totalRuleApps = totalRuleApps;
+        this.smtSolverApps = smtSolverApps;
+        this.dependencyContractApps = dependencyContractApps;
+        this.operationContractApps = operationContractApps;
+        this.blockLoopContractApps = blockLoopContractApps;
+        this.loopInvApps = loopInvApps;
+        this.autoModeTimeInMillis = autoModeTimeInMillis;
+        this.timeInMillis = timeInMillis;
+        this.timePerStepInMillis = nodes <= 1 ? .0f : (autoModeTimeInMillis / (float) (nodes - 1));
+
+        generateSummary(startNodes.get(0).proof());
+    }
+
     Statistics(Node startNode) {
         final Iterator<Node> it = startNode.subtreeIterator();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/reference/ReferenceSearcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/reference/ReferenceSearcher.java
@@ -92,7 +92,7 @@ public final class ReferenceSearcher {
                 // for each node, check that the sequent in the reference is
                 // a subset of the new sequent
                 Node n = nodesToCheck.remove();
-                if (checkedNodes.contains(n)) {
+                if (checkedNodes.contains(n) || !n.isClosed()) {
                     continue;
                 }
                 checkedNodes.add(n);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/ExternalProcessLauncher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/ExternalProcessLauncher.java
@@ -76,7 +76,9 @@ public class ExternalProcessLauncher {
      */
     public void stop() {
         if (process != null) {
-            process.destroy();
+            // make sure the solver process is properly killed,
+            // otherwise it may consume excessive CPU and RAM
+            process.destroyForcibly();
         }
         // TODO: where to close the pipe?
         // pipe.close();

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlChecks.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlChecks.java
@@ -81,7 +81,7 @@ class JmlWarnDifferentRequiresSemantics extends AbstractCheck implements JmlChec
 
             if (isRequiresClause(clause) && otherClause) {
                 addWarning(clause,
-                    "Diverging Semantics form JML Reference: Requires does not initiate a new contract. "
+                    "Diverging Semantics from JML Reference: Requires does not initiate a new contract. "
                         + "See https://keyproject.github.io/key-docs/user/JMLGrammar/#TODO");
             }
         }

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestOneStepSimplifier.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestOneStepSimplifier.java
@@ -23,9 +23,10 @@ public class TestOneStepSimplifier {
         // file to instantiate assumptions
         // (if more rules are added to the OSS set, this restriction may increase the chances that
         // old proofs still load)
-        KeYEnvironment<DefaultUserInterfaceControl> env =
-            KeYEnvironment.load(new File(testCaseDirectory, "ossRestriction.proof"));
-        Assertions.assertNotNull(env.getLoadedProof());
-        Assertions.assertTrue(env.getLoadedProof().closed());
+        try (KeYEnvironment<DefaultUserInterfaceControl> env =
+            KeYEnvironment.load(new File(testCaseDirectory, "ossRestriction.proof"))) {
+            Assertions.assertNotNull(env.getLoadedProof());
+            Assertions.assertTrue(env.getLoadedProof().closed());
+        }
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestOneStepSimplifier.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestOneStepSimplifier.java
@@ -23,10 +23,10 @@ public class TestOneStepSimplifier {
         // file to instantiate assumptions
         // (if more rules are added to the OSS set, this restriction may increase the chances that
         // old proofs still load)
-        try (KeYEnvironment<DefaultUserInterfaceControl> env =
-            KeYEnvironment.load(new File(testCaseDirectory, "ossRestriction.proof"))) {
-            Assertions.assertNotNull(env.getLoadedProof());
-            Assertions.assertTrue(env.getLoadedProof().closed());
-        }
+        KeYEnvironment<DefaultUserInterfaceControl> env =
+            KeYEnvironment.load(new File(testCaseDirectory, "ossRestriction.proof"));
+        Assertions.assertNotNull(env.getLoadedProof());
+        Assertions.assertTrue(env.getLoadedProof().closed());
+        env.dispose();
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/replay/TestCopyingReplayer.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/replay/TestCopyingReplayer.java
@@ -51,5 +51,8 @@ class TestCopyingReplayer {
         Assertions.assertEquals(proof1.countNodes(), proof2.countNodes());
 
         GeneralSettings.noPruningClosed = true;
+
+        env.dispose();
+        env2.dispose();
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.speclang.njml;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 
 import de.uka.ilkd.key.java.JavaInfo;
 import de.uka.ilkd.key.java.Position;
@@ -79,7 +80,7 @@ public class NJmlTranslatorTests {
     // }
 
     @Test
-    public void testWarnRequires() throws URISyntaxException {
+    void testWarnRequires() throws URISyntaxException {
         preParser.clearWarnings();
         String contract = "/*@ requires true; ensures true; requires true;";
         ImmutableList<TextualJMLConstruct> result =
@@ -88,8 +89,9 @@ public class NJmlTranslatorTests {
         ImmutableList<PositionedString> warnings = preParser.getWarnings();
         PositionedString message = warnings.head();
         assertEquals(
-            "Diverging Semantics form JML Reference: Requires does not initiate a new contract. "
-                + "See https://keyproject.github.io/key-docs/user/JMLGrammar/#TODO (Test.java, 5/38)",
+            "Diverging Semantics from JML Reference: Requires does not initiate a new contract. "
+                + "See https://keyproject.github.io/key-docs/user/JMLGrammar/#TODO ("
+                + Path.of("Test.java").toUri() + ", 5/38)",
             message.toString());
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/util/TestEqualsModProofIrrelevancy.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/TestEqualsModProofIrrelevancy.java
@@ -57,5 +57,7 @@ class TestEqualsModProofIrrelevancy {
                     node1.getAppliedRuleApp().equalsModProofIrrelevancy(node2.getAppliedRuleApp()));
             }
         }
+        env.dispose();
+        env2.dispose();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
@@ -16,6 +16,7 @@ import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.control.ProofControl;
 import de.uka.ilkd.key.gui.GUIListener;
 import de.uka.ilkd.key.gui.InspectorForDecisionPredicates;
+import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.UserActionListener;
 import de.uka.ilkd.key.gui.actions.useractions.UserAction;
 import de.uka.ilkd.key.gui.notification.events.ExceptionFailureEvent;
@@ -566,6 +567,7 @@ public class KeYMediator {
      * @param b true iff interactive mode is to be turned on
      */
     public void setInteractive(boolean b) {
+        MainWindow.getInstance().getAutoModeAction().setEnabled(true);
         if (getSelectedProof() != null) {
             if (b) {
                 getSelectedProof().setRuleAppIndexToInteractiveMode();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -776,6 +776,14 @@ public final class MainWindow extends JFrame {
         ThreadUtilities.invokeOnEventQueue(this::setStandardStatusLineImmediately);
     }
 
+    /**
+     * Hide the progress bar if it is currently visible.
+     */
+    public void hideStatusProgress() {
+        getStatusLine().setProgress(0);
+        statusLine.setProgressPanelVisible(false);
+    }
+
     private void setStatusLineImmediately(String str, int max) {
         // statusLine.reset();
         statusLine.setStatusText(str);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
@@ -182,7 +182,7 @@ public class WindowUserInterfaceControl extends AbstractMediatorUserInterfaceCon
             mainWindow.displayResults(info.toString());
         } else if (info != null && info.getSource() instanceof ProofMacro) {
             if (!isAtLeastOneMacroRunning()) {
-                resetStatus(this);
+                mainWindow.hideStatusProgress();
                 assert info instanceof ProofMacroFinishedInfo;
                 Proof proof = info.getProof();
                 if (proof != null && !proof.closed()

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoModeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoModeAction.java
@@ -168,6 +168,7 @@ public final class AutoModeAction extends MainWindowAction {
             // This method delegates the request only to the UserInterfaceControl which implements
             // the functionality.
             // No functionality is allowed in this method body!
+            setEnabled(false);
             getMediator().getUI().getProofControl().stopAutoMode();
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -147,9 +147,15 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
      * This can be used to pause tree updates when many goals get their state changed at once. The
      * tree is updated automatically after this is set to false.
      */
-    public void setBatchGoalStateChange(boolean value) {
+    public void setBatchGoalStateChange(boolean value, Collection<Node> nodesToUpdate) {
         if (!value && batchGoalStateChange) {
-            updateTree((TreeNode) null);
+            if (nodesToUpdate == null || nodesToUpdate.isEmpty()) {
+                updateTree((TreeNode) null);
+            } else {
+                for (Node n : nodesToUpdate) {
+                    updateTree(n);
+                }
+            }
         }
         batchGoalStateChange = value;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -4,7 +4,9 @@
 package de.uka.ilkd.key.gui.prooftree;
 
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Predicate;
 import javax.swing.*;
 import javax.swing.tree.TreeNode;
@@ -471,17 +473,23 @@ public class ProofTreePopupFactory {
             return context.proof.getSubtreeGoals(context.invokedNode);
         }
 
-        /*
+        /**
          * In addition to marking setting goals, update the tree model so that the label sizes are
          * recalculated
          */
         @Override
         public void actionPerformed(ActionEvent e) {
-            context.delegateModel.setBatchGoalStateChange(true);
+            var selectedNode = context.proofTreeView.getSelectedNode();
+            context.delegateModel.setBatchGoalStateChange(true, null);
             super.actionPerformed(e);
-            context.delegateModel.setBatchGoalStateChange(false);
-            // trigger repainting the tree after the completion of this event.
-            context.delegateView.repaint();
+            List<Node> goals = new ArrayList<>();
+            getGoalList().forEach(x -> goals.add(x.node()));
+            context.delegateModel.setBatchGoalStateChange(false, goals);
+            // make sure the node is selected again
+            if (selectedNode != null) {
+                context.proofTreeView.makeNodeVisible(selectedNode);
+            }
+            // repainting the tree after the completion of this event is done automatically
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1317,4 +1317,15 @@ public class ProofTreeView extends JPanel implements TabPanel {
             return this;
         }
     }
+
+    public Node getSelectedNode() {
+        TreePath sp = delegateView.getSelectionPath();
+        if (sp == null) {
+            return null;
+        }
+        Object treeNode = sp.getLastPathComponent();
+        return (treeNode instanceof GUIAbstractTreeNode)
+                ? ((GUIAbstractTreeNode) treeNode).getNode()
+                : null;
+    }
 }

--- a/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
@@ -45,6 +45,7 @@ import org.key_project.slicing.graph.AnnotatedEdge;
 import org.key_project.slicing.graph.ClosedGoal;
 import org.key_project.slicing.graph.DependencyGraph;
 import org.key_project.slicing.graph.GraphNode;
+import org.key_project.slicing.graph.PseudoOutput;
 import org.key_project.slicing.graph.TrackedFormula;
 import org.key_project.slicing.util.ExecutionTime;
 import org.key_project.util.EqualsModProofIrrelevancyWrapper;
@@ -385,7 +386,14 @@ public final class DependencyAnalyzer {
             Map<BranchLocation, Collection<GraphNode>> groupedOutputs = new HashMap<>();
             node.childrenIterator().forEachRemaining(
                 x -> groupedOutputs.put(x.getBranchLocation(), new ArrayList<>()));
-            data.outputs.forEach(n -> groupedOutputs.get(n.getBranchLocation()).add(n));
+            data.outputs.forEach(n -> {
+                if (n instanceof PseudoOutput) {
+                    // cut did not any new formulas
+                    // (always leads to cutWasUseful = false)
+                    return;
+                }
+                groupedOutputs.get(n.getBranchLocation()).add(n);
+            });
             boolean cutWasUseful = groupedOutputs.values().stream()
                     .allMatch(l -> l.stream().anyMatch(usefulFormulas::contains));
             if (cutWasUseful) {


### PR DESCRIPTION
Changes:
- SMT solvers are properly terminated on timeout
- Proof Macro statistics are kept visible and only count the newly applied rules
- Stop button is disabled after use, re-enabled after stop completes (this is to avoid double activation)
- Bugfix: fully disable origin tracking if it is disabled
- Bugfix: proof slicing works even if a cut introduced no new formulas in any branch
- Bugfix: detection of active git branch always refreshes correctly
- Bugfix: when marking goal(s) as interactive/automatic, proof tree no longer loses expansion state