### PR TITLE
Problem statements in KeY file can now also be a (semi-)sequent

### DIFF
--- a/key.core/src/main/antlr4/KeYParser.g4
+++ b/key.core/src/main/antlr4/KeYParser.g4
@@ -36,7 +36,7 @@ decls
 
 problem
 :
-  ( PROBLEM LBRACE a=term RBRACE
+  ( PROBLEM LBRACE ( t=termorseq ) RBRACE
   | CHOOSECONTRACT (chooseContract=string_value SEMI)?
   | PROOFOBLIGATION  (proofObligation=string_value SEMI)?
   )

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
@@ -18,7 +18,7 @@ import de.uka.ilkd.key.nparser.ParsingFacade;
  * @author weigl
  */
 public class ProblemFinder extends ExpressionBuilder {
-    private @Nullable Sequent problemTerm;
+    private @Nullable Sequent problem;
     private @Nullable String chooseContract;
     private @Nullable String proofObligation;
 
@@ -58,7 +58,7 @@ public class ProblemFinder extends ExpressionBuilder {
             }
         }
         if (ctx.PROBLEM() != null) {
-            problemTerm = accept(ctx.termorseq());
+            problem = accept(ctx.termorseq());
         }
         return null;
     }
@@ -84,7 +84,7 @@ public class ProblemFinder extends ExpressionBuilder {
     }
 
     @Nullable
-    public Sequent getProblemTerm() {
-        return problemTerm;
+    public Sequent getProblem() {
+        return problem;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
@@ -69,7 +69,7 @@ public class ProblemFinder extends ExpressionBuilder {
         if (obj instanceof Sequent s)
             return s;
         if (obj instanceof Term t)
-            return Sequent.createAnteSequent(new Semisequent(new SequentFormula(t)));
+            return Sequent.createSuccSequent(new Semisequent(new SequentFormula(t)));
         return null;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
@@ -7,8 +7,7 @@ import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
-import de.uka.ilkd.key.logic.NamespaceSet;
-import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.nparser.KeYParser;
 import de.uka.ilkd.key.nparser.ParsingFacade;
 
@@ -19,7 +18,7 @@ import de.uka.ilkd.key.nparser.ParsingFacade;
  * @author weigl
  */
 public class ProblemFinder extends ExpressionBuilder {
-    private @Nullable Term problemTerm;
+    private @Nullable Sequent problemTerm;
     private @Nullable String chooseContract;
     private @Nullable String proofObligation;
 
@@ -59,8 +58,18 @@ public class ProblemFinder extends ExpressionBuilder {
             }
         }
         if (ctx.PROBLEM() != null) {
-            problemTerm = accept(ctx.term());
+            problemTerm = accept(ctx.termorseq());
         }
+        return null;
+    }
+
+    @Override
+    public Sequent visitTermorseq(KeYParser.TermorseqContext ctx) {
+        var obj = super.visitTermorseq(ctx);
+        if (obj instanceof Sequent s)
+            return s;
+        if (obj instanceof Term t)
+            return Sequent.createAnteSequent(new Semisequent(new SequentFormula(t)));
         return null;
     }
 
@@ -75,7 +84,7 @@ public class ProblemFinder extends ExpressionBuilder {
     }
 
     @Nullable
-    public Term getProblemTerm() {
+    public Sequent getProblemTerm() {
         return problemTerm;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -249,6 +249,14 @@ public class Proof implements Named {
         this.proofFile = proofFile;
     }
 
+    public Proof(String name, Sequent problem, String header, InitConfig initConfig,
+            File proofFile) {
+        this(name, problem, initConfig.createTacletIndex(), initConfig.createBuiltInRuleIndex(),
+            initConfig);
+        problemHeader = header;
+        this.proofFile = proofFile;
+    }
+
     public Proof(String name, Term problem, String header, InitConfig initConfig) {
         this(name,
             Sequent.createSuccSequent(

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -37,7 +37,7 @@ import org.antlr.v4.runtime.Token;
  * obligation.
  */
 public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
-    private Sequent problemTerm = null;
+    private Sequent problem = null;
 
     // -------------------------------------------------------------------------
     // constructors
@@ -133,8 +133,8 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
         readRules();
 
         try {
-            problemTerm = getProblemFinder().getProblemTerm();
-            if (problemTerm == null) {
+            problem = getProblemFinder().getProblem();
+            if (problem == null) {
                 boolean chooseDLContract = chooseContract() != null;
                 boolean proofObligation = getProofObligation() != null;
                 if (!chooseDLContract && !proofObligation) {
@@ -160,12 +160,12 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
 
     @Override
     public ProofAggregate getPO() throws ProofInputException {
-        assert problemTerm != null;
+        assert problem != null;
         String name = name();
         ProofSettings settings = getPreferences();
         initConfig.setSettings(settings);
         return ProofAggregate.createProofAggregate(
-            new Proof(name, problemTerm, getParseContext().getProblemHeader() + "\n", initConfig,
+            new Proof(name, problem, getParseContext().getProblemHeader() + "\n", initConfig,
                 file.file()),
             name);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -9,7 +9,7 @@ import java.net.URISyntaxException;
 import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
-import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.nparser.ChoiceInformation;
 import de.uka.ilkd.key.nparser.KeyAst;
 import de.uka.ilkd.key.nparser.ProblemInformation;
@@ -37,7 +37,7 @@ import org.antlr.v4.runtime.Token;
  * obligation.
  */
 public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
-    private Term problemTerm = null;
+    private Sequent problemTerm = null;
 
     // -------------------------------------------------------------------------
     // constructors

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
@@ -244,7 +244,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         String test1 = "\\predicates {A; B; } (A -> B) -> (!(!(A -> B)))";
         Term t_test1 = null;
         try {
-            t_test1 = io.load(test1).loadDeclarations().loadProblem().getProblemTerm().succedent()
+            t_test1 = io.load(test1).loadDeclarations().loadProblem().getProblem().succedent()
                     .get(0).formula();
         } catch (Exception e) {
             LOGGER.error("Parser Error or Input Error", e);

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
@@ -244,7 +244,8 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         String test1 = "\\predicates {A; B; } (A -> B) -> (!(!(A -> B)))";
         Term t_test1 = null;
         try {
-            t_test1 = io.load(test1).loadDeclarations().loadProblem().getProblemTerm();
+            t_test1 = io.load(test1).loadDeclarations().loadProblem().getProblemTerm().succedent()
+                    .get(0).formula();
         } catch (Exception e) {
             LOGGER.error("Parser Error or Input Error", e);
             fail("Parser Error");


### PR DESCRIPTION
On request, this PR changes the grammar of KeY files, s.t. problem statements can also be sequents. 

* Previous: ` problem: LBRACE term RBRACE;` 
* Now: ` problem: LBRACE termorseq RBRACE;`

This means, you are allow to write 

```
\problem {
   a,b,c 
    ==> 
     d, e, f
}
```
in KeY files. 