### PR TITLE
Automatically abbreviate anon heap names

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractLoopInvariantRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractLoopInvariantRule.java
@@ -38,6 +38,10 @@ import org.key_project.util.collection.ImmutableSet;
  * @author Dominic Scheurer
  */
 public abstract class AbstractLoopInvariantRule implements BuiltInRule {
+    /**
+     * The suffix given to anon heap names created because of loops.
+     */
+    public static final String ANON_HEAP_NAME_SUFFIX = "LOOP";
 
     /**
      * The last formula the loop invariant rule was applied to. Used for checking whether
@@ -416,13 +420,12 @@ public abstract class AbstractLoopInvariantRule implements BuiltInRule {
      *
      * @param heap The original heap {@link LocationVariable}.
      * @param mod The modifiers term.
-     * @param inv The loop invariant.
      * @param services The {@link Services} object.
      * @return An {@link AnonUpdateData} object encapsulating the anonymizing update, the loop heap,
      *         the base heap, and the anonymized heap.
      */
     protected static AnonUpdateData createAnonUpdate(LocationVariable heap, Term mod,
-            LoopSpecification inv, Services services) {
+            Services services) {
         final TermBuilder tb = services.getTermBuilder();
         final HeapLDT heapLDT = services.getTypeConverter().getHeapLDT();
         final Name loopHeapName = new Name(tb.newName(heap + "_After_LOOP"));
@@ -430,7 +433,8 @@ public abstract class AbstractLoopInvariantRule implements BuiltInRule {
         services.getNamespaces().functions().addSafely(loopHeapFunc);
 
         final Term loopHeap = tb.func(loopHeapFunc);
-        final Name anonHeapName = new Name(tb.newName("anon_" + heap + "_LOOP"));
+        final Name anonHeapName =
+            new Name(tb.newName("anon_" + heap + "_" + ANON_HEAP_NAME_SUFFIX));
         final Function anonHeapFunc = new Function(anonHeapName, heap.sort());
         services.getNamespaces().functions().addSafely(anonHeapFunc);
         final Term anonHeapTerm =
@@ -491,7 +495,7 @@ public abstract class AbstractLoopInvariantRule implements BuiltInRule {
             // weigl: prevent NPE
             Term modifiesTerm = mods.get(heap);
             modifiesTerm = modifiesTerm == null ? tb.strictlyNothing() : modifiesTerm;
-            final AnonUpdateData tAnon = createAnonUpdate(heap, modifiesTerm, inst.inv, services);
+            final AnonUpdateData tAnon = createAnonUpdate(heap, modifiesTerm, services);
             anonUpdateData = anonUpdateData.append(tAnon);
 
             anonUpdate = tb.parallel(anonUpdate, tAnon.anonUpdate);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/AbbreviatingVisitor.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/AbbreviatingVisitor.java
@@ -1,0 +1,80 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.nodeviews;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.logic.Visitor;
+import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.pp.AbbrevException;
+import de.uka.ilkd.key.pp.AbbrevMap;
+import de.uka.ilkd.key.rule.AbstractLoopInvariantRule;
+
+import static de.uka.ilkd.key.logic.label.ParameterlessTermLabel.ANON_HEAP_LABEL;
+
+/**
+ * Visitor that will automatically abbreviate any anon heaps associated with loops.
+ *
+ * @author Arne Keller
+ */
+public class AbbreviatingVisitor implements Visitor {
+    /**
+     * The anon function from the heap LDT.
+     */
+    private final Function anon;
+    /**
+     * Abbreviation map of the visited proof.
+     */
+    private final AbbrevMap abbrevMap;
+
+    /**
+     * Construct new abbreviating visitor.
+     *
+     * @param services services of a proof
+     */
+    public AbbreviatingVisitor(Services services) {
+        anon = services.getTypeConverter().getHeapLDT().getAnon();
+        abbrevMap = services.getProof().abbreviations();
+    }
+
+    @Override
+    public boolean visitSubtree(Term visited) {
+        return true;
+    }
+
+    @Override
+    public void visit(Term visited) {
+        if (visited.op() == anon && visited.subs().size() == 3) {
+            TermLabel label = visited.sub(2).getLabel(ANON_HEAP_LABEL.name());
+            if (label == null) {
+                return;
+            }
+            var parts = visited.sub(2).op().name().toString().split("_");
+            if (parts.length >= 2 && parts[parts.length - 2]
+                    .equals(AbstractLoopInvariantRule.ANON_HEAP_NAME_SUFFIX)) {
+                int number = Integer.parseInt(parts[parts.length - 1]);
+                String key = "heap_loop_" + number;
+                if (!abbrevMap.containsAbbreviation(key) && !abbrevMap.containsTerm(visited)) {
+                    try {
+                        abbrevMap.put(visited, key, true);
+                    } catch (AbbrevException e) {
+                        // unreachable, as we just checked this above
+                        throw new IllegalStateException("AbbrevMap concurrently modified!");
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void subtreeEntered(Term subtreeRoot) {
+
+    }
+
+    @Override
+    public void subtreeLeft(Term subtreeRoot) {
+
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
@@ -940,8 +940,16 @@ public abstract class SequentView extends JEditorPane {
 
     protected void updateSequent(Node node) {
         var start = System.nanoTime();
-        getLogicPrinter().update(getFilter(), getLineWidth());
-        String printed = getLogicPrinter().result();
+
+        // auto-abbreviate heaps
+        if (node != null) {
+            for (var sf : node.sequent().asList()) {
+                sf.formula().execPreOrder(new AbbreviatingVisitor(node.proof().getServices()));
+            }
+        }
+
+        printer.update(filter, getLineWidth());
+        String printed = printer.result();
         boolean html =
             ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUseSyntaxHighlighting();
         var args = new HTMLSyntaxHighlighter.Args(node, printed, html);
@@ -950,10 +958,9 @@ public abstract class SequentView extends JEditorPane {
         var highlight = System.nanoTime();
         setTextCache.get(highlighted);
         var setText = System.nanoTime();
-        LOGGER.trace("updateSequent " + (node != null ? node.serialNr() : -1) + ": print "
-            + (print - start) / 1e6
-            + "ms, highlight " + (highlight - print) / 1e6 + "ms, setText "
-            + (setText - highlight) / 1e6 + "ms");
+        LOGGER.trace("updateSequent {}: print {}ms, highlight {}ms, setText {}ms",
+            node != null ? node.serialNr() : -1, (print - start) / 1e6, (highlight - print) / 1e6,
+            (setText - highlight) / 1e6);
     }
 
     public void setFilter(SequentPrintFilter sequentPrintFilter, boolean forceUpdate) {


### PR DESCRIPTION
By automatically abbreviating heap names, it is much easier to navigate and inspect the sequent view. The screenshots below show the same proof node. **Discussion points**: Should this option be automatically enabled? Is the naming scheme (`heap_loop_X`) fine?

| Previously (300k characters) | Now (35k characters, 8.5x shorter!) |
:-------------------------:|:-------------------------:
![Screenshot_20230901_163156](https://github.com/KeYProject/key/assets/12560461/3247bb9b-3920-4116-9b1b-d6a5ce7afffc) | ![Screenshot_20230901_163057](https://github.com/KeYProject/key/assets/12560461/2fc2061e-a278-4d6c-9dae-6193cc6a5397)

Heap names after method calls don't need to be abbreviated, they are already just referred to by "heapAfter_commonEntry" or similar.

This PR builds on top of #3251 and #3258. Only the last five commits in this branch are relevant.