### PR TITLE
SMT: add Z3_QF variant

### DIFF
--- a/key.core/build.gradle
+++ b/key.core/build.gradle
@@ -71,6 +71,10 @@ task generateSMTListings {
     def resourcesDir = "${project.projectDir}/src/main/resources"
     def outputDir = resourcesDir // in the future that should be "${project.buildDir}/resources/main"
     // ${project.buildDir}
+    inputs.files fileTree("$resourcesDir/$pack", {
+        exclude "$resourcesDir/$pack/DefinedSymbolsHandler.preamble.xml"
+    })
+    outputs.files file("$outputDir/$pack/DefinedSymbolsHandler.preamble.xml")
     doLast {
         new File("$outputDir/$pack/DefinedSymbolsHandler.preamble.xml").withWriter { list ->
             list.writeLine '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
@@ -92,6 +96,10 @@ task generateSolverPropsList {
     def resourcesDir = "${project.projectDir}/src/main/resources"
     def outputDir = resourcesDir // in the future that should be "${project.buildDir}/resources/main"
     // ${project.buildDir}
+    inputs.files fileTree("$outputDir/$pack/", {
+        exclude "./solvers.txt"
+    })
+    outputs.files file("$outputDir/$pack/solvers.txt")
     doLast {
         def list = []
         def dir = new File("$outputDir/$pack/")
@@ -101,14 +109,12 @@ task generateSolverPropsList {
             }
         })
         list.sort()
-        if (!file("$outputDir/$pack/solvers.txt").exists()) {
-            String files = ''
-            for (String propsFile : list) {
-                files += propsFile + System.lineSeparator()
-            }
-            new File("$outputDir/$pack/solvers.txt").withWriter { listSolvers ->
-                listSolvers.write files
-            }
+        String files = ''
+        for (String propsFile : list) {
+            files += propsFile + System.lineSeparator()
+        }
+        new File("$outputDir/$pack/solvers.txt").withWriter { listSolvers ->
+            listSolvers.write files
         }
     }
 }
@@ -185,7 +191,7 @@ task generateVersionFiles() {
 }
 
 // @AW: Say something here. From POV this explain by itself.
-processResources.dependsOn generateVersionFiles
+processResources.dependsOn generateVersionFiles, generateSolverPropsList, generateSMTListings
 
 def antlr4OutputKey = "$projectDir/build/generated-src/antlr4/main/de/uka/ilkd/key/nparser"
 task runAntlr4Key(type: JavaExec) {

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_QF.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_QF.props
@@ -1,7 +1,7 @@
 params=-in -smt2
 timeout=-1
 name=Z3_QF
-info=Z3 solver by Microsoft. Translation excludes quantifiers, making this variant much faster for certain problems.
+info=Z3 solver by Microsoft. SMT translation of the sequent excludes quantified terms, making this variant much faster for certain problems.
 command=z3
 version=--version
 minVersion=Z3 version 4.4.1

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_QF.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_QF.props
@@ -1,0 +1,22 @@
+params=-in -smt2
+timeout=-1
+name=Z3_QF
+info=Z3 solver by Microsoft. Translation excludes quantifiers, making this variant much faster for certain problems.
+command=z3
+version=--version
+minVersion=Z3 version 4.4.1
+handlers=de.uka.ilkd.key.smt.newsmt2.BooleanConnectiveHandler,\
+de.uka.ilkd.key.smt.newsmt2.PolymorphicHandler,\
+de.uka.ilkd.key.smt.newsmt2.LogicalVariableHandler,\
+de.uka.ilkd.key.smt.newsmt2.NumberConstantsHandler,\
+de.uka.ilkd.key.smt.newsmt2.IntegerOpHandler,\
+de.uka.ilkd.key.smt.newsmt2.InstanceOfHandler,\
+de.uka.ilkd.key.smt.newsmt2.CastHandler,\
+de.uka.ilkd.key.smt.newsmt2.SumProdHandler,\
+de.uka.ilkd.key.smt.newsmt2.UpdateHandler,\
+de.uka.ilkd.key.smt.newsmt2.FieldConstantHandler,\
+de.uka.ilkd.key.smt.newsmt2.FloatHandler,\
+de.uka.ilkd.key.smt.newsmt2.CastingFunctionsHandler,\
+de.uka.ilkd.key.smt.newsmt2.DefinedSymbolsHandler,\
+de.uka.ilkd.key.smt.newsmt2.UninterpretedSymbolsHandler
+handlerOptions=getUnsatCore


### PR DESCRIPTION
This PR adds a variant of the Z3 SMT configuration which excludes quantifiers, making it much faster for certain problems. I will update this PR with my usecase if I can find it again.

Additionally the PR enhances the gradle task definitions by specifying inputs and outputs, which allows gradle to automatically respond to new .props files.