### PR TITLE
Remove taclet application information from Taclet class

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/rule/Taclet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/Taclet.java
@@ -14,7 +14,6 @@ import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.op.SchemaVariable;
 import de.uka.ilkd.key.proof.Goal;
-import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.mgt.AxiomJustification;
 import de.uka.ilkd.key.proof.mgt.LemmaJustification;
 import de.uka.ilkd.key.proof.mgt.RuleJustification;
@@ -76,12 +75,6 @@ import org.key_project.util.collection.ImmutableSet;
 public abstract class Taclet implements Rule, Named, EqualsModProofIrrelevancy {
 
     protected final ImmutableSet<TacletAnnotation> tacletAnnotations;
-
-    /**
-     * The proof node that added this taclet to the set of available taclets.
-     * May be null if this taclet wasn't added by another proof step.
-     */
-    private Node addedBy = null;
 
     public RuleJustification getRuleJustification() {
         if (tacletAnnotations.contains(TacletAnnotation.LEMMA)) {
@@ -1012,13 +1005,5 @@ public abstract class Taclet implements Rule, Named, EqualsModProofIrrelevancy {
 
     public void setOrigin(@Nullable String origin) {
         this.origin = origin;
-    }
-
-    public void setAddedBy(Node addedBy) {
-        this.addedBy = addedBy;
-    }
-
-    public Node getAddedBy() {
-        return addedBy;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/TacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/TacletExecutor.java
@@ -333,8 +333,6 @@ public abstract class TacletExecutor<TacletKind extends Taclet> implements RuleE
                 neededInstances = neededInstances.add(gsc, services);
             }
 
-            tacletToAdd.setAddedBy(goal.node().parent());
-
             goal.addTaclet(tacletToAdd, neededInstances, true);
         }
     }


### PR DESCRIPTION
The responsibility of the taclet class is to have knowledge about static (mainly structural) properties.
Dynamic application information
* needed to apply the taclet should be put in the TacletApp class
* created when applying the taclet should be mangaed by the proof, goal, node or some external management depending on the kind
