### PR TITLE
Proof Slicing: make dependency tracking optional

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -255,7 +255,7 @@ public final class Goal {
     private void setNode(Node p_node) {
         if (node().sequent() != p_node.sequent()) {
             node = p_node;
-            resetTagManager();
+            tagManager = new FormulaTagManager(this);
         } else {
             node = p_node;
         }
@@ -464,18 +464,6 @@ public final class Goal {
         ruleAppIndex.clearAndDetachCache();
     }
 
-    // @Deprecated
-    // public void setProgramVariables(Namespace ns) {
-    // // final Iterator<Named> it=ns.elements().iterator();
-    // // ImmutableSet<ProgramVariable> s = DefaultImmutableSet.<ProgramVariable>nil();
-    // // while (it.hasNext()) {
-    // // s = s.add((ProgramVariable)it.next());
-    // // }
-    // // node().setGlobalProgVars(DefaultImmutableSet.<ProgramVariable>nil());
-    // // proof().getNamespaces().programVariables().set(s);
-    // // setGlobalProgVars(s);
-    // }
-
     public void addProgramVariable(ProgramVariable pv) {
         localNamespaces.programVariables().addSafely(pv);
     }
@@ -538,6 +526,7 @@ public final class Goal {
      * creates n new nodes as children of the referenced node and new n goals that have references
      * to these new nodes.
      *
+     * @param n number of goals to create
      * @return the list of new created goals.
      */
     @Nonnull
@@ -577,10 +566,6 @@ public final class Goal {
         return goalList;
     }
 
-    private void resetTagManager() {
-        tagManager = new FormulaTagManager(this);
-    }
-
     public void setBranchLabel(String s) {
         node.getNodeInfo().setBranchLabel(s);
     }
@@ -606,13 +591,20 @@ public final class Goal {
         localNamespaces = newNS.copyWithParent();
     }
 
+    /**
+     * Perform the provided rule application on this goal.
+     * Returns the new goal(s), if any.
+     * This will also populate a {@link RuleAppInfo} object and fire the corresponding event.
+     * The state of the proof is also updated.
+     *
+     * @param ruleApp the rule app
+     * @return new goal(s)
+     */
     public ImmutableList<Goal> apply(final RuleApp ruleApp) {
-
         final Proof proof = proof();
 
         final NodeChangeJournal journal = new NodeChangeJournal(proof, this);
         addGoalListener(journal);
-
 
         final Node n = node;
 
@@ -636,19 +628,14 @@ public final class Goal {
 
         proof.getServices().saveNameRecorder(n);
 
-        if (goalList != null) { // TODO: can goalList be null?
-            if (goalList.isEmpty()) {
-                proof.closeGoal(this);
-            } else {
-                proof.replace(this, goalList);
-                if (ruleApp instanceof TacletApp && ((TacletApp) ruleApp).taclet().closeGoal()) {
-                    // the first new goal is the one to be closed
-                    proof.closeGoal(goalList.head());
-                }
-                if (ruleApp instanceof SMTRuleApp) {
-                    // the first new goal is the one to be closed
-                    proof.closeGoal(goalList.head());
-                }
+        if (goalList.isEmpty()) {
+            proof.closeGoal(this);
+        } else {
+            proof.replace(this, goalList);
+            if (ruleApp instanceof TacletApp tacletApp && tacletApp.taclet().closeGoal()
+                    || ruleApp instanceof SMTRuleApp) {
+                // the first new goal is the one to be closed
+                proof.closeGoal(goalList.head());
             }
         }
 
@@ -686,6 +673,7 @@ public final class Goal {
         }
     }
 
+    @Override
     public String toString() {
         LogicPrinter lp = LogicPrinter.purePrinter(new NotationInfo(), proof().getServices());
         lp.printSequent(node.sequent());
@@ -717,9 +705,6 @@ public final class Goal {
         this.localNamespaces = ns.copyWithParent().copyWithParent();
     }
 
-    /**
-     *
-     */
     public List<RuleApp> getAllBuiltInRuleApps() {
         final BuiltInRuleAppIndex index = ruleAppIndex().builtInRuleAppIndex();
         LinkedList<RuleApp> ruleApps = new LinkedList<>();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
@@ -457,6 +457,13 @@ public class Node implements Iterable<Node> {
     }
 
     /**
+     * @return the direct children of this node.
+     */
+    public Collection<Node> children() {
+        return Collections.unmodifiableList(children);
+    }
+
+    /**
      * @return an iterator for all nodes in the subtree.
      */
     public Iterator<Node> subtreeIterator() {

--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettings.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettings.java
@@ -16,6 +16,10 @@ import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
  */
 public class SlicingSettings extends AbstractPropertiesSettings {
     /**
+     * Config key for {@link #alwaysTrack}.
+     */
+    private static final String KEY_ALWAYS_TRACK = "[ProofSlicing]alwaysTrack";
+    /**
      * Config key for {@link #aggressiveDeduplicate}.
      */
     private static final String KEY_AGGRESSIVE_DEDUPLICATE = "[ProofSlicing]aggressiveDeduplicate";
@@ -23,6 +27,12 @@ public class SlicingSettings extends AbstractPropertiesSettings {
      * Config key for {@link #dotExecutable}.
      */
     private static final String KEY_DOT_EXECUTABLE = "[ProofSlicing]dotExecutable";
+
+    /**
+     * Always track dependencies config key.
+     */
+    private final PropertyEntry<Boolean> alwaysTrack =
+        createBooleanProperty(KEY_ALWAYS_TRACK, true);
 
     /**
      * Aggressive rule deduplication config key.
@@ -41,6 +51,14 @@ public class SlicingSettings extends AbstractPropertiesSettings {
      * over {@link #aggressiveDeduplicate}.
      */
     private final Map<Proof, Boolean> aggressiveDeduplicateOverride = new WeakHashMap<>();
+
+    public boolean getAlwaysTrack() {
+        return alwaysTrack.get();
+    }
+
+    public void setAlwaysTrack(boolean value) {
+        alwaysTrack.set(value);
+    }
 
     /**
      * @param proof proof

--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettingsProvider.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettingsProvider.java
@@ -28,7 +28,19 @@ public class SlicingSettingsProvider extends SettingsPanel implements SettingsPr
      */
     private static final String INTRO_LABEL = "Adjust proof analysis algorithm options here.";
     /**
-     * Label for first option.
+     * Label for always track option.
+     */
+    private static final String ALWAYS_TRACK = "Always track dependencies";
+    /**
+     * Explanatory text for always track option.
+     */
+    private static final String ALWAYS_TRACK_INFO =
+        """
+                If enabled, the dependency tracker will construct the dependency graph as the proof
+                is created. When disabled, the dependency graph is created only when needed, and
+                the 'Show proof step that created this formula' action is not available.""";
+    /**
+     * Label for aggressive deduplicate option.
      */
     private static final String AGGRESSIVE_DEDUPLICATE = "Aggressive rule de-duplication";
     /**
@@ -43,6 +55,7 @@ public class SlicingSettingsProvider extends SettingsPanel implements SettingsPr
     private static final String DOT_EXECUTABLE_INFO =
         "Path to dot executable from the graphviz package.";
 
+    private final JCheckBox alwaysTrack;
     /**
      * Checkbox for first option.
      */
@@ -58,6 +71,8 @@ public class SlicingSettingsProvider extends SettingsPanel implements SettingsPr
         pCenter.add(new JLabel(INTRO_LABEL), new CC().span().alignX("left"));
 
         addSeparator("Dependency graph");
+        alwaysTrack = addCheckBox(ALWAYS_TRACK, ALWAYS_TRACK_INFO, true, e -> {
+        });
         dotExecutable = addTextField(DOT_EXECUTABLE, "dot", DOT_EXECUTABLE_INFO, e -> {
         });
 
@@ -83,6 +98,7 @@ public class SlicingSettingsProvider extends SettingsPanel implements SettingsPr
     @Override
     public JComponent getPanel(MainWindow window) {
         SlicingSettings ss = getSlicingSettings();
+        alwaysTrack.setSelected(ss.getAlwaysTrack());
         dotExecutable.setText(ss.getDotExecutable());
         aggressiveDeduplicate.setSelected(ss.getAggressiveDeduplicate(null));
         return this;
@@ -91,6 +107,7 @@ public class SlicingSettingsProvider extends SettingsPanel implements SettingsPr
     @Override
     public void applySettings(MainWindow window) {
         SlicingSettings ss = getSlicingSettings();
+        ss.setAlwaysTrack(alwaysTrack.isSelected());
         ss.setDotExecutable(dotExecutable.getText());
         ss.setAggressiveDeduplicate(aggressiveDeduplicate.isSelected());
     }

--- a/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/analysis/DependencyAnalyzer.java
@@ -189,6 +189,8 @@ public final class DependencyAnalyzer {
             throw new IllegalStateException("cannot analyze proof with cached references");
         }
 
+        graph.ensureProofIsTracked(proof);
+
         executionTime.start(TOTAL_WORK);
         proof.setStepIndices();
 


### PR DESCRIPTION
Fixes #3301 by adding an option to disable the dependency tracker and adding a way to create the dependency graph after the proof is done.