### PR TITLE
Restore TermImpl to package private and strengthen immutability of term and sorts

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/LabeledTermImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/LabeledTermImpl.java
@@ -18,7 +18,7 @@ import org.key_project.util.java.CollectionUtil;
  * The labeled term class is used for terms that have a label attached.
  *
  * Two labeled terms are equal if they have equal term structure and equal annotations. In contrast
- * the method {@link Term#equalsModRenaming(Object)} does not care about annotations and will just
+ * the method {@link Term#equalsModRenaming(Term)} does not care about annotations and will just
  * compare the term structure alone modula renaming.
  *
  * @see Term
@@ -39,11 +39,30 @@ class LabeledTermImpl extends TermImpl implements EqualsModProofIrrelevancy {
      * @param boundVars logic variables bound by the operator
      * @param javaBlock contains the program part of the term (if any)
      * @param labels the terms labels (must not be null or empty)
+     * @param origin a String with origin information
      */
     public LabeledTermImpl(Operator op, ImmutableArray<Term> subs,
             ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
-            ImmutableArray<TermLabel> labels) {
-        super(op, subs, boundVars, javaBlock);
+            ImmutableArray<TermLabel> labels, String origin) {
+        super(op, subs, boundVars, javaBlock, origin);
+        assert labels != null : "Term labels must not be null";
+        assert !labels.isEmpty() : "There must be at least one term label";
+        this.labels = labels;
+    }
+
+    /**
+     * creates an instance of a labeled term.
+     *
+     * @param op the top level operator
+     * @param subs the Term that are the subterms of this term
+     * @param boundVars logic variables bound by the operator
+     * @param javaBlock contains the program part of the term (if any)
+     * @param labels the terms labels (must not be null or empty)
+     */
+    public LabeledTermImpl(Operator op, ImmutableArray<Term> subs,
+                           ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
+                           ImmutableArray<TermLabel> labels) {
+        super(op, subs, boundVars, javaBlock, "");
         assert labels != null : "Term labels must not be null";
         assert !labels.isEmpty() : "There must be at least one term label";
         this.labels = labels;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/LabeledTermImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/LabeledTermImpl.java
@@ -60,8 +60,8 @@ class LabeledTermImpl extends TermImpl implements EqualsModProofIrrelevancy {
      * @param labels the terms labels (must not be null or empty)
      */
     public LabeledTermImpl(Operator op, ImmutableArray<Term> subs,
-                           ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
-                           ImmutableArray<TermLabel> labels) {
+            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
+            ImmutableArray<TermLabel> labels) {
         super(op, subs, boundVars, javaBlock, "");
         assert labels != null : "Term labels must not be null";
         assert !labels.isEmpty() : "There must be at least one term label";

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
@@ -125,11 +125,13 @@ public final class TermFactory {
     }
 
     private Term doCreateTerm(Operator op, ImmutableArray<Term> subs,
-                              ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
-                              ImmutableArray<TermLabel> labels, String origin) {
+            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
+            ImmutableArray<TermLabel> labels, String origin) {
         final Term newTerm =
-            (labels == null || labels.isEmpty() ? new TermImpl(op, subs, boundVars, javaBlock, origin)
-                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels, origin)).checked();
+            (labels == null || labels.isEmpty()
+                    ? new TermImpl(op, subs, boundVars, javaBlock, origin)
+                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels, origin))
+                            .checked();
         // Check if caching is possible. It is not possible if a non empty JavaBlock is available
         // in the term or in one of its children because the meta information like PositionInfos
         // may be different.

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
@@ -64,7 +64,7 @@ public final class TermFactory {
             subs = NO_SUBTERMS;
         }
 
-        return doCreateTerm(op, subs, boundVars, javaBlock, labels);
+        return doCreateTerm(op, subs, boundVars, javaBlock, labels, "");
     }
 
     public Term createTerm(Operator op, ImmutableArray<Term> subs,
@@ -125,11 +125,11 @@ public final class TermFactory {
     }
 
     private Term doCreateTerm(Operator op, ImmutableArray<Term> subs,
-            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
-            ImmutableArray<TermLabel> labels) {
+                              ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
+                              ImmutableArray<TermLabel> labels, String origin) {
         final Term newTerm =
-            (labels == null || labels.isEmpty() ? new TermImpl(op, subs, boundVars, javaBlock)
-                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels)).checked();
+            (labels == null || labels.isEmpty() ? new TermImpl(op, subs, boundVars, javaBlock, origin)
+                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels, origin)).checked();
         // Check if caching is possible. It is not possible if a non empty JavaBlock is available
         // in the term or in one of its children because the meta information like PositionInfos
         // may be different.
@@ -168,5 +168,9 @@ public final class TermFactory {
             return reduce.get();
         }
         throw new IllegalArgumentException("list of terms is empty.");
+    }
+
+    public Term createTermWithOrigin(Term t, String origin) {
+        return doCreateTerm(t.op(), t.subs(), t.boundVars(), t.javaBlock(), t.getLabels(), origin);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
@@ -103,7 +103,7 @@ class TermImpl implements Term, EqualsModProofIrrelevancy {
      */
     public TermImpl(Operator op, ImmutableArray<Term> subs,
             ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
-                    String origin) {
+            String origin) {
         assert op != null;
         assert subs != null;
         this.op = op;
@@ -114,7 +114,7 @@ class TermImpl implements Term, EqualsModProofIrrelevancy {
     }
 
     TermImpl(Operator op, ImmutableArray<Term> subs,
-                    ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock) {
+            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock) {
         this(op, subs, boundVars, javaBlock, "");
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
@@ -31,7 +31,7 @@ import org.key_project.util.collection.ImmutableSet;
  * The currently only class implementing the Term interface. TermFactory should be the only class
  * dealing directly with the TermImpl class.
  */
-public class TermImpl implements Term, EqualsModProofIrrelevancy {
+class TermImpl implements Term, EqualsModProofIrrelevancy {
 
     /**
      * A static empty list of terms used for memory reasons.
@@ -102,16 +102,32 @@ public class TermImpl implements Term, EqualsModProofIrrelevancy {
      * @param javaBlock the code block (if applicable) after which the term is evaluated
      */
     public TermImpl(Operator op, ImmutableArray<Term> subs,
-            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock) {
+            ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
+                    String origin) {
         assert op != null;
         assert subs != null;
         this.op = op;
         this.subs = subs.size() == 0 ? EMPTY_TERM_LIST : subs;
         this.boundVars = boundVars == null ? EMPTY_VAR_LIST : boundVars;
         this.javaBlock = javaBlock == null ? JavaBlock.EMPTY_JAVABLOCK : javaBlock;
+        this.origin = origin;
     }
 
+    TermImpl(Operator op, ImmutableArray<Term> subs,
+                    ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock) {
+        this(op, subs, boundVars, javaBlock, "");
+    }
 
+    /**
+     * For which feature is this information needed?
+     * What is the fifference from {@link de.uka.ilkd.key.logic.label.OriginTermLabel}?
+     */
+    private final String origin;
+
+    @Override
+    public @Nullable String getOrigin() {
+        return origin;
+    }
 
     // -------------------------------------------------------------------------
     // internal methods
@@ -710,14 +726,5 @@ public class TermImpl implements Term, EqualsModProofIrrelevancy {
         return containsJavaBlockRecursive == ThreeValuedTruth.TRUE;
     }
 
-    private String origin;
 
-    @Override
-    public @Nullable String getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(String origin) {
-        this.origin = origin;
-    }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/AbstractSort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/AbstractSort.java
@@ -32,10 +32,10 @@ public abstract class AbstractSort implements Sort {
     private final String origin;
 
     public AbstractSort(Name name,
-                        ImmutableSet<Sort> extendedSorts,
-                        boolean isAbstract,
-                        String documentation,
-                        String origin) {
+            ImmutableSet<Sort> extendedSorts,
+            boolean isAbstract,
+            String documentation,
+            String origin) {
         this.name = name;
         this.isAbstract = isAbstract;
         if (extendedSorts != null && extendedSorts.isEmpty()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/AbstractSort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/AbstractSort.java
@@ -17,40 +17,40 @@ import org.key_project.util.collection.ImmutableSet;
  * Abstract base class for implementations of the Sort interface.
  */
 public abstract class AbstractSort implements Sort {
-
     private final Name name;
-    private ImmutableSet<Sort> ext;
+    private final ImmutableSet<Sort> ext;
     private final boolean isAbstract;
 
     /**
-     * Documentation for this sort given by the an associated documentation comment.
+     * Documentation for this sort given by the associated documentation comment.
      *
      * @see de.uka.ilkd.key.nparser.KeYParser.One_sort_declContext#doc
      */
-    private String documentation;
+    private final String documentation;
 
     /** Information of the origin of this sort */
-    private String origin;
+    private final String origin;
 
-    public AbstractSort(Name name, ImmutableSet<Sort> ext, boolean isAbstract) {
+    public AbstractSort(Name name,
+                        ImmutableSet<Sort> extendedSorts,
+                        boolean isAbstract,
+                        String documentation,
+                        String origin) {
         this.name = name;
-        this.ext = ext;
         this.isAbstract = isAbstract;
+        if (extendedSorts != null && extendedSorts.isEmpty()) {
+            this.ext = DefaultImmutableSet.<Sort>nil().add(ANY);
+        } else {
+            this.ext = extendedSorts == null ? DefaultImmutableSet.<Sort>nil() : extendedSorts;
+        }
+        this.documentation = documentation;
+        this.origin = origin;
     }
-
 
     @Override
     public final ImmutableSet<Sort> extendsSorts() {
-        if (this == Sort.FORMULA || this == Sort.UPDATE || this == Sort.ANY) {
-            return DefaultImmutableSet.nil();
-        } else {
-            if (ext.isEmpty()) {
-                ext = DefaultImmutableSet.<Sort>nil().add(ANY);
-            }
-            return ext;
-        }
+        return ext;
     }
-
 
     @Override
     public final ImmutableSet<Sort> extendsSorts(Services services) {
@@ -125,10 +125,6 @@ public abstract class AbstractSort implements Sort {
         return name.toString();
     }
 
-    public void setDocumentation(@Nullable String documentation) {
-        this.documentation = documentation;
-    }
-
     @Nullable
     @Override
     public String getDocumentation() {
@@ -139,9 +135,5 @@ public abstract class AbstractSort implements Sort {
     @Override
     public String getOrigin() {
         return origin;
-    }
-
-    public void setOrigin(@Nullable String origin) {
-        this.origin = origin;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ArraySort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ArraySort.java
@@ -40,7 +40,7 @@ public final class ArraySort extends AbstractSort {
 
     private ArraySort(ImmutableSet<Sort> extendsSorts, SortKey sk) {
         super(new Name((sk.elemType != null ? sk.elemType.getName() : sk.elemSort.name()) + "[]"),
-            extendsSorts, false);
+            extendsSorts, false, "", "");
 
         if (extendsSorts.isEmpty()) {
             throw new IllegalArgumentException("An ArraySort extends typically three sorts"

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/GenericSort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/GenericSort.java
@@ -44,7 +44,8 @@ public final class GenericSort extends AbstractSort {
      * @param ext supersorts of this sort, which have to be either concrete sorts or plain generic
      *        sorts (i.e. not collection sorts of generic sorts)
      */
-    public GenericSort(Name name, ImmutableSet<Sort> ext, ImmutableSet<Sort> oneOf, String documentation, String origin)
+    public GenericSort(Name name, ImmutableSet<Sort> ext, ImmutableSet<Sort> oneOf,
+            String documentation, String origin)
             throws GenericSupersortException {
         super(name, ext, false, documentation, origin);
         this.oneOf = oneOf;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/GenericSort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/GenericSort.java
@@ -44,16 +44,21 @@ public final class GenericSort extends AbstractSort {
      * @param ext supersorts of this sort, which have to be either concrete sorts or plain generic
      *        sorts (i.e. not collection sorts of generic sorts)
      */
-    public GenericSort(Name name, ImmutableSet<Sort> ext, ImmutableSet<Sort> oneOf)
+    public GenericSort(Name name, ImmutableSet<Sort> ext, ImmutableSet<Sort> oneOf, String documentation, String origin)
             throws GenericSupersortException {
-        super(name, ext, false);
+        super(name, ext, false, documentation, origin);
         this.oneOf = oneOf;
         checkSupersorts();
     }
 
+    public GenericSort(Name name, ImmutableSet<Sort> ext, ImmutableSet<Sort> oneOf)
+            throws GenericSupersortException {
+        this(name, ext, oneOf, "", "");
+    }
+
 
     public GenericSort(Name name) {
-        super(name, DefaultImmutableSet.nil(), false);
+        super(name, DefaultImmutableSet.nil(), false, "", "");
         this.oneOf = DefaultImmutableSet.nil();
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ProgramSVSort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ProgramSVSort.java
@@ -280,7 +280,7 @@ public abstract class ProgramSVSort extends AbstractSort {
     // --------------------------------------------------------------------------
 
     public ProgramSVSort(Name name) {
-        super(name, DefaultImmutableSet.nil(), false);
+        super(name, DefaultImmutableSet.nil(), false, "", "");
         NAME2SORT.put(name, this);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ProxySort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ProxySort.java
@@ -10,11 +10,11 @@ import org.key_project.util.collection.ImmutableSet;
 
 public class ProxySort extends AbstractSort {
 
-    public ProxySort(Name name, ImmutableSet<Sort> ext) {
-        super(name, ext, false);
+    public ProxySort(Name name, ImmutableSet<Sort> ext, String documentation, String origin) {
+        super(name, ext, false, documentation, origin);
     }
 
     public ProxySort(Name name) {
-        this(name, DefaultImmutableSet.nil());
+        this(name, DefaultImmutableSet.nil(), "", "");
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/Sort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/Sort.java
@@ -35,7 +35,7 @@ public interface Sort extends Named, HasOrigin {
     /**
      * Any is a supersort of all sorts.
      */
-    Sort ANY = new SortImpl(new Name("any"),null, "", "");
+    Sort ANY = new SortImpl(new Name("any"), null, "", "");
 
     /**
      * Name of {@link #getCastSymbol(TermServices)}.

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/Sort.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/Sort.java
@@ -20,22 +20,22 @@ public interface Sort extends Named, HasOrigin {
     /**
      * Formulas are represented as "terms" of this sort.
      */
-    Sort FORMULA = new SortImpl(new Name("Formula"));
+    Sort FORMULA = new SortImpl(new Name("Formula"), null, "", "");
 
     /**
      * Updates are represented as "terms" of this sort.
      */
-    Sort UPDATE = new SortImpl(new Name("Update"));
+    Sort UPDATE = new SortImpl(new Name("Update"), null, "", "");
 
     /**
      * Term labels are represented as "terms" of this sort.
      */
-    Sort TERMLABEL = new SortImpl(new Name("TermLabel"));
+    Sort TERMLABEL = new SortImpl(new Name("TermLabel"), null, "", "");
 
     /**
      * Any is a supersort of all sorts.
      */
-    Sort ANY = new SortImpl(new Name("any"));
+    Sort ANY = new SortImpl(new Name("any"),null, "", "");
 
     /**
      * Name of {@link #getCastSymbol(TermServices)}.

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/SortImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/SortImpl.java
@@ -13,7 +13,8 @@ import org.key_project.util.collection.ImmutableSet;
  */
 public final class SortImpl extends AbstractSort {
 
-    public SortImpl(Name name, ImmutableSet<Sort> ext, boolean isAbstract, String documentation, String origin) {
+    public SortImpl(Name name, ImmutableSet<Sort> ext, boolean isAbstract, String documentation,
+            String origin) {
         super(name, ext, isAbstract, documentation, origin);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/SortImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/SortImpl.java
@@ -13,21 +13,29 @@ import org.key_project.util.collection.ImmutableSet;
  */
 public final class SortImpl extends AbstractSort {
 
+    public SortImpl(Name name, ImmutableSet<Sort> ext, boolean isAbstract, String documentation, String origin) {
+        super(name, ext, isAbstract, documentation, origin);
+    }
+
+    public SortImpl(Name name, ImmutableSet<Sort> ext, String documentation, String origin) {
+        this(name, ext, false, documentation, origin);
+    }
+
     public SortImpl(Name name, ImmutableSet<Sort> ext, boolean isAbstract) {
-        super(name, ext, isAbstract);
+        super(name, ext, isAbstract, "", "");
     }
 
     public SortImpl(Name name, ImmutableSet<Sort> ext) {
-        this(name, ext, false);
+        this(name, ext, false, "", "");
     }
 
     public SortImpl(Name name, Sort ext) {
-        this(name, DefaultImmutableSet.<Sort>nil().add(ext), false);
+        this(name, DefaultImmutableSet.<Sort>nil().add(ext), false, "", "");
     }
 
 
     public SortImpl(Name name) {
-        this(name, DefaultImmutableSet.nil());
+        this(name, DefaultImmutableSet.nil(), "", "");
     }
 
     public boolean equals(Object o) {

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
@@ -131,7 +131,8 @@ public class DeclarationBuilder extends DefaultBuilder {
                 Sort s = null;
                 if (isGenericSort) {
                     try {
-                        var gs = new GenericSort(sortName, ext, oneOf, documentation, BuilderHelpers.getPosition(idCtx));
+                        var gs = new GenericSort(sortName, ext, oneOf, documentation,
+                            BuilderHelpers.getPosition(idCtx));
                         s = gs;
                     } catch (GenericSupersortException e) {
                         semanticError(ctx, "Illegal sort given");
@@ -140,11 +141,12 @@ public class DeclarationBuilder extends DefaultBuilder {
                     s = Sort.ANY;
                 } else {
                     if (isProxySort) {
-                        var ps = new ProxySort(sortName, ext, documentation, BuilderHelpers.getPosition(idCtx));
+                        var ps = new ProxySort(sortName, ext, documentation,
+                            BuilderHelpers.getPosition(idCtx));
                         s = ps;
                     } else {
                         var si = new SortImpl(sortName, ext, isAbstractSort,
-                                documentation, BuilderHelpers.getPosition(idCtx));
+                            documentation, BuilderHelpers.getPosition(idCtx));
                         s = si;
                     }
                 }

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
@@ -131,9 +131,7 @@ public class DeclarationBuilder extends DefaultBuilder {
                 Sort s = null;
                 if (isGenericSort) {
                     try {
-                        var gs = new GenericSort(sortName, ext, oneOf);
-                        gs.setDocumentation(documentation);
-                        gs.setOrigin(BuilderHelpers.getPosition(idCtx));
+                        var gs = new GenericSort(sortName, ext, oneOf, documentation, BuilderHelpers.getPosition(idCtx));
                         s = gs;
                     } catch (GenericSupersortException e) {
                         semanticError(ctx, "Illegal sort given");
@@ -142,14 +140,11 @@ public class DeclarationBuilder extends DefaultBuilder {
                     s = Sort.ANY;
                 } else {
                     if (isProxySort) {
-                        var ps = new ProxySort(sortName, ext);
-                        ps.setDocumentation(documentation);
-                        ps.setOrigin(BuilderHelpers.getPosition(idCtx));
+                        var ps = new ProxySort(sortName, ext, documentation, BuilderHelpers.getPosition(idCtx));
                         s = ps;
                     } else {
-                        var si = new SortImpl(sortName, ext, isAbstractSort);
-                        si.setDocumentation(documentation);
-                        si.setOrigin(BuilderHelpers.getPosition(idCtx));
+                        var si = new SortImpl(sortName, ext, isAbstractSort,
+                                documentation, BuilderHelpers.getPosition(idCtx));
                         s = si;
                     }
                 }

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -88,8 +88,8 @@ public class ExpressionBuilder extends DefaultBuilder {
     public static Term updateOrigin(Term t, ParserRuleContext ctx, Services services) {
         try {
             t = services.getTermFactory().createTermWithOrigin(t,
-                    ctx.start.getTokenSource().getSourceName() + "@" + ctx.start.getLine()
-                + ":" + ctx.start.getCharPositionInLine() + 1);
+                ctx.start.getTokenSource().getSourceName() + "@" + ctx.start.getLine()
+                    + ":" + ctx.start.getCharPositionInLine() + 1);
         } catch (ClassCastException ignored) {
         }
         return t;

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -85,10 +85,10 @@ public class ExpressionBuilder extends DefaultBuilder {
         setSchemaVariables(schemaNamespace);
     }
 
-    public static Term updateOrigin(Term t, ParserRuleContext ctx) {
+    public static Term updateOrigin(Term t, ParserRuleContext ctx, Services services) {
         try {
-            TermImpl ti = (TermImpl) t;
-            ti.setOrigin(ctx.start.getTokenSource().getSourceName() + "@" + ctx.start.getLine()
+            t = services.getTermFactory().createTermWithOrigin(t,
+                    ctx.start.getTokenSource().getSourceName() + "@" + ctx.start.getLine()
                 + ":" + ctx.start.getCharPositionInLine() + 1);
         } catch (ClassCastException ignored) {
         }
@@ -175,7 +175,7 @@ public class ExpressionBuilder extends DefaultBuilder {
         for (int i = 1; i < t.size(); i++) {
             a = getTermFactory().createTerm(UpdateJunctor.PARALLEL_UPDATE, a, t.get(i));
         }
-        return updateOrigin(a, ctx);
+        return updateOrigin(a, ctx, services);
     }
 
     @Override
@@ -188,9 +188,9 @@ public class ExpressionBuilder extends DefaultBuilder {
         Term a = accept(ctx.a);
         Term b = accept(ctx.b);
         if (b != null) {
-            return updateOrigin(getServices().getTermBuilder().elementary(a, b), ctx);
+            return updateOrigin(getServices().getTermBuilder().elementary(a, b), ctx, services);
         }
-        return updateOrigin(a, ctx);
+        return updateOrigin(a, ctx, services);
     }
 
     @Override
@@ -211,10 +211,10 @@ public class ExpressionBuilder extends DefaultBuilder {
 
     private Term binaryTerm(ParserRuleContext ctx, Operator operator, Term left, Term right) {
         if (right == null) {
-            return updateOrigin(left, ctx);
+            return updateOrigin(left, ctx, services);
         }
         return capsulateTf(ctx,
-            () -> updateOrigin(getTermFactory().createTerm(operator, left, right), ctx));
+            () -> updateOrigin(getTermFactory().createTerm(operator, left, right), ctx, services));
     }
 
     @Override
@@ -306,7 +306,7 @@ public class ExpressionBuilder extends DefaultBuilder {
         Term termR = accept(ctx.b);
 
         if (termR == null) {
-            return updateOrigin(termL, ctx);
+            return updateOrigin(termL, ctx, services);
         }
 
         String op_name = "";
@@ -330,7 +330,7 @@ public class ExpressionBuilder extends DefaultBuilder {
     public Object visitWeak_arith_term(KeYParser.Weak_arith_termContext ctx) {
         Term termL = Objects.requireNonNull(accept(ctx.a));
         if (ctx.op.isEmpty()) {
-            return updateOrigin(termL, ctx);
+            return updateOrigin(termL, ctx, services);
         }
 
         List<Term> terms = mapOf(ctx.b);
@@ -373,7 +373,7 @@ public class ExpressionBuilder extends DefaultBuilder {
     public Object visitStrong_arith_term_1(KeYParser.Strong_arith_term_1Context ctx) {
         Term termL = accept(ctx.a);
         if (ctx.b.isEmpty()) {
-            return updateOrigin(termL, ctx);
+            return updateOrigin(termL, ctx, services);
         }
         List<Term> terms = mapOf(ctx.b);
         Term last = termL;
@@ -386,7 +386,7 @@ public class ExpressionBuilder extends DefaultBuilder {
     @Override
     public Object visitEmptyset(KeYParser.EmptysetContext ctx) {
         var op = services.getTypeConverter().getLocSetLDT().getEmpty();
-        return updateOrigin(getTermFactory().createTerm(op), ctx);
+        return updateOrigin(getTermFactory().createTerm(op), ctx, services);
     }
 
     @Override
@@ -923,7 +923,7 @@ public class ExpressionBuilder extends DefaultBuilder {
                 t = getServices().getTermBuilder().addLabel(t, labels);
             }
         }
-        return updateOrigin(t, ctx);
+        return updateOrigin(t, ctx, services);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/inst/SVInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/inst/SVInstantiations.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.PosInProgram;
 import de.uka.ilkd.key.logic.ProgramElementName;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.TermImpl;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.logic.op.ModalOperatorSV;
 import de.uka.ilkd.key.logic.op.Operator;
@@ -537,9 +536,8 @@ public class SVInstantiations implements EqualsModProofIrrelevancy {
             final ImmutableMapEntry<SchemaVariable, InstantiationEntry<?>> e = it.next();
             final Object inst = e.value().getInstantiation();
             assert inst != null : "Illegal null instantiation.";
-            if (inst instanceof TermImpl) {
-                if (!((TermImpl) inst)
-                        .equalsModIrrelevantTermLabels(cmp.getInstantiation(e.key()))) {
+            if (inst instanceof Term instAsTerm) {
+                if (!instAsTerm.equalsModIrrelevantTermLabels(cmp.getInstantiation(e.key()))) {
                     return false;
                 }
             } else if (!inst.equals(cmp.getInstantiation(e.key()))) {
@@ -568,9 +566,8 @@ public class SVInstantiations implements EqualsModProofIrrelevancy {
             final ImmutableMapEntry<SchemaVariable, InstantiationEntry<?>> e = it.next();
             final Object inst = e.value().getInstantiation();
             assert inst != null : "Illegal null instantiation.";
-            if (inst instanceof TermImpl) {
-                if (!((TermImpl) inst)
-                        .equalsModProofIrrelevancy(cmp.getInstantiation(e.key()))) {
+            if (inst instanceof Term instAsTerm) {
+                if (!instAsTerm.equalsModProofIrrelevancy(cmp.getInstantiation(e.key()))) {
                     return false;
                 }
             } else if (!inst.equals(cmp.getInstantiation(e.key()))) {

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/GenericRemovingLemmaGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/GenericRemovingLemmaGenerator.java
@@ -70,7 +70,7 @@ public class GenericRemovingLemmaGenerator extends DefaultLemmaGenerator {
             }
 
             ImmutableSet<Sort> extSorts = replaceSorts(sort.extendsSorts(), services);
-            ProxySort result = new ProxySort(sort.name(), extSorts);
+            ProxySort result = new ProxySort(sort.name(), extSorts, "", "");
             sortMap.put(sort, result);
             return result;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/UserDefinedSymbols.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/UserDefinedSymbols.java
@@ -123,7 +123,7 @@ public class UserDefinedSymbols {
         for (Sort sort : usedExtraSorts) {
             if (sort instanceof GenericSort genSort) {
                 ProxySort proxySort = new ProxySort(genSort.name(), genSort.extendsSorts(),
-                        "", "");
+                    "", "");
                 result.add(proxySort);
             } else {
                 result.add(sort);

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/UserDefinedSymbols.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/UserDefinedSymbols.java
@@ -122,7 +122,8 @@ public class UserDefinedSymbols {
         Set<Sort> result = new HashSet<>();
         for (Sort sort : usedExtraSorts) {
             if (sort instanceof GenericSort genSort) {
-                ProxySort proxySort = new ProxySort(genSort.name(), genSort.extendsSorts());
+                ProxySort proxySort = new ProxySort(genSort.name(), genSort.extendsSorts(),
+                        "", "");
                 result.add(proxySort);
             } else {
                 result.add(sort);


### PR DESCRIPTION
This PR makes TermImpl package private again (no entity outside of de....logic should see an actual implementation).
Further the PR strengthens the design decision of terms and sorts being immutable by making fields final and eliminating
setters.
