### PR TITLE
Revert lazy term index updates

### DIFF
--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/rule/ModalitySideProofRule.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.symbolic_execution.rule;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
@@ -133,7 +132,6 @@ public class ModalitySideProofRule extends AbstractSideProofRule {
     /**
      * {@inheritDoc}
      */
-    @Nonnull
     @Override
     public ImmutableList<Goal> apply(Goal goal, Services services, RuleApp ruleApp)
             throws RuleAbortException {

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/Semisequent.java
@@ -144,7 +144,6 @@ public class Semisequent implements Iterable<SequentFormula> {
      */
     private SemisequentChangeInfo insertAndRemoveRedundancyHelper(int idx,
             SequentFormula sequentFormula, SemisequentChangeInfo semiCI, FormulaChangeInfo fci) {
-        assert idx >= 0;
 
         // Search for equivalent formulas and weakest constraint
         ImmutableList<SequentFormula> searchList = semiCI.getFormulaList();
@@ -260,7 +259,6 @@ public class Semisequent implements Iterable<SequentFormula> {
      */
     public SemisequentChangeInfo replace(PosInOccurrence pos, SequentFormula sequentFormula) {
         final int idx = indexOf(pos.sequentFormula());
-        assert idx >= 0;
         final FormulaChangeInfo fci = new FormulaChangeInfo(pos, sequentFormula);
         return insertAndRemoveRedundancyHelper(idx, sequentFormula, remove(idx), fci);
     }
@@ -424,9 +422,6 @@ public class Semisequent implements Iterable<SequentFormula> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (!(o instanceof Semisequent)) {
             return false;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.rule.BuiltInRule;
 import de.uka.ilkd.key.rule.IBuiltInRuleApp;
@@ -13,25 +11,27 @@ import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
 public class BuiltInRuleAppIndex {
-    public static final AtomicLong PERF_CREATE_ALL = new AtomicLong();
-    public static final AtomicLong PERF_UPDATE = new AtomicLong();
+
     private final BuiltInRuleIndex index;
 
-    private SequentChangeInfo sequentChangeInfo = null;
+    private NewRuleListener newRuleListener = NullNewRuleListener.INSTANCE;
 
     public BuiltInRuleAppIndex(BuiltInRuleIndex index) {
         this.index = index;
     }
 
-    private BuiltInRuleAppIndex(BuiltInRuleIndex index, SequentChangeInfo sequentChangeInfo) {
+
+    public BuiltInRuleAppIndex(BuiltInRuleIndex index, NewRuleListener p_newRuleListener) {
         this.index = index;
-        this.sequentChangeInfo = sequentChangeInfo;
+        this.newRuleListener = p_newRuleListener;
     }
+
 
     /**
      * returns a list of built-in rules application applicable for the given goal and position
      */
     public ImmutableList<IBuiltInRuleApp> getBuiltInRule(Goal goal, PosInOccurrence pos) {
+
         ImmutableList<IBuiltInRuleApp> result = ImmutableSLList.nil();
 
         ImmutableList<BuiltInRule> rules = index.rules();
@@ -51,8 +51,11 @@ public class BuiltInRuleAppIndex {
      * returns a copy of this index
      */
     public BuiltInRuleAppIndex copy() {
-        return new BuiltInRuleAppIndex(index.copy(),
-            sequentChangeInfo == null ? null : sequentChangeInfo.copy());
+        return new BuiltInRuleAppIndex(index.copy());
+    }
+
+    public void setNewRuleListener(NewRuleListener p_newRuleListener) {
+        newRuleListener = p_newRuleListener;
     }
 
     public BuiltInRuleIndex builtInRuleIndex() {
@@ -79,8 +82,7 @@ public class BuiltInRuleAppIndex {
         }
     }
 
-    private static void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal,
-            boolean antec,
+    private void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal, boolean antec,
             NewRuleListener listener) {
         final Node node = goal.node();
         final Sequent seq = node.sequent();
@@ -90,8 +92,7 @@ public class BuiltInRuleAppIndex {
         }
     }
 
-    private static void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal,
-            boolean antec,
+    private void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal, boolean antec,
             SequentFormula cfma, NewRuleListener listener) {
         final PosInOccurrence pos = new PosInOccurrence(cfma, PosInTerm.getTopLevel(), antec);
         ImmutableList<BuiltInRule> subrules = ImmutableSLList.nil();
@@ -109,7 +110,7 @@ public class BuiltInRuleAppIndex {
     }
 
     // TODO: optimise?
-    private static void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal,
+    private void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal,
             PosInOccurrence pos, NewRuleListener listener) {
         ImmutableList<BuiltInRule> it = rules;
         while (!it.isEmpty()) {
@@ -125,11 +126,8 @@ public class BuiltInRuleAppIndex {
         }
     }
 
-    public void reportRuleApps(Goal goal, NewRuleListener l) {
-        var time = System.nanoTime();
+    public void reportRuleApps(NewRuleListener l, Goal goal) {
         scanSimplificationRule(goal, l);
-        sequentChangeInfo = null;
-        PERF_CREATE_ALL.getAndAdd(System.nanoTime() - time);
     }
 
     /**
@@ -137,32 +135,12 @@ public class BuiltInRuleAppIndex {
      *
      * @param sci SequentChangeInfo describing the change of the sequent
      */
-    public void sequentChanged(SequentChangeInfo sci) {
-        if (sequentChangeInfo == null) {
-            // Nothing stored, store change
-            sequentChangeInfo = sci.copy();
-        } else {
-            assert sequentChangeInfo.sequent() == sci.getOriginalSequent();
-            sequentChangeInfo.combine(sci);
-        }
-    }
+    public void sequentChanged(Goal goal, SequentChangeInfo sci, NewRuleListener listener) {
+        scanAddedFormulas(goal, true, sci, listener);
+        scanAddedFormulas(goal, false, sci, listener);
 
-    public void resetSequentChanges() {
-        sequentChangeInfo = null;
-    }
-
-    public void flushSequentChanges(Goal goal, NewRuleListener listener) {
-        if (sequentChangeInfo == null) {
-            return;
-        }
-        var time = System.nanoTime();
-        scanAddedFormulas(goal, true, sequentChangeInfo, listener);
-        scanAddedFormulas(goal, false, sequentChangeInfo, listener);
-
-        scanModifiedFormulas(goal, true, sequentChangeInfo, listener);
-        scanModifiedFormulas(goal, false, sequentChangeInfo, listener);
-        sequentChangeInfo = null;
-        PERF_UPDATE.getAndAdd(System.nanoTime() - time);
+        scanModifiedFormulas(goal, true, sci, listener);
+        scanModifiedFormulas(goal, false, sci, listener);
     }
 
     private void scanAddedFormulas(Goal goal, boolean antec, SequentChangeInfo sci,

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -366,12 +366,6 @@ public final class Goal {
             assert sci.sequent().equals(sci.getOriginalSequent());
             return;
         }
-        // sci.hasChanged() can be true for added: f, removed: f
-        // This afaik only ever happens in TestApplyTaclet.testBugBrokenApply
-        // Since SequentChangeInfo does not filter this we have to
-        // work with maybe sci.original.equals(sci.sequent)
-        // Checking this is probably too expensive for what it's worth
-        assert sci.sequent() != sci.getOriginalSequent();
         node().setSequent(sci.sequent());
         node().getNodeInfo().setSequentChangeInfo(sci);
         var time = System.nanoTime();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -91,6 +91,7 @@ public final class RuleAppIndex {
     private void setNewRuleListeners() {
         interactiveTacletAppIndex.setNewRuleListener(newRuleListener);
         automatedTacletAppIndex.setNewRuleListener(newRuleListener);
+        builtInRuleAppIndex.setNewRuleListener(newRuleListener);
     }
 
     /**
@@ -235,7 +236,8 @@ public final class RuleAppIndex {
      * constraint and position
      */
     public ImmutableList<IBuiltInRuleApp> getBuiltInRules(Goal g, PosInOccurrence pos) {
-        return builtInRuleAppIndex.getBuiltInRule(g, pos);
+
+        return builtInRuleAppIndex().getBuiltInRule(g, pos);
     }
 
 
@@ -293,9 +295,11 @@ public final class RuleAppIndex {
      * @param sci SequentChangeInfo describing the change of the sequent
      */
     public void sequentChanged(SequentChangeInfo sci) {
-        interactiveTacletAppIndex.sequentChanged(sci);
+        if (!autoMode) {
+            interactiveTacletAppIndex.sequentChanged(sci);
+        }
         automatedTacletAppIndex.sequentChanged(sci);
-        builtInRuleAppIndex.sequentChanged(sci);
+        builtInRuleAppIndex.sequentChanged(goal, sci, newRuleListener);
     }
 
     /**
@@ -314,7 +318,6 @@ public final class RuleAppIndex {
         // Currently this only applies to the taclet index
         interactiveTacletAppIndex.clearIndexes();
         automatedTacletAppIndex.clearIndexes();
-        builtInRuleAppIndex.resetSequentChanges();
     }
 
     /**
@@ -325,16 +328,18 @@ public final class RuleAppIndex {
             interactiveTacletAppIndex.fillCache();
         }
         automatedTacletAppIndex.fillCache();
-        builtInRuleAppIndex.flushSequentChanges(goal, newRuleListener);
     }
 
     /**
      * Report all rule applications that are supposed to be applied automatically, and that are
      * currently stored by the index
+     *
+     * @param l the NewRuleListener
+     * @param services the Services
      */
-    public void reportAutomatedRuleApps() {
-        automatedTacletAppIndex.reportRuleApps(newRuleListener, goal.proof().getServices());
-        builtInRuleAppIndex.reportRuleApps(goal, newRuleListener);
+    public void reportAutomatedRuleApps(NewRuleListener l, Services services) {
+        automatedTacletAppIndex.reportRuleApps(l, services);
+        builtInRuleAppIndex.reportRuleApps(l, goal);
     }
 
     /**
@@ -343,7 +348,7 @@ public final class RuleAppIndex {
      * @param p_goal the Goal which to scan
      */
     public void scanBuiltInRules(Goal p_goal) {
-        builtInRuleAppIndex.scanApplicableRules(p_goal, newRuleListener);
+        builtInRuleAppIndex().scanApplicableRules(p_goal, newRuleListener);
     }
 
     /**
@@ -377,7 +382,7 @@ public final class RuleAppIndex {
         TacletAppIndex copiedAutomatedTacletAppIndex =
             automatedTacletAppIndex.copyWith(copiedTacletIndex, goal);
         return new RuleAppIndex(copiedTacletIndex, copiedInteractiveTacletAppIndex,
-            copiedAutomatedTacletAppIndex, builtInRuleAppIndex.copy(), goal, autoMode);
+            copiedAutomatedTacletAppIndex, builtInRuleAppIndex().copy(), goal, autoMode);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
@@ -58,25 +57,30 @@ public class TacletAppIndex {
      */
     private RuleFilter ruleFilter;
 
-    private final State state;
+    /**
+     * The sequent with the formulas for which taclet indices are hold by this object. Invariant:
+     * <code>seq != null</code> implies that the indices <code>antecIndex</code>,
+     * <code>succIndex</code> are up to date for the sequent <code>seq</code>
+     */
+    private Sequent seq;
 
     private final Map<CacheKey, TermTacletAppIndex> cache;
 
     public TacletAppIndex(TacletIndex tacletIndex, Goal goal, Services services) {
-        this(tacletIndex, null, null, goal, new State(), TacletFilter.TRUE,
+        this(tacletIndex, null, null, goal, null, TacletFilter.TRUE,
             new TermTacletAppIndexCacheSet(services.getCaches().getTermTacletAppIndexCache()),
             services.getCaches().getTermTacletAppIndexCache());
     }
 
     private TacletAppIndex(TacletIndex tacletIndex, SemisequentTacletAppIndex antecIndex,
-            SemisequentTacletAppIndex succIndex, @Nonnull Goal goal, State state,
+            SemisequentTacletAppIndex succIndex, @Nonnull Goal goal, Sequent seq,
             RuleFilter ruleFilter,
             TermTacletAppIndexCacheSet indexCaches, Map<CacheKey, TermTacletAppIndex> cache) {
         this.tacletIndex = tacletIndex;
         this.antecIndex = antecIndex;
         this.succIndex = succIndex;
         this.goal = goal;
-        this.state = state;
+        this.seq = seq;
         this.ruleFilter = ruleFilter;
         this.indexCaches = indexCaches;
         this.cache = cache;
@@ -97,13 +101,13 @@ public class TacletAppIndex {
      * returns a new TacletAppIndex with a given TacletIndex
      */
     TacletAppIndex copyWith(TacletIndex p_tacletIndex, Goal goal) {
-        return new TacletAppIndex(p_tacletIndex, antecIndex, succIndex, goal, state.copy(),
+        return new TacletAppIndex(p_tacletIndex, antecIndex, succIndex, goal, getSequent(),
             ruleFilter, indexCaches, cache);
     }
 
     /**
      * Delete all cached information about taclet apps. This also makes the index cache of this
-     * index independent of the caches of other indexes (expensive)
+     * index independent from the caches of other indexes (expensive)
      */
     public void clearAndDetachCache() {
         clearIndexes();
@@ -111,7 +115,7 @@ public class TacletAppIndex {
     }
 
     public void clearIndexes() {
-        this.state.clear();
+        seq = null; // This leads to a delayed rebuild
         antecIndex = null;
         succIndex = null;
     }
@@ -131,75 +135,44 @@ public class TacletAppIndex {
      * (NewRuleListener gets informed)
      */
     public void fillCache() {
-        update(false);
+        ensureIndicesExist();
     }
 
-    private void createAllFromGoal(boolean silent) {
+    private void createAllFromGoal() {
         var time = System.nanoTime();
+        try {
+            this.seq = getNode().sequent();
 
-        this.state.seq = goal.sequent();
-        var listener = silent ? NullNewRuleListener.INSTANCE : newRuleListener;
-
-        antecIndex =
-            new SemisequentTacletAppIndex(this.state.seq, true, getServices(), tacletIndex,
-                listener, ruleFilter, indexCaches);
-        succIndex =
-            new SemisequentTacletAppIndex(this.state.seq, false, getServices(), tacletIndex,
-                listener, ruleFilter, indexCaches);
-
-        // Full rebuild from the taclet index
-        this.state.sci = null;
-        this.state.newRules = null;
-
-        PERF_CREATE_ALL.getAndAdd(System.nanoTime() - time);
-    }
-
-    private void update(boolean silent) {
-        if (!isOutdated()) {
-            return;
-        }
-        if (this.state.sci != null && this.state.sci.sequent() == goal.sequent()) {
-            deltaUpdateIndices(this.state.sci, silent);
-        } else {
-            createAllFromGoal(silent);
-        }
-        this.state.sci = null;
-    }
-
-    private void deltaUpdateIndices(SequentChangeInfo sci, boolean silent) {
-        var time = System.nanoTime();
-        this.state.seq = sci.sequent();
-
-        var listener = silent ? NullNewRuleListener.INSTANCE : newRuleListener;
-        // Sequent changes
-        antecIndex =
-            antecIndex.sequentChanged(sci, getServices(), tacletIndex, listener);
-        succIndex =
-            succIndex.sequentChanged(sci, getServices(), tacletIndex, listener);
-
-        if (this.state.newRules != null) {
-            // New rules
             antecIndex =
-                antecIndex.addTaclets(this.state.newRules, getServices(), tacletIndex, listener);
+                new SemisequentTacletAppIndex(getSequent(), true, getServices(), tacletIndex(),
+                    newRuleListener, ruleFilter, indexCaches);
             succIndex =
-                succIndex.addTaclets(this.state.newRules, getServices(), tacletIndex, listener);
-            this.state.newRules = null;
+                new SemisequentTacletAppIndex(getSequent(), false, getServices(), tacletIndex(),
+                    newRuleListener, ruleFilter, indexCaches);
+        } finally {
+            PERF_CREATE_ALL.getAndAdd(System.nanoTime() - time);
         }
+    }
 
-        PERF_UPDATE.getAndAdd(System.nanoTime() - time);
+    private void ensureIndicesExist() {
+        if (isOutdated()) {
+            // Indices are not up-to-date
+            createAllFromGoal();
+        }
     }
 
     /**
-     * @return true iff this index is currently outdated; this does not detect other modifications
-     *         like an altered user constraint
+     * @return true iff this index is currently outdated with respect to the sequent of the
+     *         associated goal; this does not detect other modifications
+     *         like an altered user
+     *         constraint
      */
     private boolean isOutdated() {
-        assert state.seq == null || (state.seq != goal.sequent()) == (state.sci != null);
-        return state.seq != goal.sequent() || state.newRules != null;
+        return getGoal() == null || getSequent() != getNode().sequent();
     }
 
     private SemisequentTacletAppIndex getIndex(PosInOccurrence pos) {
-        update(false);
+        ensureIndicesExist();
         return pos.isInAntec() ? antecIndex : succIndex;
     }
 
@@ -263,7 +236,7 @@ public class TacletAppIndex {
      */
     public ImmutableList<NoPosTacletApp> getNoFindTaclet(TacletFilter filter, Services services) {
         RuleFilter effectiveFilter = new AndRuleFilter(filter, ruleFilter);
-        return tacletIndex.getNoFindTaclet(effectiveFilter, services);
+        return tacletIndex().getNoFindTaclet(effectiveFilter, services);
     }
 
     /**
@@ -325,19 +298,31 @@ public class TacletAppIndex {
      * @param sci SequentChangeInfo describing the change of the sequent
      */
     public void sequentChanged(SequentChangeInfo sci) {
-        if (state.sci == null) {
-            if (state.seq != sci.getOriginalSequent()) {
-                // we are not up-to-date and have to rebuild everything
-                clearIndexes();
-            } else {
-                // Nothing stored, store change
-                state.sci = sci.copy();
-            }
+        if (sci.getOriginalSequent() != getSequent()) {
+            // we are not up-to-date and have to rebuild everything (lazy)
+            clearIndexes();
         } else {
-            assert state.sci.sequent() == sci.getOriginalSequent();
-            // Combine the changes
-            state.sci.combine(sci);
+            var time = System.nanoTime();
+            updateIndices(sci);
+            PERF_UPDATE.getAndAdd(System.nanoTime() - time);
         }
+    }
+
+    private void updateIndices(SequentChangeInfo sci) {
+        seq = sci.sequent();
+
+        antecIndex =
+            antecIndex.sequentChanged(sci, getServices(), tacletIndex, newRuleListener);
+
+        succIndex =
+            succIndex.sequentChanged(sci, getServices(), tacletIndex, newRuleListener);
+    }
+
+    private void updateIndices(final SetRuleFilter newTaclets) {
+        antecIndex =
+            antecIndex.addTaclets(newTaclets, getServices(), tacletIndex, newRuleListener);
+        succIndex =
+            succIndex.addTaclets(newTaclets, getServices(), tacletIndex, newRuleListener);
     }
 
 
@@ -355,6 +340,12 @@ public class TacletAppIndex {
             createNewIndexCache();
         }
 
+        if (isOutdated()) {
+            // we are not up-to-date and have to rebuild everything (lazy)
+            clearIndexes();
+            return;
+        }
+
         if (tacletApp.taclet() instanceof NoFindTaclet) {
             if (ruleFilter.filter(tacletApp.taclet())) {
                 newRuleListener.ruleAdded(tacletApp, null);
@@ -362,10 +353,10 @@ public class TacletAppIndex {
             return;
         }
 
-        if (state.newRules == null) {
-            state.newRules = new SetRuleFilter();
-        }
-        state.newRules.addRuleToSet(tacletApp.taclet());
+        final SetRuleFilter newTaclets = new SetRuleFilter();
+        newTaclets.addRuleToSet(tacletApp.taclet());
+
+        updateIndices(newTaclets);
     }
 
     /**
@@ -385,23 +376,31 @@ public class TacletAppIndex {
             }
         }
 
-        if (state.newRules == null) {
-            state.newRules = new SetRuleFilter();
+        if (isOutdated()) {
+            // we are not up-to-date and have to rebuild everything (lazy)
+            clearIndexes();
+            return;
         }
+
+        final SetRuleFilter newTaclets = new SetRuleFilter();
         for (NoPosTacletApp tacletApp : tacletApps) {
             if (tacletApp.taclet() instanceof NoFindTaclet) {
                 if (ruleFilter.filter(tacletApp.taclet())) {
                     newRuleListener.ruleAdded(tacletApp, null);
                 }
             } else {
-                state.newRules.addRuleToSet(tacletApp.taclet());
+                newTaclets.addRuleToSet(tacletApp.taclet());
             }
         }
 
-        if (state.newRules.isEmpty()) {
-            state.newRules = null;
+        if (newTaclets.isEmpty()) {
+            return;
         }
+
+        updateIndices(newTaclets);
     }
+
+
 
     /**
      * updates the internal caches after a Taclet with instantiation information has been removed
@@ -434,8 +433,31 @@ public class TacletAppIndex {
         return l1;
     }
 
+    private Goal getGoal() {
+        return goal;
+    }
+
+    private Sequent getSequent() {
+        return seq;
+    }
+
     private Services getServices() {
-        return goal.node().proof().getServices();
+        return getProof().getServices();
+    }
+
+    private Proof getProof() {
+        return getNode().proof();
+    }
+
+    private Node getNode() {
+        return goal.node();
+    }
+
+    /**
+     * returns the Taclet index for this ruleAppIndex.
+     */
+    public TacletIndex tacletIndex() {
+        return tacletIndex;
     }
 
     /**
@@ -443,60 +465,13 @@ public class TacletAppIndex {
      * taclet app.
      */
     public void reportRuleApps(NewRuleListener l, Services services) {
-        if (antecIndex != null && succIndex != null) {
-            update(true);
+        if (antecIndex != null) {
             antecIndex.reportRuleApps(l);
+        }
+        if (succIndex != null) {
             succIndex.reportRuleApps(l);
         }
 
         l.rulesAdded(getNoFindTaclet(TacletFilter.TRUE, services), null);
-    }
-
-    private static final class State {
-        /**
-         * The sequent with the formulas for which taclet indices are hold by this object.
-         * Invariant:
-         * <code>seq != null</code> implies that the indices <code>antecIndex</code>,
-         * <code>succIndex</code> are up-to-date for the sequent <code>seq</code>
-         */
-        @Nullable
-        public Sequent seq;
-
-        /**
-         * Used for delta updates. If this is nonnull, originalSequent == seq and resultingSequent
-         * ==
-         * goal.sequent.
-         */
-        @Nullable
-        public SequentChangeInfo sci;
-        @Nullable
-        public SetRuleFilter newRules;
-
-        public State() {
-            this(null, null, null);
-        }
-
-        public State(@Nullable Sequent seq, @Nullable SequentChangeInfo sequentChangeInfo,
-                @Nullable SetRuleFilter newRules) {
-            this.seq = seq;
-            this.sci = sequentChangeInfo;
-            this.newRules = newRules;
-        }
-
-        public State copy() {
-            return new State(
-                seq,
-                sci == null ? null : sci.copy(),
-                newRules == null ? null : newRules.copy());
-        }
-
-        public void clear() {
-            // This leads to a delayed rebuild
-            this.seq = null;
-            // This is needed since delta updates must be disabled as well (e.g. new taclet was
-            // added)
-            this.sci = null;
-            this.newRules = null;
-        }
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/rulefilter/SetRuleFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/rulefilter/SetRuleFilter.java
@@ -13,19 +13,7 @@ import de.uka.ilkd.key.rule.Rule;
  */
 public class SetRuleFilter implements RuleFilter {
 
-    private final HashSet<Rule> set;
-
-    public SetRuleFilter() {
-        this.set = new LinkedHashSet<>();
-    }
-
-    private SetRuleFilter(HashSet<Rule> set) {
-        this.set = set;
-    }
-
-    public SetRuleFilter copy() {
-        return new SetRuleFilter(new LinkedHashSet<>(this.set));
-    }
+    private final HashSet<Rule> set = new LinkedHashSet<>();
 
     public void addRuleToSet(Rule rule) {
         set.add(rule);

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/PerfScope.java
@@ -8,7 +8,6 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
-import de.uka.ilkd.key.proof.BuiltInRuleAppIndex;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.SemisequentTacletAppIndex;
 import de.uka.ilkd.key.proof.TacletAppIndex;
@@ -39,13 +38,11 @@ public class PerfScope {
         new Pair<>("Goal setSequent", Goal.PERF_SET_SEQUENT),
         new Pair<>("Goal update tag manager", Goal.PERF_UPDATE_TAG_MANAGER),
         new Pair<>("Goal update rule app index", Goal.PERF_UPDATE_RULE_APP_INDEX),
+        new Pair<>("Taclet app index update", TacletAppIndex.PERF_UPDATE),
         new Pair<>("Semi Taclet app index update remove", SemisequentTacletAppIndex.PERF_REMOVE),
         new Pair<>("Semi Taclet app index update add", SemisequentTacletAppIndex.PERF_ADD),
         new Pair<>("Semi Taclet app index update update", SemisequentTacletAppIndex.PERF_UPDATE),
-        new Pair<>("Taclet app index update", TacletAppIndex.PERF_UPDATE),
         new Pair<>("Taclet app index create all", TacletAppIndex.PERF_CREATE_ALL),
-        new Pair<>("Builtin app index update", BuiltInRuleAppIndex.PERF_UPDATE),
-        new Pair<>("Builtin app index create all", BuiltInRuleAppIndex.PERF_CREATE_ALL),
         new Pair<>("Goal update listeners", Goal.PERF_UPDATE_LISTENERS),
         new Pair<>("TacletApp execute", TacletApp.PERF_EXECUTE),
         new Pair<>("TacletApp pre", TacletApp.PERF_PRE),

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -99,7 +99,8 @@ public class QueueRuleApplicationManager implements AutomatedRuleApplicationMana
         // <code>FocussedRuleApplicationManager</code>) the rule index
         // reports its contents to the rule manager of the goal, which is not
         // necessarily this object
-        goal.ruleAppIndex().reportAutomatedRuleApps();
+        goal.ruleAppIndex().reportAutomatedRuleApps(goal.getRuleAppManager(),
+            goal.proof().getServices());
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
@@ -118,11 +118,4 @@ public abstract class RuleAppContainer implements Comparable<RuleAppContainer> {
         return result;
     }
 
-    @Override
-    public String toString() {
-        return "RuleAppContainer{" +
-            "ruleApp=" + ruleApp.rule().name() +
-            ", cost=" + cost +
-            '}';
-    }
 }


### PR DESCRIPTION
The optimization introduced some subtle bug. I have an example that can reproduce it.
As it is part of a lab, I cannot share it at the moment (publicly). The problem has been supplied by 
@guialvares and @wolfgangahrendt,

I assume the revert may also fix issue #3259


This commit reverts:
https://github.com/KeYProject/key/commit/8b7e5b15673c2f61965d13d40e3155f11fd2a8c1
https://github.com/KeYProject/key/commit/e18b309282b77088160ffd26f11f3b5ecee787bd
https://github.com/KeYProject/key/commit/81a18ccb6fd11e6faf40442604db36e33a14fdfe