### PR TITLE
A heap indicator in KeY's status bar

### DIFF
--- a/key.core/src/main/resources/META-INF/services/de.uka.ilkd.key.proof.init.DefaultProfileResolver
+++ b/key.core/src/main/resources/META-INF/services/de.uka.ilkd.key.proof.init.DefaultProfileResolver
@@ -4,3 +4,4 @@
 
 de.uka.ilkd.key.proof.init.JavaProfileDefaultProfileResolver
 de.uka.ilkd.key.proof.init.JavaProfileWithPermissionsDefaultProfileResolver
+de.tud.cs.se.ds.specstr.profile.StrengthAnalysisSEProfileDefaultProfileResolver

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
@@ -211,9 +211,9 @@ public final class Main {
         LOGGER.debug("Hardware: {}", System.getProperty("java.hw"));
         Runtime rt = Runtime.getRuntime();
         LOGGER.info("Memory: total {} MB, max {} MB, free {} MB",
-                rt.totalMemory() / 1048576.0,
-                rt.maxMemory() / 1048576.0,
-                rt.freeMemory() / 1048576.0);
+            rt.totalMemory() / 1048576.0,
+            rt.maxMemory() / 1048576.0,
+            rt.freeMemory() / 1048576.0);
         LOGGER.debug("Available processors: {}", rt.availableProcessors());
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
@@ -210,9 +210,10 @@ public final class Main {
         LOGGER.debug("OS: {}", System.getProperty("java.os"));
         LOGGER.debug("Hardware: {}", System.getProperty("java.hw"));
         Runtime rt = Runtime.getRuntime();
-        LOGGER.debug("Total memory: {} MB", (rt.totalMemory() / 1048576.0));
-        LOGGER.debug("Maximum memory:  {} MB", (rt.maxMemory() / 1048576.0));
-        LOGGER.debug("Free memory: {} MB", (rt.freeMemory() / 1048576.0));
+        LOGGER.info("Memory: total {} MB, max {} MB, free {} MB",
+                rt.totalMemory() / 1048576.0,
+                rt.maxMemory() / 1048576.0,
+                rt.freeMemory() / 1048576.0);
         LOGGER.debug("Available processors: {}", rt.availableProcessors());
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
@@ -1,12 +1,8 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.utilities;
 
-import de.uka.ilkd.key.gui.actions.KeyAction;
-import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
@@ -16,14 +12,22 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import javax.swing.*;
+
+import de.uka.ilkd.key.gui.actions.KeyAction;
+import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Alexander Weigl
  * @version 1 (28.10.23)
  */
 @KeYGuiExtension.Info(name = "Heap-Indicator",
-        description = "Shows an indication of the current heap consumption in the status line of key",
-        experimental = false)
+    description = "Shows an indication of the current heap consumption in the status line of key",
+    experimental = false)
 public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLine {
     @Override
     public List<JComponent> getStatusLineComponents() {
@@ -81,12 +85,12 @@ public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLin
             progressBar.setValue(used);
             progressBar.setString("%sM of %sM".formatted(used, max));
             progressBar.setStringPainted(true);
-            progressBar.setToolTipText("<html><table><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr>"
-                    .formatted(
+            progressBar.setToolTipText(
+                "<html><table><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr>"
+                        .formatted(
                             "max", max,
                             "free", free,
-                            "total", total
-                    ));
+                            "total", total));
         }
 
         private static class RunGcAction extends KeyAction {
@@ -98,14 +102,14 @@ public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLin
             public void actionPerformed(ActionEvent actionEvent) {
                 Runtime rt = Runtime.getRuntime();
                 LOGGER.info("Before GC: total {} MB, max {} MB, free {} MB",
-                        rt.totalMemory() / 1048576.0,
-                        rt.maxMemory() / 1048576.0,
-                        rt.freeMemory() / 1048576.0);
+                    rt.totalMemory() / 1048576.0,
+                    rt.maxMemory() / 1048576.0,
+                    rt.freeMemory() / 1048576.0);
                 System.gc();
                 LOGGER.info("After GC: total {} MB, max {} MB, free {} MB",
-                        rt.totalMemory() / 1048576.0,
-                        rt.maxMemory() / 1048576.0,
-                        rt.freeMemory() / 1048576.0);
+                    rt.totalMemory() / 1048576.0,
+                    rt.maxMemory() / 1048576.0,
+                    rt.freeMemory() / 1048576.0);
             }
         }
 
@@ -137,7 +141,8 @@ public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLin
             @Nullable
             private static String findJConsole() {
                 var executableLinux = Paths.get(System.getProperty("java.home"), "bin", "jconsole");
-                var executableWindows = Paths.get(System.getProperty("java.home"), "bin", "jconsole.exe");
+                var executableWindows =
+                    Paths.get(System.getProperty("java.home"), "bin", "jconsole.exe");
 
                 if (Files.exists(executableLinux)) {
                     return executableLinux.toString();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
@@ -1,0 +1,153 @@
+package de.uka.ilkd.key.gui.utilities;
+
+import de.uka.ilkd.key.gui.actions.KeyAction;
+import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Alexander Weigl
+ * @version 1 (28.10.23)
+ */
+@KeYGuiExtension.Info(name = "Heap-Indicator",
+        description = "Shows an indication of the current heap consumption in the status line of key",
+        experimental = false)
+public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLine {
+    @Override
+    public List<JComponent> getStatusLineComponents() {
+        return Collections.singletonList(new HeapStatusComponent());
+    }
+
+    private static class HeapStatusComponent extends Box {
+        private static final Logger LOGGER = LoggerFactory.getLogger(HeapStatusComponent.class);
+
+        private final JProgressBar progressBar = new JProgressBar();
+
+        private final Action actionRunGc = new RunGcAction();
+
+        private final Action actionShowMonitoring = new ShowMonitoringAction();
+
+
+        private JPopupMenu createPopupMenu() {
+            var j = new JPopupMenu("Heap");
+            progressBar.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    actionRunGc.actionPerformed(null);
+                }
+            });
+            j.add(actionShowMonitoring);
+            j.add(actionRunGc);
+            return j;
+        }
+
+        public HeapStatusComponent() {
+            super(BoxLayout.X_AXIS);
+            add(progressBar);
+            JPopupMenu menu = createPopupMenu();
+            setComponentPopupMenu(menu);
+            progressBar.setInheritsPopupMenu(true);
+
+            update();
+            var timer = new Timer(5000, (evt) -> update());
+            timer.setRepeats(true);
+            timer.start();
+        }
+
+        private void update() {
+            Runtime rt = Runtime.getRuntime();
+            final var mb = 1024 * 1024;
+
+            int max = (int) (rt.maxMemory() / mb);
+            int free = (int) (rt.freeMemory() / mb);
+            int total = (int) (rt.totalMemory() / mb);
+
+            progressBar.setMaximumSize(new Dimension(100, 25));
+
+            progressBar.setMaximum(total);
+            final var used = total - free;
+            progressBar.setValue(used);
+            progressBar.setString("%sM of %sM".formatted(used, max));
+            progressBar.setStringPainted(true);
+            progressBar.setToolTipText("<html><table><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr><tr><td>%s</td><td>%d MB</td></tr>"
+                    .formatted(
+                            "max", max,
+                            "free", free,
+                            "total", total
+                    ));
+        }
+
+        private static class RunGcAction extends KeyAction {
+            RunGcAction() {
+                setName("Run Gc");
+            }
+
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                Runtime rt = Runtime.getRuntime();
+                LOGGER.info("Before GC: total {} MB, max {} MB, free {} MB",
+                        rt.totalMemory() / 1048576.0,
+                        rt.maxMemory() / 1048576.0,
+                        rt.freeMemory() / 1048576.0);
+                System.gc();
+                LOGGER.info("After GC: total {} MB, max {} MB, free {} MB",
+                        rt.totalMemory() / 1048576.0,
+                        rt.maxMemory() / 1048576.0,
+                        rt.freeMemory() / 1048576.0);
+            }
+        }
+
+        private class ShowMonitoringAction extends KeyAction {
+            private final String pathJConsole;
+
+            ShowMonitoringAction() {
+                setName("Open JConsole");
+                pathJConsole = findJConsole();
+                if (pathJConsole == null) {
+                    setEnabled(false);
+                    setTooltip("Could not find the path to `jconsole` program, that is shipped by some JREs and JDKs.");
+                }
+            }
+
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                long pid = ProcessHandle.current().pid();
+
+                LOGGER.info("Execute jconsole: {} {}", pathJConsole, pid);
+                try {
+                    var process = new ProcessBuilder().command(pathJConsole, "" + pid).start();
+                } catch (IOException e) {
+                    JOptionPane.showConfirmDialog(HeapStatusComponent.this, e.getMessage());
+                }
+            }
+
+
+            @Nullable
+            private static String findJConsole() {
+                var executableLinux = Paths.get(System.getProperty("java.home"), "bin", "jconsole");
+                var executableWindows = Paths.get(System.getProperty("java.home"), "bin", "jconsole.exe");
+
+                if (Files.exists(executableLinux)) {
+                    return executableLinux.toString();
+                }
+
+                if (Files.exists(executableWindows)) {
+                    return executableWindows.toString();
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/HeapStatusExt.java
@@ -117,7 +117,7 @@ public class HeapStatusExt implements KeYGuiExtension, KeYGuiExtension.StatusLin
                 pathJConsole = findJConsole();
                 if (pathJConsole == null) {
                     setEnabled(false);
-                    setTooltip("Could not find the path to `jconsole` program, that is shipped by some JREs and JDKs.");
+                    setTooltip("Could not find `jconsole`, which is shipped by some JREs/JDKs.");
                 }
             }
 

--- a/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
+++ b/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
@@ -7,3 +7,4 @@ de.uka.ilkd.key.gui.nodeviews.ShowHashcodesExtension
 de.uka.ilkd.key.gui.LogView
 de.uka.ilkd.key.gui.plugins.javac.JavacExtension
 de.uka.ilkd.key.gui.plugins.caching.CachingExtension
+de.uka.ilkd.key.gui.utilities.HeapStatusExt


### PR DESCRIPTION
This PR brings two things for a clear indication of the current heap size settings. 

1. The logging level for heap information is increased from debug to info in `Main#main()`.
   Now the line 

   ```
    [14:33:40.367] INFO  Main - Memory: total 250.0 MB, max 3948.0 MB, free 236.08212280273438 MB
   ```
   should always appear. 

2. A GUI extension for the status bar: 

   ![image](https://github.com/KeYProject/key/assets/104259/33738afa-4853-429e-bf22-deb02a37619a)

   which allows to trigger `System.gc()` and to start the `jconsole` monitoring tool. 

