### PR TITLE
Update to Java 21 Runtime for Testing

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '21'
           cache: 'gradle'
       - name: Build with Gradle
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '21'
           cache: 'gradle'
 
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '21'
           cache: 'gradle'
       - name: Build with Gradle

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:
@@ -62,6 +63,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:
@@ -88,6 +91,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
+        cache: 'gradle'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
 
     - name: Assemble with Gradle

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '21'
-        distribution: 'temurin'
+        distribution: 'corretto'
         cache: 'gradle'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
 

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build with Gradle

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -12,10 +12,10 @@ jobs:
       - run: ls -ld
       - run: ls -lh 'gradle'
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build with Gradle

--- a/.github/workflows/opttest.yml
+++ b/.github/workflows/opttest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java}}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build with Gradle

--- a/.github/workflows/opttest.yml
+++ b/.github/workflows/opttest.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [17]
+        java: [21]
         tests: [":key.core.proof_references:test", ":key.core.symbolic_execution:test"]
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/opttest.yml
+++ b/.github/workflows/opttest.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           java-version: ${{matrix.java}}
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build with Gradle
@@ -89,7 +89,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Cache SMT-Solvers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [17]
+        java: [21]
     continue-on-error: true
     runs-on: ${{ matrix.os }}
     env:
@@ -46,7 +46,7 @@ jobs:
           name: pr-number
           path: pr/
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
@@ -80,11 +80,11 @@ jobs:
       matrix:
         test: [testProveRules, testRunAllFunProofs, testRunAllInfProofs]
         os: [ubuntu-latest]
-        java: [17]
+        java: [21]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
@@ -89,6 +90,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Cache SMT-Solvers
         id: smt-solvers

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        java: [17]
+        java: [17,21]
     continue-on-error: true
     runs-on: ${{ matrix.os }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK ${{matrix.java}}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
@@ -52,11 +52,11 @@ jobs:
       matrix:
         test: [testProveRules, testRunAllFunProofs, testRunAllInfProofs]
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        java: [17]
+        java: [21]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
@@ -61,6 +62,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Cache SMT-Solvers
         id: smt-solvers

--- a/.github/workflows/tests_winmac.yml
+++ b/.github/workflows/tests_winmac.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build with Gradle
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Cache SMT-Solvers

--- a/.github/workflows/update_symbex_oracles.yml
+++ b/.github/workflows/update_symbex_oracles.yml
@@ -17,10 +17,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build with Gradle

--- a/.github/workflows/update_symbex_oracles.yml
+++ b/.github/workflows/update_symbex_oracles.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build with Gradle

--- a/.github/workflows/update_symbex_oracles.yml
+++ b/.github/workflows/update_symbex_oracles.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
This PR enables the newest LTS version of Java in Githubs CI. 

:warning: This does not increase the `--release` or language level for KeY. New features are not enabled. 

:exclamation: Java 21 still not available for Github Actions. 