### PR TITLE
Fix dependency issue in SMT translation

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
@@ -69,6 +69,8 @@ public class FieldConstantHandler implements SMTHandler {
         HeapLDT heapLDT = services.getTypeConverter().getHeapLDT();
         Operator op = term.op();
 
+        trans.addSort(((SortedOperator) op).sort());
+
         if (op == heapLDT.getArr()) {
             trans.introduceSymbol("arr");
             return trans.handleAsFunctionCall("arr", term);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
@@ -39,9 +38,6 @@ import de.uka.ilkd.key.smt.newsmt2.SMTHandler.Capability;
  * @author Jonas Schiffl
  */
 public class MasterHandler {
-
-    /** the services object associated with this particular translation */
-    private final Services services;
 
     /** Exceptions that occur during translation */
     private final List<Throwable> exceptions = new ArrayList<>();
@@ -86,9 +82,8 @@ public class MasterHandler {
      * @param handlerOptions arbitrary String options for the handlers to process
      * @throws IOException if the handlers cannot be loaded
      */
-    public MasterHandler(Services services, SMTSettings settings, @Nullable String[] handlerNames,
+    public MasterHandler(Services services, SMTSettings settings, String[] handlerNames,
             String[] handlerOptions) throws IOException {
-        this.services = services;
         getTranslationState().putAll(settings.getNewSettings().getMap());
         handlers = SMTHandlerServices.getInstance().getFreshHandlers(services, handlerNames,
             handlerOptions, this);
@@ -96,7 +91,7 @@ public class MasterHandler {
 
     /**
      * Copy toplevel declarations and axioms from a collection of snippets directly and make all
-     * named declarations (name.decl) and axioms (name.axioms)
+     * named declarations (name.decls), axioms (name.axioms) and deps (name.deps)
      *
      * @param snippets
      */
@@ -113,7 +108,7 @@ public class MasterHandler {
 
         for (Entry<Object, Object> en : snippets.entrySet()) {
             String key = (String) en.getKey();
-            if (key.endsWith(".decls") || key.endsWith(".axioms")) {
+            if (key.endsWith(".decls") || key.endsWith(".axioms") || key.endsWith(".deps")) {
                 translationState.put(key, en.getValue());
             }
         }

--- a/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
@@ -99,6 +99,8 @@ public class MasterHandlerTest {
                 }
             } catch (Exception e) {
                 LOGGER.error("Error reading {}", file, e);
+                // make sure faulty test cases fail
+                throw e;
             }
         }
         return result;

--- a/key.core/src/test/resources/de/uka/ilkd/key/smt/newsmt2/cases/heap2.props
+++ b/key.core/src/test/resources/de/uka/ilkd/key/smt/newsmt2/cases/heap2.props
@@ -1,0 +1,39 @@
+### Comment
+
+Related to issue #3267.
+
+### KeY
+
+\functions { int[][] n; long[] i_arr_2; int j_0; int a_0; int i_0; int start; }
+
+\problem {
+ (j_0 = a_0 &
+ a_0 >= 0 &
+ a_0 < n.length &
+ n[i_0][j_0] >= 0 &
+ i_arr_2[i_0] >= 1 &
+ i_0 < n.length &
+ i_0 >= 0 &
+ (\forall int i;
+   (   i < n.length & i >= 0
+    -> \forall int j; (j < n.length & j >= 0 -> (n[i][j] = 0 <-> j = i)))))
+->
+ !(n[i_0][j_0] = -1 &
+ j_0 = i_0 &
+   (!n[i_0][a_0] = -1
+ & (   !a_0 = start
+    -> i_arr_2[i_0] < i_arr_2[i_0] + n[i_0][j_0])
+ & !i_arr_2[i_0] + n[i_0][j_0] = -1))
+}
+
+### contains.1
+
+(declare-const sort_Field T)
+
+### contains.2
+
+(declare-fun fieldIdentifier (U) Int)
+
+### expected
+
+valid


### PR DESCRIPTION
Previously the fieldIdentifier symbol might never be introduced, leading to an exception when trying to run the SMT solver.

Fixes #3267