### PR TITLE
Allow origin labels to be switched off completely

### DIFF
--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
@@ -3857,7 +3857,7 @@ public final class SymbolicExecutionUtil {
             logicPrinter.printTerm(term);
             return logicPrinter.result();
         } else {
-            return term != null ? TermLabel.removeIrrelevantLabels(term, services).toString()
+            return term != null ? TermLabelManager.removeIrrelevantLabels(term, services).toString()
                     : null;
         }
     }

--- a/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/ProofInfo.java
+++ b/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/ProofInfo.java
@@ -9,7 +9,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
 import de.uka.ilkd.key.logic.JavaBlock;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.pp.PosTableLayouter;
@@ -106,7 +106,7 @@ public class ProofInfo {
 
     public void getProgramVariables(Term t, Set<Term> vars) {
         if (t.op() instanceof ProgramVariable && isRelevantConstant(t)) {
-            vars.add(TermLabel.removeIrrelevantLabels(t, services));
+            vars.add(TermLabelManager.removeIrrelevantLabels(t, services));
         }
 
         for (Term sub : t.subs()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.NamespaceSet;
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.NodeOrigin;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
 import de.uka.ilkd.key.nparser.KeyIO;

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
@@ -22,7 +22,6 @@ import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.rule.IfFormulaInstDirect;
 import de.uka.ilkd.key.rule.IfFormulaInstantiation;
 import de.uka.ilkd.key.rule.TacletApp;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.RecognitionException;
 
 import org.key_project.util.collection.ImmutableList;
@@ -124,13 +123,9 @@ public class TacletAssumesModel extends DefaultComboBoxModel<IfFormulaInstantiat
             }
 
             Term term = parseFormula(manualInput);
-
-            if (ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
-                    .getUseOriginLabels()) {
-                term = services.getTermBuilder().addLabelToAllSubs(term,
-                    new NodeOrigin(SpecType.USER_INTERACTION,
-                        app.rule().displayName(), goal.node().serialNr()));
-            }
+            term = services.getTermBuilder().addLabelToAllSubs(term,
+                new NodeOrigin(SpecType.USER_INTERACTION,
+                    app.rule().displayName(), goal.node().serialNr()));
 
             return new IfFormulaInstDirect(new SequentFormula(term));
         } catch (RecognitionException e) {

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
@@ -129,8 +129,8 @@ public class TacletAssumesModel extends DefaultComboBoxModel<IfFormulaInstantiat
             if (ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
                     .getUseOriginLabels()) {
                 term = services.getTermBuilder().addLabelToAllSubs(term,
-                    new OriginTermLabel(new NodeOrigin(SpecType.USER_INTERACTION,
-                        app.rule().displayName(), goal.node().serialNr())));
+                    new NodeOrigin(SpecType.USER_INTERACTION,
+                        app.rule().displayName(), goal.node().serialNr()));
             }
 
             return new IfFormulaInstDirect(new SequentFormula(term));

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -28,7 +28,6 @@ import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.rule.inst.*;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.Pair;
 
 import org.key_project.util.collection.ImmutableList;
@@ -285,14 +284,10 @@ public class TacletFindModel extends AbstractTableModel {
     }
 
     private Term addOrigin(Term term) {
-        if (ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()) {
-            return services.getTermBuilder().addLabelToAllSubs(
-                OriginTermLabel.removeOriginLabels(term, services),
-                new NodeOrigin(SpecType.USER_INTERACTION,
-                    originalApp.rule().displayName(), goal.node().serialNr()));
-        } else {
-            return term;
-        }
+        return services.getTermBuilder().addLabelToAllSubs(
+            OriginTermLabel.removeOriginLabels(term, services),
+            new NodeOrigin(SpecType.USER_INTERACTION,
+                originalApp.rule().displayName(), goal.node().serialNr()));
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -288,8 +288,8 @@ public class TacletFindModel extends AbstractTableModel {
         if (ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()) {
             return services.getTermBuilder().addLabelToAllSubs(
                 OriginTermLabel.removeOriginLabels(term, services),
-                new OriginTermLabel(new NodeOrigin(SpecType.USER_INTERACTION,
-                    originalApp.rule().displayName(), goal.node().serialNr())));
+                new NodeOrigin(SpecType.USER_INTERACTION,
+                    originalApp.rule().displayName(), goal.node().serialNr()));
         } else {
             return term;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/AbstractFinishAuxiliaryComputationMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/AbstractFinishAuxiliaryComputationMacro.java
@@ -15,7 +15,7 @@ import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
 import de.uka.ilkd.key.logic.TermFactory;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.macros.AbstractProofMacro;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
@@ -126,7 +126,7 @@ public abstract class AbstractFinishAuxiliaryComputationMacro extends AbstractPr
         for (final SequentFormula f : symbExecGoal.sequent().succedent()) {
             result = tb.and(result, tb.not(f.formula()));
         }
-        result = TermLabel.removeIrrelevantLabels(result, tf);
+        result = TermLabelManager.removeIrrelevantLabels(result, tf);
         return result;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/ReplaceAndRegisterMethod.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/ReplaceAndRegisterMethod.java
@@ -11,7 +11,7 @@ import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
 import de.uka.ilkd.key.logic.Visitor;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.proof.OpReplacer;
@@ -154,7 +154,7 @@ abstract class ReplaceAndRegisterMethod {
         }
         final OpReplacer op =
             new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
-        term = TermLabel.removeIrrelevantLabels(term, services.getTermFactory());
+        term = TermLabelManager.removeIrrelevantLabels(term, services.getTermFactory());
         return op.replace(term);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowUnfoldTacletBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowUnfoldTacletBuilder.java
@@ -11,7 +11,7 @@ import de.uka.ilkd.key.informationflow.proof.init.StateVars;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.Function;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.op.SchemaVariable;
@@ -209,7 +209,7 @@ abstract class AbstractInfFlowUnfoldTacletBuilder extends AbstractInfFlowTacletB
             }
         }
         OpReplacer or = new OpReplacer(map, services.getTermFactory(), services.getProof());
-        term = TermLabel.removeIrrelevantLabels(term, services.getTermFactory());
+        term = TermLabelManager.removeIrrelevantLabels(term, services.getTermFactory());
         Term result = or.replace(term);
 
         return result;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -302,12 +302,6 @@ public class Services implements TermServices {
                 "Services are already owned by another proof:" + proof.name());
         }
         proof = p_proof;
-
-        // TODO: is the below still needed?
-        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()
-                || !proof.getSettings().getTermLabelSettings().getUseOriginLabels()) {
-            profile.getTermLabelManager().disableOriginLabelRefactorings();
-        }
     }
 
     /*
@@ -409,7 +403,7 @@ public class Services implements TermServices {
 
     /**
      * Returns the {@link TermBuilder} used to create {@link Term}s. Same as
-     * {@link #getTermBuilder(true).
+     * <code>getTermBuilder(true)</code>>.
      *
      * @return The {@link TermBuilder} used to create {@link Term}s.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import de.uka.ilkd.key.java.recoderext.KeYCrossReferenceServiceConfiguration;
 import de.uka.ilkd.key.java.recoderext.SchemaCrossReferenceServiceConfiguration;
 import de.uka.ilkd.key.logic.*;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.proof.init.Profile;
@@ -138,6 +139,7 @@ public class Services implements TermServices {
         this.caches = s.caches;
         this.termBuilder = new TermBuilder(new TermFactory(caches.getTermFactoryCache()), this);
         this.termBuilderWithoutCache = new TermBuilder(new TermFactory(), this);
+        this.originFactory = s.originFactory;
     }
 
     public Services getOverlay(NamespaceSet namespaces) {
@@ -354,6 +356,16 @@ public class Services implements TermServices {
      */
     public Proof getProof() {
         return proof;
+    }
+
+    private OriginTermLabelFactory originFactory;
+
+    public void setOriginFactory(OriginTermLabelFactory originFactory) {
+        this.originFactory = originFactory;
+    }
+
+    public OriginTermLabelFactory getOriginFactory() {
+        return  originFactory;
     }
 
     public interface ITermProgramVariableCollectorFactory {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.proof.init.Profile;
 import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.Debug;
 import de.uka.ilkd.key.util.KeYRecoderExcHandler;
 
@@ -78,6 +77,8 @@ public class Services implements TermServices {
 
     private ITermProgramVariableCollectorFactory factory =
         TermProgramVariableCollector::new;
+
+    private OriginTermLabelFactory originFactory;
 
     private final Profile profile;
 
@@ -355,16 +356,6 @@ public class Services implements TermServices {
         return proof;
     }
 
-    private OriginTermLabelFactory originFactory;
-
-    public void setOriginFactory(OriginTermLabelFactory originFactory) {
-        this.originFactory = originFactory;
-    }
-
-    public OriginTermLabelFactory getOriginFactory() {
-        return originFactory;
-    }
-
     public interface ITermProgramVariableCollectorFactory {
         TermProgramVariableCollector create(Services services);
     }
@@ -376,6 +367,21 @@ public class Services implements TermServices {
      */
     public Profile getProfile() {
         return profile;
+    }
+
+    /**
+     * returns the {@link JavaModel} with all path information
+     *
+     * @return the {@link JavaModel} on which this services is based on
+     */
+    public JavaModel getJavaModel() {
+        return javaModel;
+    }
+
+
+    public void setJavaModel(JavaModel javaModel) {
+        assert this.javaModel == null;
+        this.javaModel = javaModel;
     }
 
     /**
@@ -426,26 +432,39 @@ public class Services implements TermServices {
         return factory;
     }
 
-
     public void setFactory(ITermProgramVariableCollectorFactory factory) {
         this.factory = factory;
     }
 
 
+    // =================================================================================================================
+    // =================================================================================================================
+
+    // Origin label specific methods; these should eventually be moved out of the services class
+    // when doing that we must take care not to introduce dependencies to ProofSettings or similar
+    // in places
+    // where that should not occur
+
     /**
-     * returns the {@link JavaModel} with all path information
+     * sets the factory for origin term labels
      *
-     * @return the {@link JavaModel} on which this services is based on
+     * @param originFactory the {@OriginTermLabelFactory} to use, if null is passed, origin labels
+     *        should not be created
      */
-    public JavaModel getJavaModel() {
-        return javaModel;
+    public void setOriginFactory(OriginTermLabelFactory originFactory) {
+        this.originFactory = originFactory;
     }
 
-
-    public void setJavaModel(JavaModel javaModel) {
-        assert this.javaModel == null;
-        this.javaModel = javaModel;
+    /**
+     * return the factory for origin term labels
+     *
+     * @return the OriginTermLabelFactory to use or null if origin labels should not be created
+     */
+    public OriginTermLabelFactory getOriginFactory() {
+        return originFactory;
     }
+    // =================================================================================================================
+    // =================================================================================================================
 
     public Lookup createLookup() {
         Lookup lookup = new Lookup();

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -243,6 +243,7 @@ public class Services implements TermServices {
         s.setNamespaces(namespaces.copy());
         nameRecorder = nameRecorder.copy();
         s.setJavaModel(getJavaModel());
+        s.originFactory = originFactory;
         return s;
     }
 
@@ -282,6 +283,7 @@ public class Services implements TermServices {
         s.setNamespaces(namespaces.copy());
         nameRecorder = nameRecorder.copy();
         s.setJavaModel(getJavaModel());
+        s.originFactory = originFactory;
         return s;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -364,7 +364,7 @@ public class Services implements TermServices {
     }
 
     public OriginTermLabelFactory getOriginFactory() {
-        return  originFactory;
+        return originFactory;
     }
 
     public interface ITermProgramVariableCollectorFactory {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -300,6 +300,8 @@ public class Services implements TermServices {
                 "Services are already owned by another proof:" + proof.name());
         }
         proof = p_proof;
+
+        // TODO: is the below still needed?
         if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()
                 || !proof.getSettings().getTermLabelSettings().getUseOriginLabels()) {
             profile.getTermLabelManager().disableOriginLabelRefactorings();

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -282,7 +282,6 @@ public class Services implements TermServices {
         s.setNamespaces(namespaces.copy());
         nameRecorder = nameRecorder.copy();
         s.setJavaModel(getJavaModel());
-
         return s;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/JMLTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/JMLTransformer.java
@@ -501,7 +501,8 @@ public final class JMLTransformer extends RecoderModelTransformer {
                 de.uka.ilkd.key.java.Position.fromSEPosition(recoderPos);
 
             // call preparser
-            var parser = new PreParser();
+            var parser = new PreParser(ProofIndependentSettings.DEFAULT_INSTANCE
+                    .getTermLabelSettings().getUseOriginLabels());
             ImmutableList<TextualJMLConstruct> constructs =
                 parser.parseClassLevel(concatenatedComment, fileName, pos);
             warnings = warnings.append(parser.getWarnings());
@@ -557,7 +558,8 @@ public final class JMLTransformer extends RecoderModelTransformer {
             de.uka.ilkd.key.java.Position.fromSEPosition(recoderPos);
 
         // call preparser
-        var parser = new PreParser();
+        var parser = new PreParser(
+            ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels());
         ImmutableList<TextualJMLConstruct> constructs =
             parser.parseMethodLevel(concatenatedComment, fileName, pos);
         warnings = warnings.append(parser.getWarnings());

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.ldt.LocSetLDT;
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.logic.op.*;
@@ -2262,5 +2263,27 @@ public class TermBuilder {
             DoubleLDT doubleLDT = services.getTypeConverter().getDoubleLDT();
             return func(doubleLDT.getEquals(), t1, t2);
         }
+    }
+
+
+    public Term addLabelToAllSubs(Term term, OriginTermLabel.Origin origin) {
+        final OriginTermLabelFactory originFactory = services.getOriginFactory();
+        if (originFactory != null) {
+            return addLabelToAllSubs(term, originFactory.createOriginTermLabel(origin));
+        }
+        return term;
+    }
+
+    public Term addLabel(Term term, OriginTermLabel.Origin origin) {
+        final OriginTermLabelFactory originFactory = services.getOriginFactory();
+        if (originFactory != null) {
+            return addLabel(term, originFactory.createOriginTermLabel(origin));
+        }
+        return term;
+    }
+
+
+    public OriginTermLabelFactory getOriginFactory() {
+        return services.getOriginFactory();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
@@ -2266,6 +2266,16 @@ public class TermBuilder {
     }
 
 
+    // Origin label addition
+
+    /**
+     * add origin information to the term and all its sub terms
+     * nothing will be done if no origin term label factory is present
+     *
+     * @param term the term where to start to add the origin information
+     * @param origin the Origin information
+     * @return the labeled term or the same term, if no origin term label factory is present
+     */
     public Term addLabelToAllSubs(Term term, OriginTermLabel.Origin origin) {
         final OriginTermLabelFactory originFactory = services.getOriginFactory();
         if (originFactory != null) {
@@ -2274,6 +2284,14 @@ public class TermBuilder {
         return term;
     }
 
+    /**
+     * add origin information to the term
+     * nothing will be done if no origin term label factory is present
+     *
+     * @param term the term where to add the origin information
+     * @param origin the Origin information
+     * @return the labeled term or the same term, if no origin term label factory is present
+     */
     public Term addLabel(Term term, OriginTermLabel.Origin origin) {
         final OriginTermLabelFactory originFactory = services.getOriginFactory();
         if (originFactory != null) {
@@ -2282,7 +2300,11 @@ public class TermBuilder {
         return term;
     }
 
-
+    /**
+     * returns the origin term label factory
+     *
+     * @return the OriginTermLabelFactory
+     */
     public OriginTermLabelFactory getOriginFactory() {
         return services.getOriginFactory();
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabel.java
@@ -137,7 +137,7 @@ public class OriginTermLabel implements TermLabel {
      * @param origin the term's origin.
      * @param subtermOrigins the origins of the term's (former) subterms.
      */
-     OriginTermLabel(Origin origin, Set<Origin> subtermOrigins) {
+    OriginTermLabel(Origin origin, Set<Origin> subtermOrigins) {
         this(origin);
         this.subtermOrigins.addAll(subtermOrigins);
         this.subtermOrigins.removeIf(o -> o.specType == SpecType.NONE);
@@ -150,7 +150,7 @@ public class OriginTermLabel implements TermLabel {
      *
      * @param subtermOrigins the origins of the term's (former) subterms.
      */
-     OriginTermLabel(Set<Origin> subtermOrigins) {
+    OriginTermLabel(Set<Origin> subtermOrigins) {
         this.origin = new Origin(SpecType.NONE);
         this.subtermOrigins = new LinkedHashSet<>(subtermOrigins);
         this.subtermOrigins.removeIf(o -> o.specType == SpecType.NONE);

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabel.java
@@ -126,7 +126,7 @@ public class OriginTermLabel implements TermLabel {
      *
      * @param origin the term's origin.
      */
-    public OriginTermLabel(Origin origin) {
+    OriginTermLabel(Origin origin) {
         this.origin = origin;
         this.subtermOrigins = new LinkedHashSet<>();
     }
@@ -137,7 +137,7 @@ public class OriginTermLabel implements TermLabel {
      * @param origin the term's origin.
      * @param subtermOrigins the origins of the term's (former) subterms.
      */
-    public OriginTermLabel(Origin origin, Set<Origin> subtermOrigins) {
+     OriginTermLabel(Origin origin, Set<Origin> subtermOrigins) {
         this(origin);
         this.subtermOrigins.addAll(subtermOrigins);
         this.subtermOrigins.removeIf(o -> o.specType == SpecType.NONE);
@@ -150,7 +150,7 @@ public class OriginTermLabel implements TermLabel {
      *
      * @param subtermOrigins the origins of the term's (former) subterms.
      */
-    public OriginTermLabel(Set<Origin> subtermOrigins) {
+     OriginTermLabel(Set<Origin> subtermOrigins) {
         this.origin = new Origin(SpecType.NONE);
         this.subtermOrigins = new LinkedHashSet<>(subtermOrigins);
         this.subtermOrigins.removeIf(o -> o.specType == SpecType.NONE);

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabelFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/OriginTermLabelFactory.java
@@ -23,6 +23,29 @@ import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
  */
 public class OriginTermLabelFactory implements TermLabelFactory<OriginTermLabel> {
 
+    public OriginTermLabel createOriginTermLabel(Origin origin) {
+        return new OriginTermLabel(origin);
+    }
+
+    /**
+     * Creates a new {@link OriginTermLabel}.
+     *
+     * @param origin the term's origin.
+     * @param subtermOrigins the origins of the term's (former) subterms.
+     */
+    public OriginTermLabel createOriginTermLabel(Origin origin, Set<Origin> subtermOrigins) {
+        return new OriginTermLabel(origin, subtermOrigins);
+    }
+
+    /**
+     * Creates a new {@link OriginTermLabel}.
+     *
+     * @param subtermOrigins the origins of the term's (former) subterms.
+     */
+    public OriginTermLabel createOriginTermLabel(Set<Origin> subtermOrigins) {
+        return new OriginTermLabel(subtermOrigins);
+    }
+
     @Override
     public OriginTermLabel parseInstance(List<String> arguments, TermServices services)
             throws TermLabelException {

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabel.java
@@ -3,15 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic.label;
 
-import java.util.stream.Collectors;
-
-import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.Named;
 import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.TermFactory;
 import de.uka.ilkd.key.logic.label.TermLabelManager.TermLabelConfiguration;
 import de.uka.ilkd.key.logic.op.Modality;
 import de.uka.ilkd.key.proof.init.AbstractProfile;
@@ -23,9 +19,6 @@ import de.uka.ilkd.key.rule.label.TermLabelPolicy;
 import de.uka.ilkd.key.rule.label.TermLabelRefactoring;
 import de.uka.ilkd.key.rule.label.TermLabelRefactoring.RefactoringScope;
 import de.uka.ilkd.key.rule.label.TermLabelUpdate;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
-
-import org.key_project.util.collection.ImmutableArray;
 
 // spotless:off     // this protects the JavaDoc from automatic reformatting
 /**
@@ -174,39 +167,6 @@ import org.key_project.util.collection.ImmutableArray;
  */
 // spotless:on
 public interface TermLabel extends Named {
-
-    /**
-     * Remove all irrelevant labels from a term.
-     *
-     * @param term the term to transform.
-     * @param services services.
-     * @return the transformed term.
-     * @see #isProofRelevant()
-     */
-    static Term removeIrrelevantLabels(Term term, Services services) {
-        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
-                .getUseOriginLabels()) {
-            return term;
-        } else {
-            return removeIrrelevantLabels(term, services.getTermFactory());
-        }
-    }
-
-    /**
-     * Remove all irrelevant labels from a term.
-     *
-     * @param term the term to transform.
-     * @param tf a term factory.
-     * @return the transformed term.
-     * @see #isProofRelevant()
-     */
-    static Term removeIrrelevantLabels(Term term, TermFactory tf) {
-        return tf.createTerm(term.op(),
-            new ImmutableArray<>(term.subs().stream().map(t -> removeIrrelevantLabels(t, tf))
-                    .collect(Collectors.toList())),
-            term.boundVars(), term.javaBlock(), new ImmutableArray<>(term.getLabels().stream()
-                    .filter(TermLabel::isProofRelevant).collect(Collectors.toList())));
-    }
 
     /**
      * Retrieves the i-th parameter object of this term label.

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
@@ -19,7 +19,6 @@ import de.uka.ilkd.key.rule.Rule;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.label.*;
 import de.uka.ilkd.key.rule.label.ChildTermLabelPolicy;
-import de.uka.ilkd.key.rule.label.OriginTermLabelRefactoring;
 import de.uka.ilkd.key.rule.label.TermLabelMerger;
 import de.uka.ilkd.key.rule.label.TermLabelPolicy;
 import de.uka.ilkd.key.rule.label.TermLabelRefactoring;
@@ -2208,7 +2207,7 @@ public class TermLabelManager {
      * @param term the term to transform.
      * @param services services.
      * @return the transformed term.
-     * @see #isProofRelevant()
+     * @see TermLabel#isProofRelevant()
      */
     public static Term removeIrrelevantLabels(Term term, Services services) {
         if (services.getTermBuilder().getOriginFactory() == null) {
@@ -2224,7 +2223,7 @@ public class TermLabelManager {
      * @param term the term to transform.
      * @param tf a term factory.
      * @return the transformed term.
-     * @see #isProofRelevant()
+     * @see TermLabel#isProofRelevant()
      */
     public static Term removeIrrelevantLabels(Term term, TermFactory tf) {
         return tf.createTerm(term.op(),
@@ -2232,15 +2231,5 @@ public class TermLabelManager {
                     .collect(Collectors.toList())),
             term.boundVars(), term.javaBlock(), new ImmutableArray<>(term.getLabels().stream()
                     .filter(TermLabel::isProofRelevant).collect(Collectors.toList())));
-    }
-
-    /**
-     * Fully disable origin tracking. This will remove the {@link OriginTermLabelRefactoring} from
-     * the manager.
-     */
-    public void disableOriginLabelRefactorings() {
-        allRulesRefactorings = ImmutableList.fromList(
-            allRulesRefactorings.stream().filter(x -> !(x instanceof OriginTermLabelRefactoring))
-                    .collect(Collectors.toList()));
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
@@ -2203,6 +2203,38 @@ public class TermLabelManager {
     }
 
     /**
+     * Remove all irrelevant labels from a term.
+     *
+     * @param term the term to transform.
+     * @param services services.
+     * @return the transformed term.
+     * @see #isProofRelevant()
+     */
+    public static Term removeIrrelevantLabels(Term term, Services services) {
+        if (services.getTermBuilder().getOriginFactory() == null) {
+            return term;
+        } else {
+            return removeIrrelevantLabels(term, services.getTermFactory());
+        }
+    }
+
+    /**
+     * Remove all irrelevant labels from a term.
+     *
+     * @param term the term to transform.
+     * @param tf a term factory.
+     * @return the transformed term.
+     * @see #isProofRelevant()
+     */
+    public static Term removeIrrelevantLabels(Term term, TermFactory tf) {
+        return tf.createTerm(term.op(),
+            new ImmutableArray<>(term.subs().stream().map(t -> removeIrrelevantLabels(t, tf))
+                    .collect(Collectors.toList())),
+            term.boundVars(), term.javaBlock(), new ImmutableArray<>(term.getLabels().stream()
+                    .filter(TermLabel::isProofRelevant).collect(Collectors.toList())));
+    }
+
+    /**
      * Fully disable origin tracking. This will remove the {@link OriginTermLabelRefactoring} from
      * the manager.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/NodeInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/NodeInfo.java
@@ -18,7 +18,7 @@ import de.uka.ilkd.key.logic.ProgramPrefix;
 import de.uka.ilkd.key.logic.SequentChangeInfo;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.rule.AbstractAuxiliaryContractBuiltInRuleApp;
 import de.uka.ilkd.key.rule.AbstractContractRuleApp;
@@ -331,10 +331,10 @@ public class NodeInfo {
                     res = arg; // use sv name instead
                 } else {
                     if (val instanceof Term) {
-                        val = TermLabel.removeIrrelevantLabels((Term) val,
+                        val = TermLabelManager.removeIrrelevantLabels((Term) val,
                             node.proof().getServices());
                     } else if (val instanceof TermInstantiation) {
-                        val = TermLabel.removeIrrelevantLabels(
+                        val = TermLabelManager.removeIrrelevantLabels(
                             ((TermInstantiation) val).getInstantiation(),
                             node.proof().getServices());
                     }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -204,11 +204,6 @@ public class Proof implements Named {
             InitConfig initConfig) {
         this(new Name(name), initConfig);
 
-        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
-                .getUseOriginLabels()) {
-            problem = OriginTermLabel.removeOriginLabels(problem, getServices()).sequent();
-        }
-
         register(new ProofJavaSourceCollection(), ProofJavaSourceCollection.class);
         var rootNode = new Node(this, problem);
         var sources = lookup(ProofJavaSourceCollection.class);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -16,8 +16,6 @@ import javax.swing.*;
 import de.uka.ilkd.key.java.JavaInfo;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.*;
-import de.uka.ilkd.key.logic.label.OriginTermLabel;
-import de.uka.ilkd.key.logic.label.OriginTermLabel.FileOrigin;
 import de.uka.ilkd.key.pp.AbbrevMap;
 import de.uka.ilkd.key.proof.event.ProofDisposedEvent;
 import de.uka.ilkd.key.proof.event.ProofDisposedListener;
@@ -204,28 +202,9 @@ public class Proof implements Named {
             InitConfig initConfig) {
         this(new Name(name), initConfig);
 
-        register(new ProofJavaSourceCollection(), ProofJavaSourceCollection.class);
-        var rootNode = new Node(this, problem);
-        var sources = lookup(ProofJavaSourceCollection.class);
+        final var rootNode = new Node(this, problem);
 
-        rootNode.sequent().forEach(formula -> {
-            OriginTermLabel originLabel =
-                (OriginTermLabel) formula.formula().getLabel(OriginTermLabel.NAME);
-            if (originLabel != null) {
-                if (originLabel.getOrigin() instanceof FileOrigin) {
-                    ((FileOrigin) originLabel.getOrigin())
-                            .getFileName()
-                            .ifPresent(sources::addRelevantFile);
-                }
-
-                originLabel.getSubtermOrigins().stream()
-                        .filter(o -> o instanceof FileOrigin)
-                        .map(o -> (FileOrigin) o)
-                        .forEach(o -> o.getFileName().ifPresent(sources::addRelevantFile));
-            }
-        });
-
-        var firstGoal =
+        final var firstGoal =
             new Goal(rootNode, rules, new BuiltInRuleAppIndex(builtInRules), getServices());
         openGoals = openGoals.prepend(firstGoal);
         setRoot(rootNode);
@@ -233,15 +212,6 @@ public class Proof implements Named {
         if (closed()) {
             fireProofClosed();
         }
-    }
-
-    public Proof(String name, Term problem, String header, InitConfig initConfig, File proofFile) {
-        this(name,
-            Sequent.createSuccSequent(
-                Semisequent.EMPTY_SEMISEQUENT.insert(0, new SequentFormula(problem)).semisequent()),
-            initConfig.createTacletIndex(), initConfig.createBuiltInRuleIndex(), initConfig);
-        problemHeader = header;
-        this.proofFile = proofFile;
     }
 
     public Proof(String name, Sequent problem, String header, InitConfig initConfig,

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofJavaSourceCollection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofJavaSourceCollection.java
@@ -33,6 +33,8 @@ public class ProofJavaSourceCollection {
     /** @see #getRelevantFiles() */
     private ImmutableSet<URI> relevantFiles = DefaultImmutableSet.nil();
 
+    public ProofJavaSourceCollection() {}
+
     /**
      * <p>
      * Returns a set containing URIs of all files relevant to this proof.

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ReplacementMap.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ReplacementMap.java
@@ -10,9 +10,9 @@ import java.util.Set;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermFactory;
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.SVSubstitute;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.settings.TermLabelSettings;
 import de.uka.ilkd.key.util.LinkedHashMap;
 
@@ -38,7 +38,10 @@ public interface ReplacementMap<S extends SVSubstitute, T> extends Map<S, T> {
      */
     static <S extends SVSubstitute, T> ReplacementMap<S, T> create(TermFactory tf,
             Proof proof) {
-        if (ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()) {
+        var noIrrelevantTermLabelsMap = proof == null
+                ? ProofSettings.DEFAULT_SETTINGS.getTermLabelSettings().getUseOriginLabels()
+                : proof.getServices().getTermBuilder().getOriginFactory() != null;
+        if (noIrrelevantTermLabelsMap) {
             return new NoIrrelevantLabelsReplacementMap<>(tf);
         } else {
             return new DefaultReplacementMap<>();
@@ -120,7 +123,7 @@ public interface ReplacementMap<S extends SVSubstitute, T> extends Map<S, T> {
         @SuppressWarnings("unchecked")
         private <R> R wrap(R obj) {
             if (obj instanceof Term) {
-                return (R) TermLabel.removeIrrelevantLabels((Term) obj, tf);
+                return (R) TermLabelManager.removeIrrelevantLabels((Term) obj, tf);
             } else {
                 return obj;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractOperationPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractOperationPO.java
@@ -618,7 +618,7 @@ public abstract class AbstractOperationPO extends AbstractPO {
         Term result = tb.and(wellFormed != null ? wellFormed : tb.tt(), selfNotNull, selfCreated,
             selfExactType, paramsOK, mbyAtPreDef);
 
-        return tb.addLabelToAllSubs(result, new OriginTermLabel(new Origin(SpecType.REQUIRES)));
+        return tb.addLabelToAllSubs(result, new Origin(SpecType.REQUIRES));
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.proof.JavaModel;
@@ -22,6 +23,7 @@ import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
 import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.RewriteTaclet;
 import de.uka.ilkd.key.rule.Taclet;
+import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.util.Pair;
 
@@ -67,6 +69,10 @@ public abstract class AbstractPO implements IPersistablePO {
     protected AbstractPO(InitConfig initConfig, String name) {
         this.environmentConfig = initConfig;
         this.environmentServices = initConfig.getServices();
+        this.environmentServices.setOriginFactory(
+                ProofSettings.DEFAULT_SETTINGS.getTermLabelSettings().getUseOriginLabels() ?
+                        new OriginTermLabelFactory() : null
+        );
         this.javaInfo = initConfig.getServices().getJavaInfo();
         this.heapLDT = initConfig.getServices().getTypeConverter().getHeapLDT();
         this.specRepos = initConfig.getServices().getSpecificationRepository();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
-import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.proof.JavaModel;
@@ -23,7 +22,6 @@ import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
 import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.RewriteTaclet;
 import de.uka.ilkd.key.rule.Taclet;
-import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.util.Pair;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
@@ -69,10 +69,6 @@ public abstract class AbstractPO implements IPersistablePO {
     protected AbstractPO(InitConfig initConfig, String name) {
         this.environmentConfig = initConfig;
         this.environmentServices = initConfig.getServices();
-        this.environmentServices.setOriginFactory(
-                ProofSettings.DEFAULT_SETTINGS.getTermLabelSettings().getUseOriginLabels() ?
-                        new OriginTermLabelFactory() : null
-        );
         this.javaInfo = initConfig.getServices().getJavaInfo();
         this.heapLDT = initConfig.getServices().getTypeConverter().getHeapLDT();
         this.specRepos = initConfig.getServices().getSpecificationRepository();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.java.reference.TypeRef;
 import de.uka.ilkd.key.java.statement.MethodBodyStatement;
 import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.Origin;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
 import de.uka.ilkd.key.logic.label.SymbolicExecutionTermLabel;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
@@ -256,8 +256,7 @@ public class FunctionalOperationContractPO extends AbstractOperationPO implement
             }
         }
 
-        return tb.addLabelToAllSubs(frameTerm,
-            new OriginTermLabel(new Origin(SpecType.ASSIGNABLE)));
+        return tb.addLabelToAllSubs(frameTerm, new Origin(SpecType.ASSIGNABLE));
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.NamespaceSet;
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.GenericSort;
 import de.uka.ilkd.key.logic.sort.Sort;
@@ -517,6 +518,14 @@ public final class ProblemInitializer {
         // create initConfig
         InitConfig initConfig = referenceConfig.copy();
 
+        var settings = initConfig.getSettings();
+        if (settings == null) {
+            settings = ProofSettings.DEFAULT_SETTINGS;
+        }
+        initConfig.getServices().setOriginFactory(
+            settings.getTermLabelSettings().getUseOriginLabels() ?
+                        new OriginTermLabelFactory() : null
+        );
 
         // read Java
         readJava(envInput, initConfig);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -34,6 +34,7 @@ import de.uka.ilkd.key.proof.mgt.AxiomJustification;
 import de.uka.ilkd.key.rule.BuiltInRule;
 import de.uka.ilkd.key.rule.Rule;
 import de.uka.ilkd.key.rule.Taclet;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.Debug;
@@ -572,7 +573,7 @@ public final class ProblemInitializer {
 
             // TODO: Why: ProofIndependentSetting and ProofSettings do not agree on termlabels
             initConfig.getServices().setOriginFactory(
-                initConfig.getSettings().getTermLabelSettings().getUseOriginLabels()
+                    ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()
                         ? new OriginTermLabelFactory()
                         : null);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -572,7 +572,7 @@ public final class ProblemInitializer {
 
             // TODO: Why: ProofIndependentSetting and ProofSettings do not agree on termlabels
             initConfig.getServices().setOriginFactory(
-                false && initConfig.getSettings().getTermLabelSettings().getUseOriginLabels()
+                initConfig.getSettings().getTermLabelSettings().getUseOriginLabels()
                         ? new OriginTermLabelFactory()
                         : null);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -454,6 +454,7 @@ public final class ProblemInitializer {
                 cleanupNamespaces(currentBaseConfig);
                 baseConfig = currentBaseConfig;
             }
+
             InitConfig ic = prepare(envInput, currentBaseConfig);
             if (Debug.ENABLE_DEBUG) {
                 print(ic);
@@ -518,14 +519,6 @@ public final class ProblemInitializer {
         // create initConfig
         InitConfig initConfig = referenceConfig.copy();
 
-        var settings = initConfig.getSettings();
-        if (settings == null) {
-            settings = ProofSettings.DEFAULT_SETTINGS;
-        }
-        initConfig.getServices().setOriginFactory(
-            settings.getTermLabelSettings().getUseOriginLabels() ? new OriginTermLabelFactory()
-                    : null);
-
         // read Java
         readJava(envInput, initConfig);
 
@@ -576,6 +569,12 @@ public final class ProblemInitializer {
         try {
             // determine environment
             initConfig = determineEnvironment(po, Objects.requireNonNull(initConfig));
+
+            // TODO: Why: ProofIndependentSetting and ProofSettings do not agree on termlabels
+            initConfig.getServices().setOriginFactory(
+                false && initConfig.getSettings().getTermLabelSettings().getUseOriginLabels()
+                        ? new OriginTermLabelFactory()
+                        : null);
 
             // read problem
             reportStatus("Loading problem \"" + po.name() + "\"");

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -573,9 +573,10 @@ public final class ProblemInitializer {
 
             // TODO: Why: ProofIndependentSetting and ProofSettings do not agree on termlabels
             initConfig.getServices().setOriginFactory(
-                    ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels()
-                        ? new OriginTermLabelFactory()
-                        : null);
+                ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
+                        .getUseOriginLabels()
+                                ? new OriginTermLabelFactory()
+                                : null);
 
             // read problem
             reportStatus("Loading problem \"" + po.name() + "\"");

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -523,9 +523,8 @@ public final class ProblemInitializer {
             settings = ProofSettings.DEFAULT_SETTINGS;
         }
         initConfig.getServices().setOriginFactory(
-            settings.getTermLabelSettings().getUseOriginLabels() ?
-                        new OriginTermLabelFactory() : null
-        );
+            settings.getTermLabelSettings().getUseOriginLabels() ? new OriginTermLabelFactory()
+                    : null);
 
         // read Java
         readJava(envInput, initConfig);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/RewriteTacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/RewriteTacletExecutor.java
@@ -105,7 +105,6 @@ public class RewriteTacletExecutor<TacletKind extends RewriteTaclet>
         if (gt instanceof RewriteTacletGoalTemplate) {
             final SequentFormula cf = applyReplacewithHelper(goal, termLabelState,
                 (RewriteTacletGoalTemplate) gt, posOfFind, services, matchCond, ruleApp);
-
             currentSequent.combine(currentSequent.sequent().changeFormula(cf, posOfFind));
         } else {
             // Then there was no replacewith...

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelPolicy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelPolicy.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.Rule;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 import org.key_project.util.collection.ImmutableArray;
 
@@ -38,8 +37,7 @@ public class OriginTermLabelPolicy implements TermLabelPolicy {
             return label;
         }
 
-        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
-                .getUseOriginLabels()) {
+        if (services.getTermBuilder().getOriginFactory() == null) {
             return null;
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelRefactoring.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelRefactoring.java
@@ -22,7 +22,6 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.BuiltInRule;
 import de.uka.ilkd.key.rule.Rule;
 import de.uka.ilkd.key.rule.Taclet;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
@@ -81,8 +80,7 @@ public class OriginTermLabelRefactoring implements TermLabelRefactoring {
             }
         }
 
-        if (!ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings()
-                .getUseOriginLabels()) {
+        if (services.getTermBuilder().getOriginFactory() == null) {
             if (oldLabel != null) {
                 labels.remove(oldLabel);
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelRefactoring.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/label/OriginTermLabelRefactoring.java
@@ -14,6 +14,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.Origin;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.logic.label.TermLabelState;
 import de.uka.ilkd.key.proof.FormulaTag;
@@ -89,15 +90,16 @@ public class OriginTermLabelRefactoring implements TermLabelRefactoring {
         }
 
         Set<Origin> subtermOrigins = collectSubtermOrigins(term.subs(), new LinkedHashSet<>());
-
+        OriginTermLabelFactory factory = services.getTermBuilder().getOriginFactory();
         OriginTermLabel newLabel = null;
         if (oldLabel != null) {
             labels.remove(oldLabel);
             final Origin oldOrigin = oldLabel.getOrigin();
-            newLabel = new OriginTermLabel(oldOrigin, subtermOrigins);
+            newLabel = factory.createOriginTermLabel(oldOrigin, subtermOrigins);
         } else if (!subtermOrigins.isEmpty()) {
             final Origin commonOrigin = OriginTermLabel.computeCommonOrigin(subtermOrigins);
-            newLabel = new OriginTermLabel(commonOrigin, subtermOrigins);
+
+            newLabel = factory.createOriginTermLabel(commonOrigin, subtermOrigins);
         }
 
         if (newLabel != null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Monomial.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Monomial.java
@@ -10,7 +10,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.logic.LexPathOrdering;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.AbstractTermTransformer;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.util.Debug;
@@ -36,7 +36,7 @@ public class Monomial {
 
     public static Monomial create(Term monoTerm, Services services) {
         final LRUCache<Term, Monomial> monomialCache = services.getCaches().getMonomialCache();
-        monoTerm = TermLabel.removeIrrelevantLabels(monoTerm, services);
+        monoTerm = TermLabelManager.removeIrrelevantLabels(monoTerm, services);
         Monomial res;
 
         synchronized (monomialCache) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Polynomial.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Polynomial.java
@@ -10,7 +10,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.TypeConverter;
 import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.AbstractTermTransformer;
 import de.uka.ilkd.key.logic.op.Operator;
 
@@ -49,7 +49,7 @@ public class Polynomial {
 
     public static Polynomial create(Term polyTerm, Services services) {
         final LRUCache<Term, Polynomial> cache = services.getCaches().getPolynomialCache();
-        polyTerm = TermLabel.removeIrrelevantLabels(polyTerm, services);
+        polyTerm = TermLabelManager.removeIrrelevantLabels(polyTerm, services);
 
         Polynomial res;
         synchronized (cache) {

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/ContractFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/ContractFactory.java
@@ -489,7 +489,7 @@ public class ContractFactory {
                             Set<Origin> origins = new HashSet<>();
                             origins.add(o1);
                             origins.add(o2);
-                            uol = new OriginTermLabel(origins);
+                            uol = tb.getOriginFactory().createOriginTermLabel(origins);
                             newLabels.add(uol);
                             break;
                         }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
@@ -282,7 +282,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
             Position pos = comments[0].getStartPosition();
 
             // call preparser
-            var parser = new PreParser();
+            var parser = new PreParser(services.getOriginFactory() != null);
             ImmutableList<TextualJMLConstruct> constructs =
                 parser.parseClassLevel(concatenatedComment, fileName, pos);
             warnings = warnings.append(parser.getWarnings());
@@ -356,7 +356,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
             Position pos = comments[0].getStartPosition();
 
             // call preparser
-            PreParser parser = new PreParser();
+            PreParser parser = new PreParser(services.getOriginFactory() != null);
             constructs = parser.parseClassLevel(concatenatedComment, fileName, pos);
             warnings = warnings.append(parser.getWarnings());
         } else {
@@ -653,7 +653,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
         }
         final String concatenatedComment = concatenate(comments);
         final Position position = comments[0].getStartPosition();
-        final var parser = new PreParser();
+        final var parser = new PreParser(services.getOriginFactory() != null);
         final ImmutableList<TextualJMLConstruct> constructs =
             parser.parseMethodLevel(concatenatedComment, fileName, position);
         warnings = warnings.append(parser.getWarnings());
@@ -684,7 +684,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
         Position pos = comments[0].getStartPosition();
 
         // call preparser
-        var parser = new PreParser();
+        var parser = new PreParser(services.getOriginFactory() != null);
         ImmutableList<TextualJMLConstruct> constructs =
             parser.parseMethodLevel(concatenatedComment, fileName, pos);
         warnings = warnings.append(parser.getWarnings());

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.ProgramElementName;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermBuilder;
-import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.Origin;
 import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
@@ -839,7 +839,7 @@ public class JMLSpecFactory {
                     Term excNull = tb.addLabelToAllSubs(
                         (tb.label(tb.equals(tb.var(progVars.excVar), tb.NULL()),
                             ParameterlessTermLabel.IMPLICIT_SPECIFICATION_LABEL)),
-                        new OriginTermLabel(new Origin(SpecType.ENSURES)));
+                        new Origin(SpecType.ENSURES));
                     Term post1 = (originalBehavior == Behavior.NORMAL_BEHAVIOR
                             ? tb.convertToFormula(clauses.ensures.get(heap))
                             : tb.imp(excNull, tb.convertToFormula(clauses.ensures.get(heap))));

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
@@ -138,8 +138,7 @@ public class JmlIO {
     }
 
     private Term attachTermLabel(Term term, OriginTermLabel.SpecType type) {
-        return services.getTermBuilder().addLabel(term,
-            new OriginTermLabel(new OriginTermLabel.Origin(type)));
+        return services.getTermBuilder().addLabel(term,  new OriginTermLabel.Origin(type));
     }
 
 
@@ -215,7 +214,7 @@ public class JmlIO {
      */
     public Term translateTerm(LabeledParserRuleContext expr, OriginTermLabel.SpecType type) {
         Term term = translateTerm(expr.first);
-        OriginTermLabel origin = new OriginTermLabel(new OriginTermLabel.Origin(type));
+        OriginTermLabel.Origin origin = new OriginTermLabel.Origin(type);
         if (expr.second != null) {
             return services.getTermBuilder().addLabel(term, expr.second);
         } else {

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
@@ -138,7 +138,7 @@ public class JmlIO {
     }
 
     private Term attachTermLabel(Term term, OriginTermLabel.SpecType type) {
-        return services.getTermBuilder().addLabel(term,  new OriginTermLabel.Origin(type));
+        return services.getTermBuilder().addLabel(term, new OriginTermLabel.Origin(type));
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
@@ -40,7 +40,14 @@ public class LabeledParserRuleContext {
         second = null;
     }
 
-    public LabeledParserRuleContext(ParserRuleContext ctx, OriginTermLabel.SpecType specType) {
+    public static LabeledParserRuleContext createLabeledParserRuleContext(ParserRuleContext ctx,
+            OriginTermLabel.SpecType specType, boolean attachOriginLabel) {
+        return attachOriginLabel
+                ? new LabeledParserRuleContext(ctx, constructTermLabel(ctx, specType))
+                : new LabeledParserRuleContext(ctx);
+    }
+
+    private LabeledParserRuleContext(ParserRuleContext ctx, OriginTermLabel.SpecType specType) {
         this(ctx, constructTermLabel(ctx, specType));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.util.MiscTools;
 
@@ -48,6 +49,6 @@ public class LabeledParserRuleContext {
         URI filename = MiscTools.getURIFromTokenSource(ctx.start.getTokenSource());
         int line = ctx.start.getLine();
         OriginTermLabel.Origin origin = new OriginTermLabel.FileOrigin(specType, filename, line);
-        return new OriginTermLabel(origin);
+        return new OriginTermLabelFactory().createOriginTermLabel(origin);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/PreParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/PreParser.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 
 import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.parser.Location;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 
@@ -22,8 +23,12 @@ public class PreParser {
     /** warnings */
     private ImmutableList<PositionedString> warnings = ImmutableSLList.nil();
 
+    private boolean attachOrigin;
+
     /** constructor */
-    public PreParser() {}
+    public PreParser(boolean attachOrigin) {
+        this.attachOrigin = attachOrigin;
+    }
 
     /**
      * Parses a JML constructs on class level, e.g., invariants and methods contracts, and returns a
@@ -35,7 +40,8 @@ public class PreParser {
         JmlParser.Classlevel_commentsContext ctx = p.classlevel_comments();
         p.getErrorReporter().throwException();
         jmlCheck(ctx);
-        TextualTranslator translator = new TextualTranslator();
+        TextualTranslator translator = new TextualTranslator(
+            ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels());
         ctx.accept(translator);
         return translator.constructs;
     }
@@ -76,7 +82,8 @@ public class PreParser {
         JmlParser.Methodlevel_commentContext ctx = p.methodlevel_comment();
         p.getErrorReporter().throwException();
         jmlCheck(ctx);
-        TextualTranslator translator = new TextualTranslator();
+        TextualTranslator translator = new TextualTranslator(
+            ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels());
         ctx.accept(translator);
         return translator.constructs;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
@@ -23,6 +23,8 @@ import static de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLSpecCase.Cla
 import static de.uka.ilkd.key.speclang.njml.Translator.raiseError;
 
 class TextualTranslator extends JmlParserBaseVisitor<Object> {
+    private final boolean attachOriginLabel;
+
     public ImmutableList<TextualJMLConstruct> constructs = ImmutableSLList.nil();
     private ImmutableList<JMLModifier> mods = ImmutableSLList.nil();
     @Nullable
@@ -69,6 +71,10 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         case JmlLexer.CODE_BIGINT_MATH -> JMLModifier.CODE_BIGINT_MATH;
         default -> throw new IllegalStateException("Illegal token is given");
         };
+    }
+
+    public TextualTranslator(boolean attachOriginLabel) {
+        this.attachOriginLabel = attachOriginLabel;
     }
 
     @Override
@@ -157,8 +163,10 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         assert methodContract != null;
         Name[] heaps = visitTargetHeap(ctx.targetHeap());
         final boolean isFree = ctx.ENSURES().getText().endsWith("_free");
-        final LabeledParserRuleContext ctx2 = new LabeledParserRuleContext(ctx,
-            isFree ? OriginTermLabel.SpecType.ENSURES_FREE : OriginTermLabel.SpecType.ENSURES);
+        final LabeledParserRuleContext ctx2 =
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                isFree ? OriginTermLabel.SpecType.ENSURES_FREE : OriginTermLabel.SpecType.ENSURES,
+                attachOriginLabel);
         for (Name heap : heaps) {
             methodContract.addClause(isFree ? ENSURES_FREE : ENSURES, heap, ctx2);
         }
@@ -171,9 +179,13 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         Name[] heaps = visitTargetHeap(ctx.targetHeap());
         for (Name heap : heaps) {
             final boolean isFree = ctx.REQUIRES().getText().endsWith("_free");
+
             LabeledParserRuleContext ctx2 =
-                new LabeledParserRuleContext(ctx, isFree ? OriginTermLabel.SpecType.REQUIRES_FREE
-                        : OriginTermLabel.SpecType.REQUIRES);
+                LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                    isFree ? OriginTermLabel.SpecType.REQUIRES_FREE
+                            : OriginTermLabel.SpecType.REQUIRES,
+                    attachOriginLabel);
+
             methodContract.addClause(isFree ? REQUIRES_FREE : REQUIRES, heap, ctx2);
         }
         return null;
@@ -183,7 +195,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitMeasured_by_clause(JmlParser.Measured_by_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(MEASURED_BY,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.MEASURED_BY));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.MEASURED_BY, attachOriginLabel));
         return null;
     }
 
@@ -224,7 +237,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         boolean depends = ctx.MEASURED_BY() != null || ctx.COLON() != null;
         Name[] heaps = visitTargetHeap(ctx.targetHeap());
         final LabeledParserRuleContext ctx2 =
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.ACCESSIBLE);
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.ACCESSIBLE, attachOriginLabel);
         for (Name heap : heaps) {
             if (depends) {
                 TextualJMLDepends d = new TextualJMLDepends(mods, heaps, ctx2);
@@ -244,9 +258,11 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         final boolean isFree =
             ctx.ASSIGNABLE() != null && ctx.ASSIGNABLE().getText().endsWith("_free")
                     || ctx.MODIFIES() != null && ctx.MODIFIES().getText().endsWith("_free");
-        final LabeledParserRuleContext ctx2 = new LabeledParserRuleContext(ctx, isFree
-                ? OriginTermLabel.SpecType.ASSIGNABLE_FREE
-                : OriginTermLabel.SpecType.ASSIGNABLE);
+        final LabeledParserRuleContext ctx2 =
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx, isFree
+                    ? OriginTermLabel.SpecType.ASSIGNABLE_FREE
+                    : OriginTermLabel.SpecType.ASSIGNABLE,
+                attachOriginLabel);
         for (Name heap : heaps) {
             if (methodContract != null) {
                 methodContract.addClause(isFree ? ASSIGNABLE_FREE : ASSIGNABLE, heap, ctx2);
@@ -264,7 +280,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     @Override
     public Object visitVariant_function(JmlParser.Variant_functionContext ctx) {
         final LabeledParserRuleContext ctx2 =
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.DECREASES);
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.DECREASES, attachOriginLabel);
         if (loopContract != null) {
             loopContract.setVariant(ctx2);
         } else {
@@ -326,7 +343,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitSignals_clause(JmlParser.Signals_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(SIGNALS,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.SIGNALS));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.SIGNALS, attachOriginLabel));
         return this;
     }
 
@@ -334,7 +352,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitSignals_only_clause(JmlParser.Signals_only_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(SIGNALS_ONLY,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.SIGNALS_ONLY));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.SIGNALS_ONLY, attachOriginLabel));
         return null;
     }
 
@@ -342,7 +361,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitBreaks_clause(JmlParser.Breaks_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(BREAKS,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.BREAKS));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.BREAKS, attachOriginLabel));
         return null;
     }
 
@@ -350,7 +370,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitContinues_clause(JmlParser.Continues_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(CONTINUES,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.CONTINUES));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.CONTINUES, attachOriginLabel));
         return null;
     }
 
@@ -358,7 +379,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitReturns_clause(JmlParser.Returns_clauseContext ctx) {
         assert methodContract != null;
         methodContract.addClause(RETURNS,
-            new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.RETURNS));
+            LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                OriginTermLabel.SpecType.RETURNS, attachOriginLabel));
         return null;
     }
 
@@ -458,9 +480,10 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         Name[] heaps = visitTargetHeap(ctx.targetHeap());
         for (Name heap : heaps) {
             loopContract.addClause(type, heap,
-                new LabeledParserRuleContext(ctx,
+                LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
                     isFree ? OriginTermLabel.SpecType.LOOP_INVARIANT_FREE
-                            : OriginTermLabel.SpecType.LOOP_INVARIANT));
+                            : OriginTermLabel.SpecType.LOOP_INVARIANT,
+                    attachOriginLabel));
         }
         return null;
     }
@@ -470,7 +493,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitAssume_statement(JmlParser.Assume_statementContext ctx) {
         TextualJMLAssertStatement b =
             new TextualJMLAssertStatement(TextualJMLAssertStatement.Kind.ASSUME,
-                new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.ASSUME));
+                LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                    OriginTermLabel.SpecType.ASSUME, attachOriginLabel));
         constructs = constructs.append(b);
         return null;
     }
@@ -480,7 +504,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
     public Object visitAssert_statement(JmlParser.Assert_statementContext ctx) {
         TextualJMLAssertStatement b =
             new TextualJMLAssertStatement(TextualJMLAssertStatement.Kind.ASSERT,
-                new LabeledParserRuleContext(ctx, OriginTermLabel.SpecType.ASSERT));
+                LabeledParserRuleContext.createLabeledParserRuleContext(ctx,
+                    OriginTermLabel.SpecType.ASSERT, attachOriginLabel));
         constructs = constructs.append(b);
         return null;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggersSet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggersSet.java
@@ -15,7 +15,7 @@ import de.uka.ilkd.key.java.recoderext.ImplicitFieldAdder;
 import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.TermServices;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.Equality;
 import de.uka.ilkd.key.logic.op.IfThenElse;
 import de.uka.ilkd.key.logic.op.Junctor;
@@ -61,7 +61,7 @@ public class TriggersSet {
 
     static TriggersSet create(Term allTerm, Services services) {
         final Map<Term, TriggersSet> triggerSetCache = services.getCaches().getTriggerSetCache();
-        allTerm = TermLabel.removeIrrelevantLabels(allTerm, services);
+        allTerm = TermLabelManager.removeIrrelevantLabels(allTerm, services);
         TriggersSet trs;
 
         synchronized (triggerSetCache) {

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/ContractFactoryTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/ContractFactoryTest.java
@@ -10,7 +10,8 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
 import de.uka.ilkd.key.java.abstraction.PrimitiveType;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLSpecCase;
@@ -59,9 +60,10 @@ public class ContractFactoryTest {
             javaInfo =
                 new HelperClassForTests().parse(new File(TEST_FILE)).getFirstProof().getJavaInfo();
             services = javaInfo.getServices();
+            services.setOriginFactory(new OriginTermLabelFactory());
             testClassType = javaInfo.getKeYJavaType("testPackage.TestClass");
         }
-        preParser = new PreParser();
+        preParser = new PreParser(services.getOriginFactory() != null);
     }
 
     /**
@@ -182,6 +184,6 @@ public class ContractFactoryTest {
 
         // remove origin labels
         Term combinedMod = singleContract.getMod();
-        return TermLabel.removeIrrelevantLabels(combinedMod, services);
+        return TermLabelManager.removeIrrelevantLabels(combinedMod, services);
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLPreTranslator.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLPreTranslator.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestJMLPreTranslator {
     private ImmutableList<TextualJMLConstruct> parseMethodSpec(String ms) {
-        return new PreParser().parseClassLevel(ms);
+        return new PreParser(true).parseClassLevel(ms);
     }
 
     // region lexing

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatementTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatementTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TextualJMLAssertStatementTest {
     private static ImmutableList<TextualJMLConstruct> parseMethodLevel(String ms) {
-        return new PreParser().parseMethodLevel(ms, null, Position.newOneBased(1, 1));
+        return new PreParser(true).parseMethodLevel(ms, null, Position.newOneBased(1, 1));
     }
 
     private static void assertTextRepr(String input, String text) {

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/MethodlevelTranslatorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/MethodlevelTranslatorTest.java
@@ -79,7 +79,7 @@ public class MethodlevelTranslatorTest {
             modelMethodParameters.param_decl().stream().anyMatch(it -> it.NULLABLE() != null));
 
         // Test translation
-        final TextualTranslator translator = new TextualTranslator();
+        final TextualTranslator translator = new TextualTranslator(false);
         ctx.accept(translator);
         final var translationOpt =
             translator.constructs.stream().filter(c -> c instanceof TextualJMLMethodDecl)
@@ -128,7 +128,7 @@ public class MethodlevelTranslatorTest {
 
         // Test translation
 
-        final TextualTranslator translator = new TextualTranslator();
+        final TextualTranslator translator = new TextualTranslator(false);
         ctx.accept(translator);
         final var translationOpt =
             translator.constructs.stream().filter(c -> c instanceof TextualJMLMethodDecl)

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.java.JavaInfo;
 import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
+import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.jml.pretranslation.JMLModifier;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
@@ -37,8 +38,9 @@ public class NJmlTranslatorTests {
         JavaInfo javaInfo =
             new HelperClassForTests().parse(new File(testFile)).getFirstProof().getJavaInfo();
         Services services = javaInfo.getServices();
+        services.setOriginFactory(new OriginTermLabelFactory());
         KeYJavaType testClassType = javaInfo.getKeYJavaType("testPackage.TestClass");
-        preParser = new PreParser();
+        preParser = new PreParser(services.getOriginFactory() != null);
     }
 
     @Test

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/TextualTranslatorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/TextualTranslatorTest.java
@@ -27,7 +27,7 @@ public class TextualTranslatorTest {
         JmlLexer lexer = JmlFacade.createLexer(expr);
         JmlParser p = JmlFacade.createParser(lexer);
         JmlParser.Methodlevel_commentContext ctx = p.methodlevel_comment();
-        TextualTranslator translator = new TextualTranslator();
+        TextualTranslator translator = new TextualTranslator(true);
         ctx.accept(translator);
         final ImmutableList<TextualJMLConstruct> constructs = translator.constructs;
         assertEquals(2, constructs.size());
@@ -45,7 +45,7 @@ public class TextualTranslatorTest {
         JmlLexer lexer = JmlFacade.createLexer(expr);
         JmlParser p = JmlFacade.createParser(lexer);
         JmlParser.Methodlevel_commentContext ctx = p.methodlevel_comment();
-        TextualTranslator translator = new TextualTranslator();
+        TextualTranslator translator = new TextualTranslator(true);
         ctx.accept(translator);
         final ImmutableList<TextualJMLConstruct> constructs = translator.constructs;
         assertEquals(2, constructs.size());

--- a/key.ui/examples/performance-test/Dynamic(Dynamic__foo_08()).JML_operation_contract.0.key
+++ b/key.ui/examples/performance-test/Dynamic(Dynamic__foo_08()).JML_operation_contract.0.key
@@ -20,7 +20,7 @@
 [StrategyProperty]BLOCK_OPTIONS_KEY=BLOCK_CONTRACT_INTERNAL
 [StrategyProperty]QUERY_NEW_OPTIONS_KEY=QUERY_OFF
 [Strategy]Timeout=-1
-[Strategy]MaximumNumberOfAutomaticApplications=10000
+[Strategy]MaximumNumberOfAutomaticApplications=12000
 [SMTSettings]integersMaximum=2147483645
 [Choice]DefaultChoices=Strings-Strings\\:on , reach-reach\\:on , JavaCard-JavaCard\\:on , assertions-assertions\\:on , bigint-bigint\\:on , programRules-programRules\\:Java , intRules-intRules\\:arithmeticSemanticsIgnoringOF , modelFields-modelFields\\:treatAsAxiom , initialisation-initialisation\\:disableStaticInitialisation , sequences-sequences\\:on , integerSimplificationRules-integerSimplificationRules\\:full , runtimeExceptions-runtimeExceptions\\:allow
 [SMTSettings]useConstantsForBigOrSmallIntegers=true

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TacletMatchCompletionDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TacletMatchCompletionDialog.java
@@ -27,7 +27,7 @@ import de.uka.ilkd.key.gui.utilities.BracketMatchingTextArea;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.LocSetLDT;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.logic.label.TermLabelManager;
 import de.uka.ilkd.key.logic.op.IObserverFunction;
 import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.pp.LogicPrinter;
@@ -705,7 +705,7 @@ public class TacletMatchCompletionDialog extends ApplyTacletDialog {
         final NotationInfo ni = new NotationInfo();
 
         Services services = mediator.getServices();
-        final Term t = TermLabel.removeIrrelevantLabels(term, services);
+        final Term t = TermLabelManager.removeIrrelevantLabels(term, services);
         LogicPrinter p = LogicPrinter.purePrinter(ni, services);
         boolean pretty = mediator.getNotationInfo().isPrettySyntax();
         ni.refresh(services, pretty, false);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -4,8 +4,7 @@
 package de.uka.ilkd.key.gui.originlabels;
 
 import java.awt.event.ActionEvent;
-import javax.swing.Action;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.KeyAction;
@@ -13,7 +12,6 @@ import de.uka.ilkd.key.gui.actions.MainWindowAction;
 import de.uka.ilkd.key.gui.actions.QuickLoadAction;
 import de.uka.ilkd.key.gui.actions.QuickSaveAction;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
-import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.TermLabelSettings;
 
@@ -23,8 +21,6 @@ import de.uka.ilkd.key.settings.TermLabelSettings;
  * @author lanzinger
  */
 public class ToggleTermOriginTrackingAction extends MainWindowAction {
-    private static final long serialVersionUID = -2092724865788720558L;
-
     /**
      * Create a new action.
      *
@@ -47,32 +43,6 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
         lookupAcceleratorKey();
     }
 
-    private void handleAction() {
-        Proof proof = mainWindow.getMediator().getSelectedProof();
-        TermLabelSettings settings =
-            ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings();
-
-        /*
-         * if (proof != null) {
-         * Services services = proof.getServices();
-         *
-         * if (!settings.getUseOriginLabels()) {
-         * for (Proof p : services.getSpecificationRepository().getAllProofs()) {
-         * for (Goal g : p.openGoals()) {
-         * g.setSequent(OriginTermLabel.removeOriginLabels(g.sequent(), services));
-         * }
-         * }
-         *
-         * services.getSpecificationRepository()
-         * .map(term -> OriginTermLabel.removeOriginLabels(term, services), services);
-         * }
-         *
-         * mainWindow.getMediator().getSelectionModel().fireSelectedNodeChanged();
-         * }
-         */
-
-    }
-
     @Override
     public void actionPerformed(ActionEvent event) {
         TermLabelSettings settings =
@@ -85,15 +55,11 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
             "Origin", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null,
             options, options[2]);
 
-        switch (selection) {
-        case 0:
+        if (selection == JOptionPane.OK_OPTION) {
             QuickSaveAction.quickSave(mainWindow);
             QuickLoadAction.quickLoad(mainWindow);
-            // fallthrough
-        case 1:
-            settings.setUseOriginLabels(!settings.getUseOriginLabels());
-            handleAction();
         }
+        settings.setUseOriginLabels(!settings.getUseOriginLabels());
 
         setSelected(
             ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings().getUseOriginLabels());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -13,9 +13,6 @@ import de.uka.ilkd.key.gui.actions.MainWindowAction;
 import de.uka.ilkd.key.gui.actions.QuickLoadAction;
 import de.uka.ilkd.key.gui.actions.QuickSaveAction;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
-import de.uka.ilkd.key.java.Services;
-import de.uka.ilkd.key.logic.label.OriginTermLabel;
-import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.TermLabelSettings;
@@ -55,22 +52,24 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
         TermLabelSettings settings =
             ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings();
 
-        /* if (proof != null) {
-            Services services = proof.getServices();
-
-            if (!settings.getUseOriginLabels()) {
-                for (Proof p : services.getSpecificationRepository().getAllProofs()) {
-                    for (Goal g : p.openGoals()) {
-                        g.setSequent(OriginTermLabel.removeOriginLabels(g.sequent(), services));
-                    }
-                }
-
-                services.getSpecificationRepository()
-                        .map(term -> OriginTermLabel.removeOriginLabels(term, services), services);
-            }
-
-            mainWindow.getMediator().getSelectionModel().fireSelectedNodeChanged();
-        }*/
+        /*
+         * if (proof != null) {
+         * Services services = proof.getServices();
+         *
+         * if (!settings.getUseOriginLabels()) {
+         * for (Proof p : services.getSpecificationRepository().getAllProofs()) {
+         * for (Goal g : p.openGoals()) {
+         * g.setSequent(OriginTermLabel.removeOriginLabels(g.sequent(), services));
+         * }
+         * }
+         *
+         * services.getSpecificationRepository()
+         * .map(term -> OriginTermLabel.removeOriginLabels(term, services), services);
+         * }
+         *
+         * mainWindow.getMediator().getSelectionModel().fireSelectedNodeChanged();
+         * }
+         */
 
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -55,7 +55,7 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
         TermLabelSettings settings =
             ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings();
 
-        if (proof != null) {
+        /* if (proof != null) {
             Services services = proof.getServices();
 
             if (!settings.getUseOriginLabels()) {
@@ -70,7 +70,8 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
             }
 
             mainWindow.getMediator().getSelectionModel().fireSelectedNodeChanged();
-        }
+        }*/
+        
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -71,7 +71,7 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
 
             mainWindow.getMediator().getSelectionModel().fireSelectedNodeChanged();
         }*/
-        
+
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -78,38 +78,21 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
         TermLabelSettings settings =
             ProofIndependentSettings.DEFAULT_INSTANCE.getTermLabelSettings();
 
-        if (!settings.getUseOriginLabels()) {
-            Object[] options = { "Reload", "Continue without reloading", "Cancel" };
+        Object[] options = { "Reload", "Continue without reloading", "Cancel" };
 
-            int selection = JOptionPane.showOptionDialog(mainWindow,
-                "Origin information will be added to all newly loaded proofs.\n"
-                    + "To see origin information in your current proof, "
-                    + "you need to reload it.",
-                "Origin", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null,
-                options, options[2]);
+        int selection = JOptionPane.showOptionDialog(mainWindow,
+            "For the change to take effect, you need to reload the proof.",
+            "Origin", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null,
+            options, options[2]);
 
-            switch (selection) {
-            case 0:
-                QuickSaveAction.quickSave(mainWindow);
-                QuickLoadAction.quickLoad(mainWindow);
-                // fallthrough
-            case 1:
-                settings.setUseOriginLabels(!settings.getUseOriginLabels());
-                handleAction();
-            }
-        } else {
-            Object[] options = { "Remove", "Cancel" };
-
-            int selection = JOptionPane.showOptionDialog(mainWindow,
-                "All origin information will be removed from "
-                    + "every open goal and every proof obligation.",
-                "Origin", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null,
-                options, options[1]);
-
-            if (selection == 0) {
-                settings.setUseOriginLabels(!settings.getUseOriginLabels());
-                handleAction();
-            }
+        switch (selection) {
+        case 0:
+            QuickSaveAction.quickSave(mainWindow);
+            QuickLoadAction.quickLoad(mainWindow);
+            // fallthrough
+        case 1:
+            settings.setUseOriginLabels(!settings.getUseOriginLabels());
+            handleAction();
         }
 
         setSelected(

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
@@ -41,6 +41,7 @@ import de.uka.ilkd.key.java.statement.MethodBodyStatement;
 import de.uka.ilkd.key.java.statement.Then;
 import de.uka.ilkd.key.java.visitor.JavaASTVisitor;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.pp.Range;
 import de.uka.ilkd.key.proof.Node;
@@ -200,6 +201,10 @@ public final class SourceView extends JComponent {
             }
         });
 
+        if (mainWindow.getMediator().getSelectedProof() != null) {
+            ensureProofJavaSourceCollectionExists(mainWindow.getMediator().getSelectedProof());
+        }
+
         // add a listener for changes in the proof tree
         mainWindow.getMediator().addKeYSelectionListener(new KeYSelectionListener() {
             @Override
@@ -212,12 +217,38 @@ public final class SourceView extends JComponent {
             @Override
             public void selectedProofChanged(KeYSelectionEvent e) {
                 clear();
+                ensureProofJavaSourceCollectionExists(e.getSource().getSelectedProof());
                 updateGUI();
             }
         });
 
         KeYGuiExtensionFacade.installKeyboardShortcuts(null, this,
             KeYGuiExtension.KeyboardShortcuts.SOURCE_VIEW);
+
+    }
+
+    private void ensureProofJavaSourceCollectionExists(Proof proof) {
+        if (proof.lookup(ProofJavaSourceCollection.class) == null) {
+            final var sources = new ProofJavaSourceCollection();
+            proof.register(sources, ProofJavaSourceCollection.class);
+            proof.root().sequent().forEach(formula -> {
+                OriginTermLabel originLabel =
+                    (OriginTermLabel) formula.formula().getLabel(OriginTermLabel.NAME);
+                if (originLabel != null) {
+                    if (originLabel.getOrigin() instanceof OriginTermLabel.FileOrigin) {
+                        ((OriginTermLabel.FileOrigin) originLabel.getOrigin())
+                                .getFileName()
+                                .ifPresent(sources::addRelevantFile);
+                    }
+
+                    originLabel.getSubtermOrigins().stream()
+                            .filter(o -> o instanceof OriginTermLabel.FileOrigin)
+                            .map(o -> (OriginTermLabel.FileOrigin) o)
+                            .forEach(o -> o.getFileName().ifPresent(sources::addRelevantFile));
+                }
+            });
+        }
+
 
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
@@ -228,7 +228,7 @@ public final class SourceView extends JComponent {
     }
 
     private void ensureProofJavaSourceCollectionExists(Proof proof) {
-        if (proof.lookup(ProofJavaSourceCollection.class) == null) {
+        if (proof != null && proof.lookup(ProofJavaSourceCollection.class) == null) {
             final var sources = new ProofJavaSourceCollection();
             proof.register(sources, ProofJavaSourceCollection.class);
             proof.root().sequent().forEach(formula -> {


### PR DESCRIPTION
This PR allows to fully disable origin label creation if tracking is disabled. Switching tracking of an reloading, does no longer introduce origin labels in the first place.

- OriginLabels are only created via OriginTermLabelFactory
- Services have an OriginTermLabelFactory
- TermBuilder adds origin labels only when services has a factory set
- Changing origin tracking requires reloading
- Proof object no longer depends on origin labels 
- Proof object no longer responsible for source view related initialization of relevant files (moved to source view)


The following should be considered for the midterm, but should not be a blocker for merging this PR:
- remove hard coded OriginLabel knowledge from services, termbuilder etc. and provide a more general framework (this item can also be postponed)

@Reviewers:
- any idea how to pass knowledge about origin tracking to the PreParser in a nicer manner?

Fixes #3315 
 