### PR TITLE
Improve thread-safety of KeY

### DIFF
--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsFeature.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsFeature.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.logic.op.Junctor;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.SVInstantiationProjection;
 
 /**
@@ -35,9 +36,9 @@ public class CutHeapObjectsFeature extends BinaryFeature {
      * {@inheritDoc}
      */
     @Override
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Term cutFormula =
-            SVInstantiationProjection.create(new Name("cutFormula"), false).toTerm(app, pos, goal);
+            SVInstantiationProjection.create(new Name("cutFormula"), false).toTerm(app, pos, goal, mState);
         if (cutFormula != null) {
             if (cutFormula.op() == Junctor.NOT) {
                 cutFormula = cutFormula.sub(0);

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsFeature.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsFeature.java
@@ -38,7 +38,8 @@ public class CutHeapObjectsFeature extends BinaryFeature {
     @Override
     protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Term cutFormula =
-            SVInstantiationProjection.create(new Name("cutFormula"), false).toTerm(app, pos, goal, mState);
+            SVInstantiationProjection.create(new Name("cutFormula"), false).toTerm(app, pos, goal,
+                mState);
         if (cutFormula != null) {
             if (cutFormula.op() == Junctor.NOT) {
                 cutFormula = cutFormula.sub(0);

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsTermGenerator.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsTermGenerator.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Function;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termgenerator.TermGenerator;
 
 /**
@@ -31,7 +32,7 @@ public class CutHeapObjectsTermGenerator implements TermGenerator {
      * {@inheritDoc}
      */
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         // Compute collect terms of sequent formulas
         Sequent sequent = goal.sequent();
         Set<Term> topTerms = new LinkedHashSet<>();

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsTermGenerator.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/CutHeapObjectsTermGenerator.java
@@ -32,7 +32,8 @@ public class CutHeapObjectsTermGenerator implements TermGenerator {
      * {@inheritDoc}
      */
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         // Compute collect terms of sequent formulas
         Sequent sequent = goal.sequent();
         Set<Term> topTerms = new LinkedHashSet<>();

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SimplifyTermStrategy.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SimplifyTermStrategy.java
@@ -49,7 +49,7 @@ public class SimplifyTermStrategy extends JavaCardDLStrategy {
     @Override
     protected Feature setupApprovalF() {
         Feature superFeature = super.setupApprovalF();
-        Feature labelFeature = (app, pos, goal) -> {
+        Feature labelFeature = (app, pos, goal, mState) -> {
             boolean hasLabel = false;
             if (pos != null && app instanceof TacletApp) {
                 Term findTerm = pos.subTerm();

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionStrategy.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionStrategy.java
@@ -117,7 +117,7 @@ public class SymbolicExecutionStrategy extends JavaCardDLStrategy {
         // body branches)
         globalF = add(globalF, ifZero(not(new BinaryFeature() {
             @Override
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
                 return pos != null
                         && SymbolicExecutionUtil.hasSymbolicExecutionLabel(pos.subTerm());
             }

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionStrategy.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionStrategy.java
@@ -117,7 +117,8 @@ public class SymbolicExecutionStrategy extends JavaCardDLStrategy {
         // body branches)
         globalF = add(globalF, ifZero(not(new BinaryFeature() {
             @Override
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
                 return pos != null
                         && SymbolicExecutionUtil.hasSymbolicExecutionLabel(pos.subTerm());
             }

--- a/key.core.testgen/src/main/java/de/uka/ilkd/key/macros/TestGenMacro.java
+++ b/key.core.testgen/src/main/java/de/uka/ilkd/key/macros/TestGenMacro.java
@@ -79,7 +79,8 @@ class TestGenStrategy extends FilterStrategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         if (TestGenStrategy.isUnwindRule(app.rule())) {
             return NumberRuleAppCost.create(TestGenStrategy.UNWIND_COST);
         }

--- a/key.core.testgen/src/main/java/de/uka/ilkd/key/macros/TestGenMacro.java
+++ b/key.core.testgen/src/main/java/de/uka/ilkd/key/macros/TestGenMacro.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.settings.TestGenerationSettings;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.Strategy;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class TestGenMacro extends StrategyProofMacro {
     @Override
@@ -78,11 +79,11 @@ class TestGenStrategy extends FilterStrategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         if (TestGenStrategy.isUnwindRule(app.rule())) {
             return NumberRuleAppCost.create(TestGenStrategy.UNWIND_COST);
         }
-        return super.computeCost(app, pio, goal);
+        return super.computeCost(app, pio, goal, mState);
     }
 
     private int computeUnwindRules(Goal goal) {

--- a/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
@@ -15,7 +15,7 @@ import de.uka.ilkd.key.nparser.KeyIO;
 import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
-import de.uka.ilkd.key.rule.match.legacy.LegacyTacletMatcher;
+import de.uka.ilkd.key.rule.match.vm.VMTacletMatcher;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
@@ -68,7 +68,7 @@ public class Matcher {
         Taclet t = parseTaclet(patternString, copyServices);
 
         // Build Matcher for Matchpattern
-        LegacyTacletMatcher ltm = new LegacyTacletMatcher(t);
+       VMTacletMatcher ltm = new VMTacletMatcher(t);
 
         // patternSequent should not be null, as we have created it
         assert t.ifSequent() != null;
@@ -94,7 +94,7 @@ public class Matcher {
 
             Queue<SearchNode> queue = new LinkedList<>();
             // init
-            queue.add(new SearchNode(patternArray, asize, antecCand, succCand));
+            queue.add(new SearchNode(patternArray, asize));
 
 
             while (!queue.isEmpty()) {
@@ -103,7 +103,7 @@ public class Matcher {
                 LOGGER.debug(inAntecedent ? "In Antec: " : "In Succ");
 
                 IfMatchResult ma = ltm.matchIf((inAntecedent ? antecCand : succCand),
-                    node.getPatternTerm(), node.mc, copyServices);
+                    node.getPatternTerm(), node.getMatchConditions(), copyServices);
 
                 if (!ma.getMatchConditions().isEmpty()) {
                     ImmutableList<MatchConditions> testma = ma.getMatchConditions();
@@ -139,7 +139,7 @@ public class Matcher {
      */
     private VariableAssignments extractAssignments(SearchNode sn, VariableAssignments assignments) {
         VariableAssignments va = new VariableAssignments();
-        SVInstantiations insts = sn.mc.getInstantiations();
+        SVInstantiations insts = sn.getInstantiations();
         Set<String> varNames = assignments.getTypeMap().keySet();
         for (String varName : varNames) {
             SchemaVariable sv = insts.lookupVar(new Name(varName));

--- a/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
@@ -68,7 +68,7 @@ public class Matcher {
         Taclet t = parseTaclet(patternString, copyServices);
 
         // Build Matcher for Matchpattern
-       VMTacletMatcher ltm = new VMTacletMatcher(t);
+        VMTacletMatcher ltm = new VMTacletMatcher(t);
 
         // patternSequent should not be null, as we have created it
         assert t.ifSequent() != null;

--- a/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
@@ -68,7 +68,7 @@ public class Matcher {
         Taclet t = parseTaclet(patternString, copyServices);
 
         // Build Matcher for Matchpattern
-        VMTacletMatcher ltm = new VMTacletMatcher(t);
+        VMTacletMatcher tacletMatcher = new VMTacletMatcher(t);
 
         // patternSequent should not be null, as we have created it
         assert t.ifSequent() != null;
@@ -102,7 +102,7 @@ public class Matcher {
                 boolean inAntecedent = node.isAntecedent();
                 LOGGER.debug(inAntecedent ? "In Antec: " : "In Succ");
 
-                IfMatchResult ma = ltm.matchIf((inAntecedent ? antecCand : succCand),
+                IfMatchResult ma = tacletMatcher.matchIf((inAntecedent ? antecCand : succCand),
                     node.getPatternTerm(), node.getMatchConditions(), copyServices);
 
                 if (!ma.getMatchConditions().isEmpty()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/Matcher.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import de.uka.ilkd.key.rule.match.legacy.LegacyTacletMatcher;
 
+import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 
 import org.antlr.v4.runtime.CharStreams;
@@ -79,9 +80,9 @@ public class Matcher {
         List<SearchNode> finalCandidates = new ArrayList<>(100);
         if (size > 0) {
             // Iteratoren durch die Sequent
-            ImmutableList<IfFormulaInstantiation> antecCand =
+            ImmutableArray<IfFormulaInstantiation> antecCand =
                 IfFormulaInstSeq.createList(currentSeq, true, copyServices);
-            ImmutableList<IfFormulaInstantiation> succCand =
+            ImmutableArray<IfFormulaInstantiation> succCand =
                 IfFormulaInstSeq.createList(currentSeq, false, copyServices);
 
             SequentFormula[] patternArray = new SequentFormula[patternSeq.size()];

--- a/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
@@ -49,7 +49,7 @@ public final class SearchNode {
     }
 
     public SVInstantiations getInstantiations() {
-        return mc.getInstantiations();
+        return mc == null ? null : mc.getInstantiations();
     }
 
     public MatchConditions getMatchConditions() {

--- a/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
@@ -8,28 +8,23 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.rule.IfFormulaInstantiation;
 import de.uka.ilkd.key.rule.MatchConditions;
 
+import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import org.key_project.util.collection.ImmutableArray;
 
 /**
  * Created by sarah on 5/2/17.
  */
-public class SearchNode {
-    final SequentFormula[] pattern;
-    int pos = 0;
-    int succAntPos = 0;
-    public final MatchConditions mc;
-    final ImmutableArray<IfFormulaInstantiation> antec;
-    final ImmutableArray<IfFormulaInstantiation> succ;
+public final class SearchNode {
+    private final SequentFormula[] pattern;
+    private final int pos;
+    private final int succAntPos;
+    private final MatchConditions mc;
 
 
-
-    public SearchNode(SequentFormula[] pattern, int succAntPos,
-            ImmutableArray<IfFormulaInstantiation> antec,
-            ImmutableArray<IfFormulaInstantiation> succ) {
+    public SearchNode(SequentFormula[] pattern, int succAntPos) {
         this.pattern = pattern;
+        this.pos = 0;
         this.succAntPos = succAntPos;
-        this.antec = antec;
-        this.succ = succ;
         this.mc = MatchConditions.EMPTY_MATCHCONDITIONS;
     }
 
@@ -38,8 +33,6 @@ public class SearchNode {
         this.succAntPos = parent.succAntPos;
         int parentPos = parent.pos;
         this.pos = parentPos + 1;
-        antec = parent.antec;
-        succ = parent.succ;
         mc = cond;
     }
 
@@ -55,4 +48,11 @@ public class SearchNode {
         return pos >= pattern.length;
     }
 
+    public SVInstantiations getInstantiations() {
+        return mc.getInstantiations();
+    }
+
+    public MatchConditions getMatchConditions() {
+        return mc;
+    }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
@@ -8,7 +8,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.rule.IfFormulaInstantiation;
 import de.uka.ilkd.key.rule.MatchConditions;
 
-import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableArray;
 
 /**
  * Created by sarah on 5/2/17.
@@ -18,14 +18,14 @@ public class SearchNode {
     int pos = 0;
     int succAntPos = 0;
     public final MatchConditions mc;
-    final ImmutableList<IfFormulaInstantiation> antec;
-    final ImmutableList<IfFormulaInstantiation> succ;
+    final ImmutableArray<IfFormulaInstantiation> antec;
+    final ImmutableArray<IfFormulaInstantiation> succ;
 
 
 
     public SearchNode(SequentFormula[] pattern, int succAntPos,
-            ImmutableList<IfFormulaInstantiation> antec,
-            ImmutableList<IfFormulaInstantiation> succ) {
+                      ImmutableArray<IfFormulaInstantiation> antec,
+                      ImmutableArray<IfFormulaInstantiation> succ) {
         this.pattern = pattern;
         this.succAntPos = succAntPos;
         this.antec = antec;

--- a/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
@@ -5,11 +5,8 @@ package de.uka.ilkd.key.api;
 
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.rule.IfFormulaInstantiation;
 import de.uka.ilkd.key.rule.MatchConditions;
-
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
-import org.key_project.util.collection.ImmutableArray;
 
 /**
  * Created by sarah on 5/2/17.

--- a/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/api/SearchNode.java
@@ -24,8 +24,8 @@ public class SearchNode {
 
 
     public SearchNode(SequentFormula[] pattern, int succAntPos,
-                      ImmutableArray<IfFormulaInstantiation> antec,
-                      ImmutableArray<IfFormulaInstantiation> succ) {
+            ImmutableArray<IfFormulaInstantiation> antec,
+            ImmutableArray<IfFormulaInstantiation> succ) {
         this.pattern = pattern;
         this.succAntPos = succAntPos;
         this.antec = antec;

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.proof.*;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.inst.SortException;
 
+import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
@@ -119,9 +120,9 @@ public class TacletInstantiationModel {
         int size = asize + ifseq.succedent().size();
 
         if (size > 0) {
-            ImmutableList<IfFormulaInstantiation> antecCand =
+            ImmutableArray<IfFormulaInstantiation> antecCand =
                 IfFormulaInstSeq.createList(seq, true, services);
-            ImmutableList<IfFormulaInstantiation> succCand =
+            ImmutableArray<IfFormulaInstantiation> succCand =
                 IfFormulaInstSeq.createList(seq, false, services);
 
             Iterator<SequentFormula> it = ifseq.iterator();

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/SelfcompositionStateExpansionMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/SelfcompositionStateExpansionMacro.java
@@ -22,8 +22,8 @@ import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.StrategyProperties;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
-
 import de.uka.ilkd.key.strategy.feature.MutableState;
+
 import org.key_project.util.collection.ImmutableList;
 
 /**
@@ -124,7 +124,8 @@ public class SelfcompositionStateExpansionMacro extends AbstractPropositionalExp
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if ((admittedRuleNames.contains(name) || name.startsWith(INF_FLOW_UNFOLD_PREFIX))
                     && ruleApplicationInContextAllowed(ruleApp, pio, goal)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/SelfcompositionStateExpansionMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/SelfcompositionStateExpansionMacro.java
@@ -23,6 +23,7 @@ import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.StrategyProperties;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import org.key_project.util.collection.ImmutableList;
 
 /**
@@ -123,14 +124,14 @@ public class SelfcompositionStateExpansionMacro extends AbstractPropositionalExp
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if ((admittedRuleNames.contains(name) || name.startsWith(INF_FLOW_UNFOLD_PREFIX))
                     && ruleApplicationInContextAllowed(ruleApp, pio, goal)) {
                 JavaCardDLStrategyFactory strategyFactory = new JavaCardDLStrategyFactory();
                 Strategy javaDlStrategy =
                     strategyFactory.create(goal.proof(), new StrategyProperties());
-                RuleAppCost costs = javaDlStrategy.computeCost(ruleApp, pio, goal);
+                RuleAppCost costs = javaDlStrategy.computeCost(ruleApp, pio, goal, mState);
                 if ("orLeft".equals(name)) {
                     costs = costs.add(NumberRuleAppCost.create(100));
                 }

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/UseInformationFlowContractMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/UseInformationFlowContractMacro.java
@@ -22,8 +22,8 @@ import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 import de.uka.ilkd.key.strategy.feature.FocusIsSubFormulaOfInfFlowContractAppFeature;
 import de.uka.ilkd.key.strategy.feature.InfFlowContractAppFeature;
-
 import de.uka.ilkd.key.strategy.feature.MutableState;
+
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSet;
@@ -182,7 +182,8 @@ public class UseInformationFlowContractMacro extends StrategyProofMacro {
 
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             // first try to apply
             // - impLeft on previous information flow contract application
             // formula, else

--- a/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/UseInformationFlowContractMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/informationflow/macros/UseInformationFlowContractMacro.java
@@ -23,6 +23,7 @@ import de.uka.ilkd.key.strategy.TopRuleAppCost;
 import de.uka.ilkd.key.strategy.feature.FocusIsSubFormulaOfInfFlowContractAppFeature;
 import de.uka.ilkd.key.strategy.feature.InfFlowContractAppFeature;
 
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSet;
@@ -181,7 +182,7 @@ public class UseInformationFlowContractMacro extends StrategyProofMacro {
 
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
             // first try to apply
             // - impLeft on previous information flow contract application
             // formula, else
@@ -190,14 +191,14 @@ public class UseInformationFlowContractMacro extends StrategyProofMacro {
             String name = ruleApp.rule().name().toString();
             if (name.startsWith(INF_FLOW_RULENAME_PREFIX)
                     && ruleApplicationInContextAllowed(ruleApp, pio, goal)) {
-                return InfFlowContractAppFeature.INSTANCE.computeCost(ruleApp, pio, goal);
+                return InfFlowContractAppFeature.INSTANCE.computeCost(ruleApp, pio, goal, mState);
             } else if (name.equals(DOUBLE_IMP_LEFT_RULENAME)) {
                 RuleAppCost impLeftCost = FocusIsSubFormulaOfInfFlowContractAppFeature.INSTANCE
-                        .computeCost(ruleApp, pio, goal);
+                        .computeCost(ruleApp, pio, goal, mState);
                 return impLeftCost.add(NumberRuleAppCost.create(-10010));
             } else if (name.equals(IMP_LEFT_RULENAME)) {
                 RuleAppCost impLeftCost = FocusIsSubFormulaOfInfFlowContractAppFeature.INSTANCE
-                        .computeCost(ruleApp, pio, goal);
+                        .computeCost(ruleApp, pio, goal, mState);
                 return impLeftCost.add(NumberRuleAppCost.create(-10000));
             } else if (admittedRuleNames.contains(name)
                     && ruleApplicationInContextAllowed(ruleApp, pio, goal)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
@@ -23,10 +23,12 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.AbstractBetaFeature.TermInfo;
 import de.uka.ilkd.key.strategy.feature.AppliedRuleAppsNameCache;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.ClausesGraph;
+import de.uka.ilkd.key.strategy.quantifierHeuristics.Metavariable;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.TriggersSet;
 import de.uka.ilkd.key.util.Pair;
 
 import org.key_project.util.LRUCache;
+import org.key_project.util.collection.ImmutableSet;
 
 /**
  * <p>
@@ -147,6 +149,10 @@ public class ServiceCaches {
     private final AppliedRuleAppsNameCache appliedRuleAppsNameCache =
         new AppliedRuleAppsNameCache();
 
+    /** Cache used by EqualityConstraint to speed up meta variable search */
+    private final LRUCache<Term, ImmutableSet<Metavariable>> mvCache = new LRUCache<>(2000);
+
+
     /**
      * Returns the cache used by {@link TermTacletAppIndexCacheSet} instances.
      *
@@ -219,4 +225,9 @@ public class ServiceCaches {
     public AppliedRuleAppsNameCache getAppliedRuleAppsNameCache() {
         return appliedRuleAppsNameCache;
     }
+
+    public LRUCache<Term, ImmutableSet<Metavariable>> getMVCache() {
+        return mvCache;
+    }
+
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermFactory.java
@@ -128,12 +128,11 @@ public final class TermFactory {
     private Term doCreateTerm(Operator op, ImmutableArray<Term> subs,
             ImmutableArray<QuantifiableVariable> boundVars, JavaBlock javaBlock,
             ImmutableArray<TermLabel> labels, String origin) {
-        final Term newTerm =
+        final TermImpl newTerm =
             (labels == null || labels.isEmpty()
                     ? new TermImpl(op, subs, boundVars, javaBlock, origin)
-                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels, origin))
-                            .checked();
-        // Check if caching is possible. It is not possible if a non empty JavaBlock is available
+                    : new LabeledTermImpl(op, subs, boundVars, javaBlock, labels, origin));
+        // Check if caching is possible. It is not possible if a non-empty JavaBlock is available
         // in the term or in one of its children because the meta information like PositionInfos
         // may be different.
         if (cache != null && !newTerm.containsJavaBlockRecursive()) {
@@ -142,14 +141,14 @@ public final class TermFactory {
                 term = cache.get(newTerm);
             }
             if (term == null) {
-                term = newTerm;
+                term = newTerm.checked();
                 synchronized (cache) {
                     cache.put(term, term);
                 }
             }
             return term;
         } else {
-            return newTerm;
+            return newTerm.checked();
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractBlastingMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractBlastingMacro.java
@@ -42,6 +42,7 @@ import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import org.key_project.util.collection.ImmutableList;
 
 public abstract class AbstractBlastingMacro extends StrategyProofMacro {
@@ -204,7 +205,7 @@ public abstract class AbstractBlastingMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
 
             if (app.rule() instanceof OneStepSimplifier) {
                 return NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractBlastingMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractBlastingMacro.java
@@ -41,8 +41,8 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
-
 import de.uka.ilkd.key.strategy.feature.MutableState;
+
 import org.key_project.util.collection.ImmutableList;
 
 public abstract class AbstractBlastingMacro extends StrategyProofMacro {
@@ -205,7 +205,8 @@ public abstract class AbstractBlastingMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
 
             if (app.rule() instanceof OneStepSimplifier) {
                 return NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractPropositionalExpansionMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractPropositionalExpansionMacro.java
@@ -97,7 +97,8 @@ public abstract class AbstractPropositionalExpansionMacro extends StrategyProofM
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (ruleApp instanceof OneStepSimplifierRuleApp && allowOSS) {
                 return delegate.computeCost(ruleApp, pio, goal, mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractPropositionalExpansionMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractPropositionalExpansionMacro.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.rule.OneStepSimplifierRuleApp;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.*;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * The Class AbstractPropositionalExpansionMacro applies purely propositional rules.
@@ -96,12 +97,12 @@ public abstract class AbstractPropositionalExpansionMacro extends StrategyProofM
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (ruleApp instanceof OneStepSimplifierRuleApp && allowOSS) {
-                return delegate.computeCost(ruleApp, pio, goal);
+                return delegate.computeCost(ruleApp, pio, goal, mState);
             } else if (admittedRuleNames.contains(name)) {
-                final RuleAppCost origCost = delegate.computeCost(ruleApp, pio, goal);
+                final RuleAppCost origCost = delegate.computeCost(ruleApp, pio, goal, mState);
                 // pass through negative costs
                 if (origCost instanceof NumberRuleAppCost
                         && ((NumberRuleAppCost) origCost).getValue() < 0) {

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AutoPilotPrepareProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AutoPilotPrepareProofMacro.java
@@ -95,7 +95,8 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
 
             Rule rule = app.rule();
             if (FinishSymbolicExecutionMacro.isForbiddenRule(rule)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AutoPilotPrepareProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AutoPilotPrepareProofMacro.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.strategy.*;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
     private static final Set<String> ADMITTED_RULES =
@@ -68,7 +69,7 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
         /** the modality cache used by this strategy */
         private final ModalityCache modalityCache = new ModalityCache();
 
-        public AutoPilotStrategy(Proof proof, PosInOccurrence posInOcc) {
+        public AutoPilotStrategy(Proof proof) {
             this.delegate = proof.getActiveStrategy();
         }
 
@@ -79,14 +80,14 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
 
         @Override
         public boolean isApprovedApp(RuleApp app, PosInOccurrence pio, Goal goal) {
-            return computeCost(app, pio, goal) != TopRuleAppCost.INSTANCE &&
+            return computeCost(app, pio, goal, new MutableState()) != TopRuleAppCost.INSTANCE &&
             // Assumptions are normally not considered by the cost
             // computation, because they are normally not yet
             // instantiated when the costs are computed. Because the
             // application of a rule sometimes makes sense only if
             // the assumptions are instantiated in a particular way
             // (for instance equalities should not be applied on
-            // themselves), we need to give the delegate the possiblity
+            // themselves), we need to give the delegate the possibility
             // to reject the application of a rule by calling
             // isApprovedApp. Otherwise, in particular equalities may
             // be applied on themselves.
@@ -94,7 +95,7 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
 
             Rule rule = app.rule();
             if (FinishSymbolicExecutionMacro.isForbiddenRule(rule)) {
@@ -102,7 +103,7 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
             }
 
             if (modalityCache.hasModality(goal.node().sequent())) {
-                return delegate.computeCost(app, pio, goal);
+                return delegate.computeCost(app, pio, goal, mState);
             }
 
             if (isAdmittedRule(rule)) {
@@ -138,6 +139,6 @@ public class AutoPilotPrepareProofMacro extends StrategyProofMacro {
 
     @Override
     protected Strategy createStrategy(Proof proof, PosInOccurrence posInOcc) {
-        return new AutoPilotStrategy(proof, posInOcc);
+        return new AutoPilotStrategy(proof);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/FilterStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/FilterStrategy.java
@@ -26,7 +26,8 @@ public abstract class FilterStrategy implements Strategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         if (!isApprovedApp(app, pio, goal)) {
             return TopRuleAppCost.INSTANCE;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/FilterStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/FilterStrategy.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public abstract class FilterStrategy implements Strategy {
 
@@ -25,11 +26,11 @@ public abstract class FilterStrategy implements Strategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         if (!isApprovedApp(app, pio, goal)) {
             return TopRuleAppCost.INSTANCE;
         }
-        return delegate.computeCost(app, pio, goal);
+        return delegate.computeCost(app, pio, goal, mState);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/OneStepProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/OneStepProofMacro.java
@@ -83,7 +83,8 @@ public class OneStepProofMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             return delegate.computeCost(app, pio, goal, mState);
 
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/OneStepProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/OneStepProofMacro.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Apply a single proof step.
@@ -82,8 +83,8 @@ public class OneStepProofMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
-            return delegate.computeCost(app, pio, goal);
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+            return delegate.computeCost(app, pio, goal, mState);
 
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/PrepareInfFlowContractPreBranchesMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/PrepareInfFlowContractPreBranchesMacro.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 import de.uka.ilkd.key.strategy.feature.FocusIsSubFormulaOfInfFlowContractAppFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termfeature.IsPostConditionTermFeature;
 
 
@@ -77,14 +78,14 @@ public class PrepareInfFlowContractPreBranchesMacro extends StrategyProofMacro {
 
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (name.equals("hide_right")) {
                 return applyTF("b", IsPostConditionTermFeature.INSTANCE).computeCost(ruleApp, pio,
-                    goal);
+                    goal, mState);
             } else if (name.equals(AND_RIGHT_RULENAME)) {
                 RuleAppCost andRightCost = FocusIsSubFormulaOfInfFlowContractAppFeature.INSTANCE
-                        .computeCost(ruleApp, pio, goal);
+                        .computeCost(ruleApp, pio, goal, mState);
                 return andRightCost.add(NumberRuleAppCost.create(1));
             } else {
                 return TopRuleAppCost.INSTANCE;
@@ -128,8 +129,8 @@ public class PrepareInfFlowContractPreBranchesMacro extends StrategyProofMacro {
 
 
         @Override
-        protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal) {
-            return computeCost(app, pio, goal);
+        protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+            return computeCost(app, pio, goal, mState);
         }
 
         @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/PrepareInfFlowContractPreBranchesMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/PrepareInfFlowContractPreBranchesMacro.java
@@ -78,7 +78,8 @@ public class PrepareInfFlowContractPreBranchesMacro extends StrategyProofMacro {
 
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (name.equals("hide_right")) {
                 return applyTF("b", IsPostConditionTermFeature.INSTANCE).computeCost(ruleApp, pio,
@@ -129,7 +130,8 @@ public class PrepareInfFlowContractPreBranchesMacro extends StrategyProofMacro {
 
 
         @Override
-        protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+        protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             return computeCost(app, pio, goal, mState);
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/WellDefinednessMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/WellDefinednessMacro.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import org.key_project.util.collection.ImmutableList;
 
 /**
@@ -100,7 +101,7 @@ public class WellDefinednessMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (name.startsWith(WD_PREFIX)) {
                 return NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/WellDefinednessMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/WellDefinednessMacro.java
@@ -18,8 +18,8 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCostCollector;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
-
 import de.uka.ilkd.key.strategy.feature.MutableState;
+
 import org.key_project.util.collection.ImmutableList;
 
 /**
@@ -101,7 +101,8 @@ public class WellDefinednessMacro extends StrategyProofMacro {
         }
 
         @Override
-        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pio, Goal goal,
+                MutableState mState) {
             String name = ruleApp.rule().name().toString();
             if (name.startsWith(WD_PREFIX)) {
                 return NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppListener.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppListener.java
@@ -14,5 +14,5 @@ public interface RuleAppListener {
      *
      * @param e the proof event containing the rule application.
      */
-    void ruleApplied(de.uka.ilkd.key.proof.ProofEvent e);
+    void ruleApplied(ProofEvent e);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstSeq.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstSeq.java
@@ -51,7 +51,7 @@ public class IfFormulaInstSeq implements IfFormulaInstantiation {
      * Create a list with all formulas of a given semisequent
      */
     private static ImmutableArray<IfFormulaInstantiation> createListHelp(Sequent p_s,
-                                                                         boolean antec) {
+            boolean antec) {
         Semisequent semi;
         if (antec) {
             semi = p_s.antecedent();
@@ -62,7 +62,7 @@ public class IfFormulaInstSeq implements IfFormulaInstantiation {
         final IfFormulaInstSeq[] assumesInstFromSeq = new IfFormulaInstSeq[semi.size()];
         int i = assumesInstFromSeq.length - 1;
 
-        for (final var sf:semi) {
+        for (final var sf : semi) {
             assumesInstFromSeq[i] = new IfFormulaInstSeq(p_s, antec, sf);
             --i;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstSeq.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstSeq.java
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.rule;
 
-import java.util.Iterator;
-
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.PosInTerm;
@@ -13,8 +11,8 @@ import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.proof.io.OutputStreamProofSaver;
 
-import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableArray;
+
 
 /**
  * Instantiation of an if-formula that is a formula of an existing sequent.
@@ -52,29 +50,33 @@ public class IfFormulaInstSeq implements IfFormulaInstantiation {
     /**
      * Create a list with all formulas of a given semisequent
      */
-    private static ImmutableList<IfFormulaInstantiation> createListHelp(Sequent p_s,
-            boolean antec) {
-        ImmutableList<IfFormulaInstantiation> res = ImmutableSLList.nil();
-        Iterator<SequentFormula> it;
+    private static ImmutableArray<IfFormulaInstantiation> createListHelp(Sequent p_s,
+                                                                         boolean antec) {
+        Semisequent semi;
         if (antec) {
-            it = p_s.antecedent().iterator();
+            semi = p_s.antecedent();
         } else {
-            it = p_s.succedent().iterator();
-        }
-        while (it.hasNext()) {
-            res = res.prepend(new IfFormulaInstSeq(p_s, antec, it.next()));
+            semi = p_s.succedent();
         }
 
-        return res;
+        final IfFormulaInstSeq[] assumesInstFromSeq = new IfFormulaInstSeq[semi.size()];
+        int i = assumesInstFromSeq.length - 1;
+
+        for (final var sf:semi) {
+            assumesInstFromSeq[i] = new IfFormulaInstSeq(p_s, antec, sf);
+            --i;
+        }
+
+        return new ImmutableArray<>(assumesInstFromSeq);
     }
 
-    public static ImmutableList<IfFormulaInstantiation> createList(Sequent p_s, boolean antec,
+    public static ImmutableArray<IfFormulaInstantiation> createList(Sequent p_s, boolean antec,
             Services services) {
         final IfFormulaInstantiationCache cache =
             services.getCaches().getIfFormulaInstantiationCache();
         final Semisequent semi = antec ? p_s.antecedent() : p_s.succedent();
 
-        ImmutableList<IfFormulaInstantiation> val = cache.get(antec, semi);
+        ImmutableArray<IfFormulaInstantiation> val = cache.get(antec, semi);
 
         if (val == null) {
             val = createListHelp(p_s, antec);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstantiationCache.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstantiationCache.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.util.Pair;
 
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableList;
 
 // a simple cache for the results of the method <code>createList</code>
 public final class IfFormulaInstantiationCache {
@@ -38,7 +37,7 @@ public final class IfFormulaInstantiationCache {
     }
 
     public void put(boolean antec, Semisequent s,
-                    ImmutableArray<IfFormulaInstantiation> value) {
+            ImmutableArray<IfFormulaInstantiation> value) {
         try {
             writeLock.lock();
             (antec ? antecCache : succCache).put(System.identityHashCode(s), new Pair<>(s, value));

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstantiationCache.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/IfFormulaInstantiationCache.java
@@ -11,24 +11,25 @@ import de.uka.ilkd.key.logic.Semisequent;
 import de.uka.ilkd.key.util.Pair;
 
 import org.key_project.util.LRUCache;
+import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 
 // a simple cache for the results of the method <code>createList</code>
 public final class IfFormulaInstantiationCache {
 
-    private final LRUCache<Integer, Pair<Semisequent, ImmutableList<IfFormulaInstantiation>>> antecCache =
+    private final LRUCache<Integer, Pair<Semisequent, ImmutableArray<IfFormulaInstantiation>>> antecCache =
         new LRUCache<>(50);
-    private final LRUCache<Integer, Pair<Semisequent, ImmutableList<IfFormulaInstantiation>>> succCache =
+    private final LRUCache<Integer, Pair<Semisequent, ImmutableArray<IfFormulaInstantiation>>> succCache =
         new LRUCache<>(50);
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final ReadLock readLock = lock.readLock();
     private final WriteLock writeLock = lock.writeLock();
 
-    public ImmutableList<IfFormulaInstantiation> get(boolean antec, Semisequent s) {
+    public ImmutableArray<IfFormulaInstantiation> get(boolean antec, Semisequent s) {
         try {
             readLock.lock();
-            final Pair<Semisequent, ImmutableList<IfFormulaInstantiation>> p =
+            final Pair<Semisequent, ImmutableArray<IfFormulaInstantiation>> p =
                 (antec ? antecCache : succCache).get(System.identityHashCode(s));
             return p != null && p.first == s ? p.second : null;
         } finally {
@@ -37,7 +38,7 @@ public final class IfFormulaInstantiationCache {
     }
 
     public void put(boolean antec, Semisequent s,
-            ImmutableList<IfFormulaInstantiation> value) {
+                    ImmutableArray<IfFormulaInstantiation> value) {
         try {
             writeLock.lock();
             (antec ? antecCache : succCache).put(System.identityHashCode(s), new Pair<>(s, value));

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -24,6 +24,7 @@ import org.key_project.util.EqualsModProofIrrelevancy;
 import org.key_project.util.EqualsModProofIrrelevancyUtil;
 import org.key_project.util.collection.*;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -43,7 +44,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     public static final AtomicLong PERF_PRE = new AtomicLong();
 
     /** the taclet for which the application information is collected */
-    private final Taclet taclet;
+    private final @NonNull Taclet taclet;
 
     /**
      * contains the instantiations of the schema variables of the Taclet
@@ -51,12 +52,12 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     protected final SVInstantiations instantiations;
 
     /**
-     * caches a created match condition (instantiations, RenameTable.EMPTY)
+     * caches a created match condition {@code (instantiations, RenameTable.EMPTY)}
      */
     private final MatchConditions matchConditions;
 
     /**
-     * chosen instantiations for the if sequent formulas
+     * chosen instantiations for the assumes-sequent formulas
      */
     protected final ImmutableList<IfFormulaInstantiation> ifInstantiations;
 
@@ -84,14 +85,6 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
         this.instantiations = instantiations;
         this.ifInstantiations = ifInstantiations;
         this.matchConditions = new MatchConditions(instantiations, RenameTable.EMPTY_TABLE);
-    }
-
-    /**
-     * constructs a TacletApp for the given taclet. With some information about required
-     * instantiations.
-     */
-    TacletApp(Taclet taclet, SVInstantiations instantiations) {
-        this(taclet, instantiations, null);
     }
 
     /**
@@ -162,7 +155,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      * @return the Rule the application information is collected for
      */
     @Override
-    public Rule rule() {
+    public Taclet rule() {
         return taclet;
     }
 
@@ -378,13 +371,15 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
         return true;
     }
 
-    /**
+    /*
      * applies the specified rule at the specified position if all schema variables have been
      * instantiated and creates a new goal if the if-sequent does not match. The new goal proves
-     * that the if sequent can be derived.
+     * that the assumes-sequent can be derived.
      *
      * @param goal the Goal where to apply the rule
+     *
      * @param services the Services encapsulating all java information
+     *
      * @return list of new created goals
      */
     /*
@@ -421,8 +416,8 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
 
 
     /**
-     * creates a new Tacletapp where the SchemaVariable sv is instantiated with the the given Term
-     * term. Sort equality is checked. If the check fails an IllegalArgumentException is thrown
+     * creates a new Tacletapp where the SchemaVariable sv is instantiated with the given term.
+     * Sort equality is checked. If the check fails an IllegalArgumentException is thrown.
      *
      * @param sv the SchemaVariable to be instantiated
      * @param term the Term the SchemaVariable is instantiated with
@@ -677,13 +672,17 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     }
 
     /**
+     * <p>
      * Collect names which would result in a clash for a new logical variable.
-     *
+     * </p>
+     * <p>
      * The clashing names include the names of the bound and unbound variables of "notFreeIn"
      * clauses. Additionally, equally-named program variables are avoided.
-     *
+     * </p>
+     * <p>
      * While this analysis is not strictly necessary (two different variables may bear the same
      * name), it is vital not to cause confusion with the user.
+     * </p>
      *
      * @param sv the schema variable to instantiate with a fresh variable, not <code>null</code>
      * @param services the services object, not <code>null</code>
@@ -814,7 +813,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     /**
      * checks if the instantiation of <code>sv</code> with <code>pe</code> is possible. If the
      * resulting instantiation is valid a new taclet application with an extended instantiation
-     * mapping is created and returned. Otherwise an exception is thrown.
+     * mapping is created and returned. Otherwise, an exception is thrown.
      *
      * @param sv the SchemaVariable to be instantiated
      * @param pe the ProgramElement the SV is instantiated with
@@ -887,8 +886,9 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
 
     /**
      * Creates a new Taclet application by matching the given formulas against the formulas of the
-     * if sequent, adding SV instantiations, constraints and metavariables as needed. This will fail
-     * if the if formulas have already been instantiated.
+     * assumes-sequent, adding SV instantiations, constraints and metavariables as needed. This will
+     * fail
+     * if the assumes-formulas have already been instantiated.
      */
     public TacletApp setIfFormulaInstantiations(ImmutableList<IfFormulaInstantiation> p_list,
             Services p_services) {
@@ -908,11 +908,13 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     }
 
     /**
-     * Find all possible instantiations of the if sequent formulas within the sequent "seq".
+     * Find all possible instantiations of the assumes-sequent formulas within the sequent "seq".
      *
      * @param seq uninstantiated if sequent from taclet
-     * @param services
-     * @return a list of tacletapps with the found if formula instantiations When the IfSequent is
+     * @param services the {@link Services} to access information about the logic signature or
+     *        program model
+     * @return a list of tacletapps with the found assumes-formula instantiations When the IfSequent
+     *         is
      *         empty, it returns a tacletapp with ifInstantiations == null instead of
      *         ifInstantiations == nil(), seemingly (LG 2022-02-07) to be more efficient.
      */
@@ -944,8 +946,10 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      * @param instAntec list of the formulas of the antecedent
      * @param instAlreadyMatched matched instantiations, for exactly those formulas that are no
      *        longer in ruleSuccTail and ruleAntecTail
-     * @param matchCond match conditions until now, i.e. after matching the first formulas of the assumes-sequent
-     * @param services the {@link Services} to access information about the logic signature or program model
+     * @param matchCond match conditions until now, i.e. after matching the first formulas of the
+     *        assumes-sequent
+     * @param services the {@link Services} to access information about the logic signature or
+     *        program model
      * @return a list of tacletapps with the found if formula instantiations
      */
     private ImmutableList<TacletApp> findIfFormulaInstantiationsHelp(
@@ -1021,7 +1025,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
     }
 
     /**
-     * @return true iff the if instantiation list is not null or no if sequent is needed
+     * @return true iff the if-instantiation list is not null or no if sequent is needed
      */
     public boolean ifInstsComplete() {
         return ifInstantiations != null || taclet().ifSequent().isEmpty();
@@ -1140,8 +1144,7 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      * @return null iff there is no conflict and one of the conflict-causing bound SchemaVariables
      */
     public SchemaVariable varSVNameConflict() {
-        for (SchemaVariable schemaVariable : uninstantiatedVars()) {
-            SchemaVariable sv = schemaVariable;
+        for (final SchemaVariable sv : uninstantiatedVars()) {
             if (sv instanceof TermSV || sv instanceof FormulaSV) {
                 TacletPrefix prefix = taclet().getPrefix(sv);
                 HashSet<Name> names = new LinkedHashSet<>();
@@ -1209,7 +1212,6 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
             if (nvc != null) {
                 KeYJavaType kjt;
                 Object o = nvc.getTypeDefiningObject();
-                JavaInfo javaInfo = services.getJavaInfo();
                 if (o instanceof SchemaVariable peerSV) {
                     final TypeConverter tc = services.getTypeConverter();
                     final Object peerInst = instantiations().getInstantiation(peerSV);
@@ -1302,16 +1304,12 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
         if (!matchConditions.equalsModProofIrrelevancy(that.matchConditions)) {
             return false;
         }
-        if ((missingVars != null || that.missingVars.size() != 0)
-                && (missingVars.size() != 0 || that.missingVars != null)
+        if ((missingVars != null || !that.missingVars.isEmpty())
+                && (!missingVars.isEmpty() || that.missingVars != null)
                 && !Objects.equals(missingVars, that.missingVars)) {
             return false;
         }
-        if (rule() instanceof Taclet) {
-            if (!((Taclet) rule()).equalsModProofIrrelevancy(that.rule())) {
-                return false;
-            }
-        } else if (!rule().equals(that.rule())) {
+        if (!taclet.equalsModProofIrrelevancy(that.taclet)) {
             return false;
         }
         return true;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -944,15 +944,14 @@ public abstract class TacletApp implements RuleApp, EqualsModProofIrrelevancy {
      * @param instAntec list of the formulas of the antecedent
      * @param instAlreadyMatched matched instantiations, for exactly those formulas that are no
      *        longer in ruleSuccTail and ruleAntecTail
-     * @param matchCond match conditions until now, i.e. after matching the first formulas of the if
-     *        sequent
-     * @param services
+     * @param matchCond match conditions until now, i.e. after matching the first formulas of the assumes-sequent
+     * @param services the {@link Services} to access information about the logic signature or program model
      * @return a list of tacletapps with the found if formula instantiations
      */
     private ImmutableList<TacletApp> findIfFormulaInstantiationsHelp(
             ImmutableList<SequentFormula> ruleSuccTail, ImmutableList<SequentFormula> ruleAntecTail,
-            ImmutableList<IfFormulaInstantiation> instSucc,
-            ImmutableList<IfFormulaInstantiation> instAntec,
+            ImmutableArray<IfFormulaInstantiation> instSucc,
+            ImmutableArray<IfFormulaInstantiation> instAntec,
             ImmutableList<IfFormulaInstantiation> instAlreadyMatched, MatchConditions matchCond,
             Services services) {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletMatcher.java
@@ -8,8 +8,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.SVSubstitute;
 import de.uka.ilkd.key.logic.op.SchemaVariable;
-
-import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableArray;
 
 public interface TacletMatcher {
 
@@ -29,8 +28,8 @@ public interface TacletMatcher {
      *         could successfully be matched against p_template, and the corresponding
      *         MatchConditions.
      */
-    IfMatchResult matchIf(ImmutableList<IfFormulaInstantiation> p_toMatch,
-            Term p_template, MatchConditions p_matchCond, Services p_services);
+    IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
+                          Term p_template, MatchConditions p_matchCond, Services p_services);
 
     /**
      * Match the whole if sequent using the given list of instantiations of all assumes-sequent

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletMatcher.java
@@ -8,7 +8,6 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.SVSubstitute;
 import de.uka.ilkd.key.logic.op.SchemaVariable;
-import org.key_project.util.collection.ImmutableArray;
 
 public interface TacletMatcher {
 
@@ -29,7 +28,7 @@ public interface TacletMatcher {
      *         MatchConditions.
      */
     IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
-                          Term p_template, MatchConditions p_matchCond, Services p_services);
+            Term p_template, MatchConditions p_matchCond, Services p_services);
 
     /**
      * Match the whole if sequent using the given list of instantiations of all assumes-sequent

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/match/legacy/LegacyTacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/match/legacy/LegacyTacletMatcher.java
@@ -223,7 +223,7 @@ public final class LegacyTacletMatcher implements TacletMatcher {
      */
     @Override
     public IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
-                                 Term p_template, MatchConditions p_matchCond, Services p_services) {
+            Term p_template, MatchConditions p_matchCond, Services p_services) {
         ImmutableList<IfFormulaInstantiation> resFormulas =
             ImmutableSLList.nil();
         ImmutableList<MatchConditions> resMC = ImmutableSLList.nil();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/match/legacy/LegacyTacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/match/legacy/LegacyTacletMatcher.java
@@ -219,12 +219,11 @@ public final class LegacyTacletMatcher implements TacletMatcher {
     /**
      * (non-Javadoc)
      *
-     * @see de.uka.ilkd.key.rule.TacletMatcher#matchIf(ImmutableList, de.uka.ilkd.key.logic.Term,
-     *      de.uka.ilkd.key.rule.MatchConditions, de.uka.ilkd.key.java.Services)
+     * @see TacletMatcher#matchIf(ImmutableArray, Term, MatchConditions, Services)
      */
     @Override
-    public IfMatchResult matchIf(ImmutableList<IfFormulaInstantiation> p_toMatch,
-            Term p_template, MatchConditions p_matchCond, Services p_services) {
+    public IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
+                                 Term p_template, MatchConditions p_matchCond, Services p_services) {
         ImmutableList<IfFormulaInstantiation> resFormulas =
             ImmutableSLList.nil();
         ImmutableList<MatchConditions> resMC = ImmutableSLList.nil();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
@@ -39,10 +39,12 @@ import org.key_project.util.collection.ImmutableSet;
  * <p>
  * Matching algorithm using a virtual machine based approach inspired by Voronkonv et al. It matches
  * exactly one taclet and does not produce code trees.
- *</p><p>
+ * </p>
+ * <p>
  * Instances of this class should <strong>not</strong> be created directly, use
  * {@link TacletMatcherKit#createTacletMatcher(Taclet)} instead.
- *</p>
+ * </p>
+ *
  * @see TacletMatcherKit
  */
 public class VMTacletMatcher implements TacletMatcher {
@@ -110,7 +112,7 @@ public class VMTacletMatcher implements TacletMatcher {
      */
     @Override
     public final IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
-                                       Term p_template, MatchConditions p_matchCond, Services p_services) {
+            Term p_template, MatchConditions p_matchCond, Services p_services) {
         TacletMatchProgram prg = assumesMatchPrograms.get(p_template);
 
 
@@ -148,7 +150,8 @@ public class VMTacletMatcher implements TacletMatcher {
 
     /**
      * the formula ensures that the update context described the update of the given formula.
-     * If it does not then {@code null} is returned, otherwise the formula without the update context.
+     * If it does not then {@code null} is returned, otherwise the formula without the update
+     * context.
      *
      * @param context the list of update label pairs describing the update context
      * @param formula the formula whose own update context must be equal (modulo renaming) to the
@@ -331,7 +334,7 @@ public class VMTacletMatcher implements TacletMatcher {
         if (findMatchProgram != TacletMatchProgram.EMPTY_PROGRAM) {
             if (ignoreTopLevelUpdates) {
                 Pair</* term below updates */Term, MatchConditions> resultUpdateMatch =
-                        matchAndIgnoreUpdatePrefix(term, matchCond);
+                    matchAndIgnoreUpdatePrefix(term, matchCond);
                 term = resultUpdateMatch.first;
                 matchCond = resultUpdateMatch.second;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.TermServices;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.op.SVSubstitute;
@@ -37,12 +36,13 @@ import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
+ * <p>
  * Matching algorithm using a virtual machine based approach inspired by Voronkonv et al. It matches
  * exactly one taclet and does not produce code trees.
- *
+ *</p><p>
  * Instances of this class should <strong>not</strong> be created directly, use
  * {@link TacletMatcherKit#createTacletMatcher(Taclet)} instead.
- *
+ *</p>
  * @see TacletMatcherKit
  */
 public class VMTacletMatcher implements TacletMatcher {
@@ -106,12 +106,11 @@ public class VMTacletMatcher implements TacletMatcher {
     /**
      * (non-Javadoc)
      *
-     * @see de.uka.ilkd.key.rule.TacletMatcher#matchIf(ImmutableList, de.uka.ilkd.key.logic.Term,
-     *      de.uka.ilkd.key.rule.MatchConditions, de.uka.ilkd.key.java.Services)
+     * @see TacletMatcher#matchIf(Iterable, Term, MatchConditions, Services)
      */
     @Override
-    public final IfMatchResult matchIf(ImmutableList<IfFormulaInstantiation> p_toMatch,
-            Term p_template, MatchConditions p_matchCond, Services p_services) {
+    public final IfMatchResult matchIf(Iterable<IfFormulaInstantiation> p_toMatch,
+                                       Term p_template, MatchConditions p_matchCond, Services p_services) {
         TacletMatchProgram prg = assumesMatchPrograms.get(p_template);
 
 
@@ -128,11 +127,7 @@ public class VMTacletMatcher implements TacletMatcher {
             context = p_matchCond.getInstantiations().getUpdateContext();
         }
 
-        ImmutableList<IfFormulaInstantiation> workingList = p_toMatch;
-        while (!workingList.isEmpty()) {
-            final IfFormulaInstantiation cf = workingList.head();
-            workingList = workingList.tail();
-
+        for (var cf : p_toMatch) {
             Term formula = cf.getConstrainedFormula().formula();
 
             if (updateContextPresent) {
@@ -152,8 +147,8 @@ public class VMTacletMatcher implements TacletMatcher {
     }
 
     /**
-     * the formula ensures that the update context described the update of the given formula It it
-     * does not {@code null} is returned, otherwise the formula without the update context.
+     * the formula ensures that the update context described the update of the given formula.
+     * If it does not then {@code null} is returned, otherwise the formula without the update context.
      *
      * @param context the list of update label pairs describing the update context
      * @param formula the formula whose own update context must be equal (modulo renaming) to the
@@ -308,12 +303,11 @@ public class VMTacletMatcher implements TacletMatcher {
      *
      * @param term the term to be matched
      * @param matchCond the accumulated match conditions for a successful match
-     * @param services the Services
      * @return a pair of updated match conditions and the unwrapped term without the ignored updates
      *         (Which have been added to the update context in the match conditions)
      */
     private Pair<Term, MatchConditions> matchAndIgnoreUpdatePrefix(final Term term,
-            MatchConditions matchCond, final TermServices services) {
+            MatchConditions matchCond) {
 
         final Operator sourceOp = term.op();
 
@@ -322,8 +316,7 @@ public class VMTacletMatcher implements TacletMatcher {
             Term update = UpdateApplication.getUpdate(term);
             matchCond = matchCond.setInstantiations(
                 matchCond.getInstantiations().addUpdate(update, term.getLabels()));
-            return matchAndIgnoreUpdatePrefix(UpdateApplication.getTarget(term), matchCond,
-                services);
+            return matchAndIgnoreUpdatePrefix(UpdateApplication.getTarget(term), matchCond);
         } else {
             return new Pair<>(term, matchCond);
         }
@@ -338,7 +331,7 @@ public class VMTacletMatcher implements TacletMatcher {
         if (findMatchProgram != TacletMatchProgram.EMPTY_PROGRAM) {
             if (ignoreTopLevelUpdates) {
                 Pair</* term below updates */Term, MatchConditions> resultUpdateMatch =
-                    matchAndIgnoreUpdatePrefix(term, matchCond, services);
+                        matchAndIgnoreUpdatePrefix(term, matchCond);
                 term = resultUpdateMatch.first;
                 matchCond = resultUpdateMatch.second;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.RuleSet;
 import de.uka.ilkd.key.strategy.feature.ConditionalFeature;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.feature.RuleSetDispatchFeature;
 import de.uka.ilkd.key.strategy.feature.instantiator.BackTrackingManager;
 import de.uka.ilkd.key.strategy.feature.instantiator.ForEachCP;
@@ -106,13 +107,14 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection im
         d.clear(getHeuristic(ruleSet));
     }
 
-    private final BackTrackingManager btManager = new BackTrackingManager();
 
     public void instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal,
             RuleAppCostCollector collector) {
+        final MutableState mState = new MutableState();
+        final BackTrackingManager btManager = mState.getBacktrackingManager();
         btManager.setup(app);
         do {
-            final RuleAppCost cost = instantiateApp(app, pio, goal);
+            final RuleAppCost cost = instantiateApp(app, pio, goal, mState);
             if (cost instanceof TopRuleAppCost) {
                 continue;
             }
@@ -124,14 +126,14 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection im
         } while (btManager.backtrack());
     }
 
-    protected abstract RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal);
+    protected abstract RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState);
 
     protected Feature forEach(TermBuffer x, TermGenerator gen, Feature body) {
-        return ForEachCP.create(x, gen, body, btManager);
+        return ForEachCP.create(x, gen, body);
     }
 
     protected Feature oneOf(Feature[] features) {
-        return OneOfCP.create(features, btManager);
+        return OneOfCP.create(features);
     }
 
     protected Feature oneOf(Feature feature0, Feature feature1) {
@@ -154,7 +156,7 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection im
 
     protected Feature instantiate(Name sv, ProjectionToTerm value) {
         if (instantiateActive) {
-            return SVInstantiationCP.create(sv, value, btManager);
+            return SVInstantiationCP.create(sv, value);
         } else {
             return longConst(0);
         }
@@ -162,7 +164,7 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection im
 
     protected Feature instantiateTriggeredVariable(ProjectionToTerm value) {
         if (instantiateActive) {
-            return SVInstantiationCP.createTriggeredVarCP(value, btManager);
+            return SVInstantiationCP.createTriggeredVarCP(value);
         } else {
             return longConst(0);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
@@ -126,7 +126,8 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection im
         } while (btManager.backtrack());
     }
 
-    protected abstract RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState);
+    protected abstract RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState);
 
     protected Feature forEach(TermBuffer x, TermGenerator gen, Feature body) {
         return ForEachCP.create(x, gen, body);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/BuiltInRuleAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/BuiltInRuleAppContainer.java
@@ -96,10 +96,7 @@ public class BuiltInRuleAppContainer extends RuleAppContainer {
     static RuleAppContainer createAppContainer(IBuiltInRuleApp bir, PosInOccurrence pio,
             Goal goal) {
         final RuleAppCost cost = goal.getGoalStrategy().computeCost(bir, pio, goal);
-
-        final BuiltInRuleAppContainer container = new BuiltInRuleAppContainer(bir, pio, cost, goal);
-
-        return container;
+        return new BuiltInRuleAppContainer(bir, pio, cost, goal);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FIFOStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FIFOStrategy.java
@@ -29,7 +29,8 @@ public class FIFOStrategy implements Strategy {
      *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
      *         all (it is discarded by the strategy).
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         return NumberRuleAppCost.create(goal.getTime());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FIFOStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FIFOStrategy.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.definition.StrategySettingsDefinition;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Trivial implementation of the Strategy interface that uses only the goal time to determine the
@@ -28,7 +29,7 @@ public class FIFOStrategy implements Strategy {
      *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
      *         all (it is discarded by the strategy).
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         return NumberRuleAppCost.create(goal.getTime());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
@@ -116,7 +116,8 @@ public class FocussedRuleApplicationManager
                  * rule app within the focussed formula, but not within the focussed subterm
                  */
                 return isBelow(focFormula, pos) && !NonDuplicateAppModPositionFeature.INSTANCE
-                        .computeCost(rule, pos, goal, new MutableState()).equals(BinaryFeature.TOP_COST);
+                        .computeCost(rule, pos, goal, new MutableState())
+                        .equals(BinaryFeature.TOP_COST);
             } else {
                 return !onlyModifyFocussedFormula;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.proof.FormulaTag;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.feature.NonDuplicateAppModPositionFeature;
 
 import org.key_project.util.collection.ImmutableList;
@@ -115,7 +116,7 @@ public class FocussedRuleApplicationManager
                  * rule app within the focussed formula, but not within the focussed subterm
                  */
                 return isBelow(focFormula, pos) && !NonDuplicateAppModPositionFeature.INSTANCE
-                        .computeCost(rule, pos, goal).equals(BinaryFeature.TOP_COST);
+                        .computeCost(rule, pos, goal, new MutableState()).equals(BinaryFeature.TOP_COST);
             } else {
                 return !onlyModifyFocussedFormula;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiationCachePool.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiationCachePool.java
@@ -13,7 +13,7 @@ import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.rule.IfFormulaInstantiation;
 
 import org.key_project.util.LRUCache;
-import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableArray;
 
 /**
  * Direct-mapped cache of lists of formulas (potential instantiations of if-formulas of taclets)
@@ -70,19 +70,19 @@ public class IfInstantiationCachePool {
 
     public static class IfInstantiationCache {
 
-        private final HashMap<Long, ImmutableList<IfFormulaInstantiation>> antecCache =
+        private final HashMap<Long, ImmutableArray<IfFormulaInstantiation>> antecCache =
             new LinkedHashMap<>();
-        private final HashMap<Long, ImmutableList<IfFormulaInstantiation>> succCache =
+        private final HashMap<Long, ImmutableArray<IfFormulaInstantiation>> succCache =
             new LinkedHashMap<>();
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         private final ReadLock readLock = lock.readLock();
         private final WriteLock writeLock = lock.writeLock();
 
-        public ImmutableList<IfFormulaInstantiation> get(boolean antec, Long key) {
+        public ImmutableArray<IfFormulaInstantiation> get(boolean antec, Long key) {
             try {
                 readLock.lock();
-                final HashMap<Long, ImmutableList<IfFormulaInstantiation>> cache =
+                final HashMap<Long, ImmutableArray<IfFormulaInstantiation>> cache =
                     antec ? antecCache : succCache;
                 return cache.get(key);
             } finally {
@@ -90,8 +90,8 @@ public class IfInstantiationCachePool {
             }
         }
 
-        public void put(boolean antec, Long key, ImmutableList<IfFormulaInstantiation> value) {
-            final HashMap<Long, ImmutableList<IfFormulaInstantiation>> cache =
+        public void put(boolean antec, Long key, ImmutableArray<IfFormulaInstantiation> value) {
+            final HashMap<Long, ImmutableArray<IfFormulaInstantiation>> cache =
                 antec ? antecCache : succCache;
             try {
                 writeLock.lock();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiator.java
@@ -22,6 +22,7 @@ import de.uka.ilkd.key.rule.Taclet;
 import de.uka.ilkd.key.strategy.IfInstantiationCachePool.IfInstantiationCache;
 import de.uka.ilkd.key.util.Debug;
 
+import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
@@ -32,8 +33,8 @@ public class IfInstantiator {
     private final Goal goal;
     private final IfInstantiationCache ifInstCache;
 
-    private ImmutableList<IfFormulaInstantiation> allAntecFormulas;
-    private ImmutableList<IfFormulaInstantiation> allSuccFormulas;
+    private ImmutableArray<IfFormulaInstantiation> allAntecFormulas;
+    private ImmutableArray<IfFormulaInstantiation> allSuccFormulas;
 
     private ImmutableList<NoPosTacletApp> results = ImmutableSLList.nil();
 
@@ -58,7 +59,7 @@ public class IfInstantiator {
     }
 
     /**
-     * Find all possible instantiations of the if sequent formulas within the sequent "p_seq".
+     * Find all possible instantiations of the assumes-sequent formulas within the sequent {@code goal.sequent()}
      */
     public void findIfFormulaInstantiations() {
         final Sequent p_seq = goal.sequent();
@@ -92,18 +93,18 @@ public class IfInstantiator {
      * @return a list of potential if-formula instantiations (analogously to
      *         <code>IfFormulaInstSeq.createList</code>)
      */
-    private ImmutableList<IfFormulaInstantiation> getSequentFormulas(boolean p_antec,
+    private ImmutableArray<IfFormulaInstantiation> getSequentFormulas(boolean p_antec,
             boolean p_all) {
         if (p_all) {
             return getAllSequentFormulas(p_antec);
         }
 
-        final ImmutableList<IfFormulaInstantiation> cache = getNewSequentFormulasFromCache(p_antec);
+        final ImmutableArray<IfFormulaInstantiation> cache = getNewSequentFormulasFromCache(p_antec);
         if (cache != null) {
             return cache;
         }
 
-        final ImmutableList<IfFormulaInstantiation> newFormulas = selectNewFormulas(p_antec);
+        final ImmutableArray<IfFormulaInstantiation> newFormulas = selectNewFormulas(p_antec);
 
         addNewSequentFormulasToCache(newFormulas, p_antec);
 
@@ -116,16 +117,18 @@ public class IfInstantiator {
      *         the current goal for which the method <code>isNewFormula</code> returns
      *         <code>true</code>
      */
-    private ImmutableList<IfFormulaInstantiation> selectNewFormulas(boolean p_antec) {
-        ImmutableList<IfFormulaInstantiation> res = ImmutableSLList.nil();
+    private ImmutableArray<IfFormulaInstantiation> selectNewFormulas(boolean p_antec) {
+        final ImmutableArray<IfFormulaInstantiation> allSequentFormulas = getAllSequentFormulas(p_antec);
+        final IfFormulaInstantiation[] res = new IfFormulaInstantiation[allSequentFormulas.size()];
 
-        for (final IfFormulaInstantiation ifInstantiation : getAllSequentFormulas(p_antec)) {
+        int i = 0;
+        for (final IfFormulaInstantiation ifInstantiation : allSequentFormulas) {
             if (isNewFormulaDirect((IfFormulaInstSeq) ifInstantiation)) {
-                res = res.prepend(ifInstantiation);
+                res[i] = ifInstantiation;
+                ++i;
             }
         }
-
-        return res;
+        return new ImmutableArray<>(res, 0, i);
     }
 
     /**
@@ -136,7 +139,7 @@ public class IfInstantiator {
     private boolean isNewFormula(IfFormulaInstSeq p_ifInstantiation) {
         final boolean antec = p_ifInstantiation.inAntec();
 
-        final ImmutableList<IfFormulaInstantiation> cache = getNewSequentFormulasFromCache(antec);
+        final ImmutableArray<IfFormulaInstantiation> cache = getNewSequentFormulasFromCache(antec);
 
         if (cache != null) {
             return cache.contains(p_ifInstantiation);
@@ -167,17 +170,17 @@ public class IfInstantiator {
         return tacletAppContainer.getAge() < formulaAge;
     }
 
-    private ImmutableList<IfFormulaInstantiation> getNewSequentFormulasFromCache(boolean p_antec) {
+    private ImmutableArray<IfFormulaInstantiation> getNewSequentFormulasFromCache(boolean p_antec) {
         return ifInstCache.get(p_antec, tacletAppContainer.getAge());
     }
 
-    private void addNewSequentFormulasToCache(ImmutableList<IfFormulaInstantiation> p_list,
+    private void addNewSequentFormulasToCache(ImmutableArray<IfFormulaInstantiation> p_list,
             boolean p_antec) {
         ifInstCache.put(p_antec, tacletAppContainer.getAge(), p_list);
     }
 
 
-    private ImmutableList<IfFormulaInstantiation> getAllSequentFormulas(boolean p_antec) {
+    private ImmutableArray<IfFormulaInstantiation> getAllSequentFormulas(boolean p_antec) {
         return p_antec ? allAntecFormulas : allSuccFormulas;
     }
 
@@ -187,14 +190,14 @@ public class IfInstantiator {
      * @param p_ifSeqTail tail of the current semisequent as list
      * @param p_ifSeqTail2nd the following semisequent (i.e. antecedent) or null
      * @param p_matchCond match conditions until now, i.e. after matching the first formulas of the
-     *        if sequent
+     *        assumes-sequent
      * @param p_alreadyMatchedNewFor at least one new formula has already been matched, i.e. a
      *        formula that has been modified recently
      */
     private void findIfFormulaInstantiationsHelp(ImmutableList<SequentFormula> p_ifSeqTail,
             ImmutableList<SequentFormula> p_ifSeqTail2nd,
-            ImmutableList<IfFormulaInstantiation> p_alreadyMatched, MatchConditions p_matchCond,
-            boolean p_alreadyMatchedNewFor) {
+                                                 ImmutableList<IfFormulaInstantiation> p_alreadyMatched,
+                                                 MatchConditions p_matchCond, boolean p_alreadyMatchedNewFor) {
 
         while (p_ifSeqTail.isEmpty()) {
             if (p_ifSeqTail2nd == null) {
@@ -212,7 +215,7 @@ public class IfInstantiator {
         final boolean antec = p_ifSeqTail2nd == null;
         final boolean lastIfFormula =
             p_ifSeqTail.size() == 1 && (p_ifSeqTail2nd == null || p_ifSeqTail2nd.isEmpty());
-        final ImmutableList<IfFormulaInstantiation> formulas =
+        final ImmutableArray<IfFormulaInstantiation> formulas =
             getSequentFormulas(antec, !lastIfFormula || p_alreadyMatchedNewFor);
         final IfMatchResult mr = getTaclet().getMatcher().matchIf(formulas,
             p_ifSeqTail.head().formula(), p_matchCond, getServices());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IfInstantiator.java
@@ -59,7 +59,8 @@ public class IfInstantiator {
     }
 
     /**
-     * Find all possible instantiations of the assumes-sequent formulas within the sequent {@code goal.sequent()}
+     * Find all possible instantiations of the assumes-sequent formulas within the sequent
+     * {@code goal.sequent()}
      */
     public void findIfFormulaInstantiations() {
         final Sequent p_seq = goal.sequent();
@@ -99,7 +100,8 @@ public class IfInstantiator {
             return getAllSequentFormulas(p_antec);
         }
 
-        final ImmutableArray<IfFormulaInstantiation> cache = getNewSequentFormulasFromCache(p_antec);
+        final ImmutableArray<IfFormulaInstantiation> cache =
+            getNewSequentFormulasFromCache(p_antec);
         if (cache != null) {
             return cache;
         }
@@ -118,7 +120,8 @@ public class IfInstantiator {
      *         <code>true</code>
      */
     private ImmutableArray<IfFormulaInstantiation> selectNewFormulas(boolean p_antec) {
-        final ImmutableArray<IfFormulaInstantiation> allSequentFormulas = getAllSequentFormulas(p_antec);
+        final ImmutableArray<IfFormulaInstantiation> allSequentFormulas =
+            getAllSequentFormulas(p_antec);
         final IfFormulaInstantiation[] res = new IfFormulaInstantiation[allSequentFormulas.size()];
 
         int i = 0;
@@ -196,8 +199,8 @@ public class IfInstantiator {
      */
     private void findIfFormulaInstantiationsHelp(ImmutableList<SequentFormula> p_ifSeqTail,
             ImmutableList<SequentFormula> p_ifSeqTail2nd,
-                                                 ImmutableList<IfFormulaInstantiation> p_alreadyMatched,
-                                                 MatchConditions p_matchCond, boolean p_alreadyMatchedNewFor) {
+            ImmutableList<IfFormulaInstantiation> p_alreadyMatched,
+            MatchConditions p_matchCond, boolean p_alreadyMatchedNewFor) {
 
         while (p_ifSeqTail.isEmpty()) {
             if (p_ifSeqTail2nd == null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
@@ -17,8 +17,6 @@ import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 public class IntroducedSymbolBy extends BinaryTacletAppFeature {
-
-
     private final Name ruleSetName;
     private final Name schemaVar;
     private final ProjectionToTerm term;
@@ -46,16 +44,13 @@ public class IntroducedSymbolBy extends BinaryTacletAppFeature {
             if (ra instanceof TacletApp ta) {
                 if (ta.taclet().getRuleSets().contains(new RuleSet(ruleSetName))) {
                     final Object svInstValue = ta.instantiations().lookupValue(schemaVar);
-                    if (svInstValue instanceof Term) {
-                        return term.toTerm(app, pos, goal, mState).op() == ((Term) svInstValue)
-                                .op();
+                    if (svInstValue instanceof Term svInstAsTerm) {
+                        return term.toTerm(app, pos, goal, mState).op() == svInstAsTerm.op();
                     }
                 }
             }
             n = n.parent();
         }
-
         return false;
     }
-
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
@@ -47,7 +47,8 @@ public class IntroducedSymbolBy extends BinaryTacletAppFeature {
                 if (ta.taclet().getRuleSets().contains(new RuleSet(ruleSetName))) {
                     final Object svInstValue = ta.instantiations().lookupValue(schemaVar);
                     if (svInstValue instanceof Term) {
-                        return term.toTerm(app, pos, goal, mState).op() == ((Term) svInstValue).op();
+                        return term.toTerm(app, pos, goal, mState).op() == ((Term) svInstValue)
+                                .op();
                     }
                 }
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/IntroducedSymbolBy.java
@@ -13,6 +13,7 @@ import de.uka.ilkd.key.rule.RuleSet;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.strategy.feature.BinaryTacletAppFeature;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 public class IntroducedSymbolBy extends BinaryTacletAppFeature {
@@ -36,7 +37,7 @@ public class IntroducedSymbolBy extends BinaryTacletAppFeature {
     }
 
     @Override
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Node root = goal.proof().root();
 
         Node n = goal.node();
@@ -46,7 +47,7 @@ public class IntroducedSymbolBy extends BinaryTacletAppFeature {
                 if (ta.taclet().getRuleSets().contains(new RuleSet(ruleSetName))) {
                     final Object svInstValue = ta.instantiations().lookupValue(schemaVar);
                     if (svInstValue instanceof Term) {
-                        return term.toTerm(app, pos, goal).op() == ((Term) svInstValue).op();
+                        return term.toTerm(app, pos, goal, mState).op() == ((Term) svInstValue).op();
                     }
                 }
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
@@ -2040,17 +2040,19 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
     /**
      * Evaluate the cost of a <code>RuleApp</code>.
      *
-     * @param app    rule application
-     * @param pio    corresponding {@link PosInOccurrence}
-     * @param goal   corresponding goal
-     * @param mState the {@link MutableState} to query for information like current value of {@link TermBuffer}s or
-     * {@link de.uka.ilkd.key.strategy.feature.instantiator.ChoicePoint}s
+     * @param app rule application
+     * @param pio corresponding {@link PosInOccurrence}
+     * @param goal corresponding goal
+     * @param mState the {@link MutableState} to query for information like current value of
+     *        {@link TermBuffer}s or
+     *        {@link de.uka.ilkd.key.strategy.feature.instantiator.ChoicePoint}s
      * @return the cost of the rule application expressed as a <code>RuleAppCost</code> object.
-     * <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
-     * all (it is discarded by the strategy).
+     *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
+     *         all (it is discarded by the strategy).
      */
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         var time = System.nanoTime();
         try {
             return costComputationF.computeCost(app, pio, goal, mState);
@@ -2072,14 +2074,16 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
     public final boolean isApprovedApp(RuleApp app, PosInOccurrence pio, Goal goal) {
         var time = System.nanoTime();
         try {
-            return !(approvalF.computeCost(app, pio, goal, new MutableState()) == TopRuleAppCost.INSTANCE);
+            return !(approvalF.computeCost(app, pio, goal,
+                new MutableState()) == TopRuleAppCost.INSTANCE);
         } finally {
             PERF_APPROVE.addAndGet(System.nanoTime() - time);
         }
     }
 
     @Override
-    protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         var time = System.nanoTime();
         try {
             return instantiationF.computeCost(app, pio, goal, mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/JavaCardDLStrategy.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.ldt.SeqLDT;
 import de.uka.ilkd.key.logic.Name;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.PosInTerm;
+import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Equality;
 import de.uka.ilkd.key.logic.op.Junctor;
 import de.uka.ilkd.key.logic.op.Quantifier;
@@ -1432,10 +1433,31 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
                 applyTF("subsumRightBigger", tf.polynomial), PolynomialValuesCmpFeature
                         .lt(instOf("subsumRightSmaller"), instOf("subsumRightBigger"))));
 
-        final TermBuffer one = new TermBuffer();
-        one.setContent(getServices().getTermBuilder().zTerm("1"));
-        final TermBuffer two = new TermBuffer();
-        two.setContent(getServices().getTermBuilder().zTerm("2"));
+        final Term tOne = getServices().getTermBuilder().zTerm("1");
+        final TermBuffer one = new TermBuffer() {
+            public void setContent(Term t, MutableState mState) {}
+
+            public Term getContent(MutableState mState) {
+                return tOne;
+            }
+
+            public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return tOne;
+            }
+        };
+
+        final Term tTwo = getServices().getTermBuilder().zTerm("2");
+        final TermBuffer two = new TermBuffer() {
+            public void setContent(Term t, MutableState mState) {}
+
+            public Term getContent(MutableState mState) {
+                return tTwo;
+            }
+
+            public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return tTwo;
+            }
+        };
 
         bindRuleSet(d, "inEqSimp_or_tautInEqs",
             SumFeature.createSum(applyTF("tautLeft", tf.monomial),
@@ -2018,18 +2040,20 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
     /**
      * Evaluate the cost of a <code>RuleApp</code>.
      *
-     * @param app rule application
-     * @param pio corresponding {@link PosInOccurrence}
-     * @param goal corresponding goal
+     * @param app    rule application
+     * @param pio    corresponding {@link PosInOccurrence}
+     * @param goal   corresponding goal
+     * @param mState the {@link MutableState} to query for information like current value of {@link TermBuffer}s or
+     * {@link de.uka.ilkd.key.strategy.feature.instantiator.ChoicePoint}s
      * @return the cost of the rule application expressed as a <code>RuleAppCost</code> object.
-     *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
-     *         all (it is discarded by the strategy).
+     * <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
+     * all (it is discarded by the strategy).
      */
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         var time = System.nanoTime();
         try {
-            return costComputationF.computeCost(app, pio, goal);
+            return costComputationF.computeCost(app, pio, goal, mState);
         } finally {
             PERF_COMPUTE.addAndGet(System.nanoTime() - time);
         }
@@ -2048,17 +2072,17 @@ public class JavaCardDLStrategy extends AbstractFeatureStrategy {
     public final boolean isApprovedApp(RuleApp app, PosInOccurrence pio, Goal goal) {
         var time = System.nanoTime();
         try {
-            return !(approvalF.computeCost(app, pio, goal) == TopRuleAppCost.INSTANCE);
+            return !(approvalF.computeCost(app, pio, goal, new MutableState()) == TopRuleAppCost.INSTANCE);
         } finally {
             PERF_APPROVE.addAndGet(System.nanoTime() - time);
         }
     }
 
     @Override
-    protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal) {
+    protected RuleAppCost instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         var time = System.nanoTime();
         try {
-            return instantiationF.computeCost(app, pio, goal);
+            return instantiationF.computeCost(app, pio, goal, mState);
         } finally {
             PERF_INSTANTIATE.addAndGet(System.nanoTime() - time);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -10,8 +10,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
-
 import de.uka.ilkd.key.strategy.feature.Feature;
+
 import org.key_project.util.collection.ImmutableHeap;
 import org.key_project.util.collection.ImmutableLeftistHeap;
 import org.key_project.util.collection.ImmutableList;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 
+import de.uka.ilkd.key.strategy.feature.Feature;
 import org.key_project.util.collection.ImmutableHeap;
 import org.key_project.util.collection.ImmutableLeftistHeap;
 import org.key_project.util.collection.ImmutableList;
@@ -25,7 +26,7 @@ import org.jspecify.annotations.Nullable;
  * {@link RuleApp} corresponds to its {@link RuleAppCost}. A {@link RuleApp} can be equipped with a
  * {@link RuleAppCost} by converting it into a {@link RuleAppContainer}. The cost of a
  * {@link RuleApp} is computed according to a given {@link Strategy} (see
- * {@link Strategy#computeCost(RuleApp, PosInOccurrence, Goal)}).
+ * {@link Feature#computeCost(RuleApp, PosInOccurrence, Goal, de.uka.ilkd.key.strategy.feature.MutableState)}).
  */
 public class QueueRuleApplicationManager implements AutomatedRuleApplicationManager {
     public static final AtomicLong PERF_QUEUE_OPS = new AtomicLong();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/SimpleFilteredStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/SimpleFilteredStrategy.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.proof.rulefilter.RuleFilter;
 import de.uka.ilkd.key.proof.rulefilter.TacletFilter;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.feature.NonDuplicateAppFeature;
 
 /**
@@ -43,12 +44,12 @@ public class SimpleFilteredStrategy implements Strategy {
      *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
      *         all (it is discarded by the strategy).
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         if (app instanceof TacletApp && !ruleFilter.filter(app.rule())) {
             return TopRuleAppCost.INSTANCE;
         }
 
-        RuleAppCost res = NonDuplicateAppFeature.INSTANCE.computeCost(app, pio, goal);
+        RuleAppCost res = NonDuplicateAppFeature.INSTANCE.computeCost(app, pio, goal, mState);
         if (res == TopRuleAppCost.INSTANCE) {
             return res;
         }
@@ -70,7 +71,7 @@ public class SimpleFilteredStrategy implements Strategy {
     public boolean isApprovedApp(RuleApp app, PosInOccurrence pio, Goal goal) {
         // do not apply a rule twice
         return !(app instanceof TacletApp) || NonDuplicateAppFeature.INSTANCE.computeCost(app, pio,
-            goal) != TopRuleAppCost.INSTANCE;
+            goal, new MutableState()) != TopRuleAppCost.INSTANCE;
     }
 
     public void instantiateApp(RuleApp app, PosInOccurrence pio, Goal goal,

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/SimpleFilteredStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/SimpleFilteredStrategy.java
@@ -44,7 +44,8 @@ public class SimpleFilteredStrategy implements Strategy {
      *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
      *         all (it is discarded by the strategy).
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         if (app instanceof TacletApp && !ruleFilter.filter(app.rule())) {
             return TopRuleAppCost.INSTANCE;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/Strategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/Strategy.java
@@ -10,13 +10,29 @@ import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Generic interface for evaluating the cost of a RuleApp with regard to a specific strategy
  */
 public interface Strategy extends Named, Feature {
     /**
-     * Checks if the {@link Strategy} should stop at the first non closeable {@link Goal}.
+     * Evaluate the cost of a <code>RuleApp</code>. Starts a new independent computation.
+     *
+     * @param app the RuleApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
+     * @return the cost of the rule application expressed as a
+     * <code>RuleAppCost</code> object. <code>TopRuleAppCost.INSTANCE</code>
+     * indicates that the rule shall not be applied at all (it is discarded by
+     * the strategy).
+     */
+    default RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+        return computeCost(app, pos, goal, new MutableState());
+    }
+
+    /**
+     * Checks if the {@link Strategy} should stop at the first non-closeable {@link Goal}.
      *
      * @return {@code true} stop, {@code false} continue on other {@link Goal}s.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/Strategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/Strategy.java
@@ -23,9 +23,9 @@ public interface Strategy extends Named, Feature {
      * @param pos position where <code>app</code> is to be applied
      * @param goal the goal on which <code>app</code> is to be applied
      * @return the cost of the rule application expressed as a
-     * <code>RuleAppCost</code> object. <code>TopRuleAppCost.INSTANCE</code>
-     * indicates that the rule shall not be applied at all (it is discarded by
-     * the strategy).
+     *         <code>RuleAppCost</code> object. <code>TopRuleAppCost.INSTANCE</code>
+     *         indicates that the rule shall not be applied at all (it is discarded by
+     *         the strategy).
      */
     default RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
         return computeCost(app, pos, goal, new MutableState());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractBetaFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractBetaFeature.java
@@ -319,13 +319,14 @@ public abstract class AbstractBetaFeature implements Feature {
     /**
      * Compute the cost of a RuleApp.
      *
-     * @param app    the RuleApp
-     * @param pos    position where <code>app</code> is to be applied
-     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param app the RuleApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
      * @param mState
      * @return the cost of <code>app</code>
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final Term findTerm = pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractBetaFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractBetaFeature.java
@@ -319,12 +319,13 @@ public abstract class AbstractBetaFeature implements Feature {
     /**
      * Compute the cost of a RuleApp.
      *
-     * @param app the RuleApp
-     * @param pos position where <code>app</code> is to be applied
-     * @param goal the goal on which <code>app</code> is to be applied
+     * @param app    the RuleApp
+     * @param pos    position where <code>app</code> is to be applied
+     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param mState
      * @return the cost of <code>app</code>
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final Term findTerm = pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AgeFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AgeFeature.java
@@ -19,7 +19,8 @@ public class AgeFeature implements Feature {
 
     private AgeFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return NumberRuleAppCost.create(goal.getTime());
         // return LongRuleAppCost.create ( goal.getTime() / goal.sequent ().size () );
         // return LongRuleAppCost.create ( (long)Math.sqrt ( goal.getTime () ) );

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AgeFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AgeFeature.java
@@ -19,7 +19,7 @@ public class AgeFeature implements Feature {
 
     private AgeFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return NumberRuleAppCost.create(goal.getTime());
         // return LongRuleAppCost.create ( goal.getTime() / goal.sequent ().size () );
         // return LongRuleAppCost.create ( (long)Math.sqrt ( goal.getTime () ) );

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AllowedCutPositionFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AllowedCutPositionFeature.java
@@ -23,7 +23,7 @@ public class AllowedCutPositionFeature extends BinaryFeature {
 
     private AllowedCutPositionFeature() {}
 
-    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertFalse(pos == null, "Feature is only applicable to rules with find");
 
         return onlyBelowRightJunctors(pos);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ApplyTFFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ApplyTFFeature.java
@@ -47,7 +47,8 @@ public class ApplyTFFeature implements Feature {
         return new ApplyTFFeature(proj, tf, TopRuleAppCost.INSTANCE, true);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Term te = proj.toTerm(app, pos, goal, mState);
         if (te == null) {
             Debug.assertFalse(demandInst, "ApplyTFFeature: got undefined argument (null)");

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ApplyTFFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ApplyTFFeature.java
@@ -47,14 +47,14 @@ public class ApplyTFFeature implements Feature {
         return new ApplyTFFeature(proj, tf, TopRuleAppCost.INSTANCE, true);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term te = proj.toTerm(app, pos, goal);
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term te = proj.toTerm(app, pos, goal, mState);
         if (te == null) {
             Debug.assertFalse(demandInst, "ApplyTFFeature: got undefined argument (null)");
             return noInstCost;
         }
 
-        return termFeature.compute(te, goal.proof().getServices());
+        return termFeature.compute(te, mState, goal.proof().getServices());
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AtomsSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AtomsSmallerThanFeature.java
@@ -35,10 +35,9 @@ public class AtomsSmallerThanFeature extends AbstractMonomialSmallerThanFeature 
         return new AtomsSmallerThanFeature(left, right, numbers);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        final boolean res = lessThan(collectAtoms(left.toTerm(app, pos, goal)),
-            collectAtoms(right.toTerm(app, pos, goal)), pos, goal);
-        return res;
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return lessThan(collectAtoms(left.toTerm(app, pos, goal, mState)),
+            collectAtoms(right.toTerm(app, pos, goal, mState)), pos, goal);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AutomatedRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AutomatedRuleFeature.java
@@ -18,7 +18,7 @@ public class AutomatedRuleFeature extends BinaryTacletAppFeature {
 
     private AutomatedRuleFeature() {}
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return AnyRuleSetTacletFilter.INSTANCE.filter(app.rule());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryFeature.java
@@ -22,7 +22,8 @@ public abstract class BinaryFeature implements Feature {
     /** Constant that represents the boolean value false */
     public static final RuleAppCost TOP_COST = TopRuleAppCost.INSTANCE;
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return filter(app, pos, goal, mState) ? ZERO_COST : TOP_COST;
     }
 
@@ -30,12 +31,13 @@ public abstract class BinaryFeature implements Feature {
      * Compute whether the result of the feature is zero (<code>true</code>) or infinity
      * (<code>false</code>)
      *
-     * @param app    the RuleApp
-     * @param pos    position where <code>app</code> is to be applied
-     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param app the RuleApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
      * @param mState mutable state needed for feature computation
      * @return true iff the result of the feature is supposed to be zero.
      */
-    protected abstract boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
+    protected abstract boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState);
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryFeature.java
@@ -22,19 +22,20 @@ public abstract class BinaryFeature implements Feature {
     /** Constant that represents the boolean value false */
     public static final RuleAppCost TOP_COST = TopRuleAppCost.INSTANCE;
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return filter(app, pos, goal) ? ZERO_COST : TOP_COST;
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return filter(app, pos, goal, mState) ? ZERO_COST : TOP_COST;
     }
 
     /**
      * Compute whether the result of the feature is zero (<code>true</code>) or infinity
      * (<code>false</code>)
      *
-     * @param app the RuleApp
-     * @param pos position where <code>app</code> is to be applied
-     * @param goal the goal on which <code>app</code> is to be applied
-     * @return true iff the the result of the feature is supposed to be zero.
+     * @param app    the RuleApp
+     * @param pos    position where <code>app</code> is to be applied
+     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param mState mutable state needed for feature computation
+     * @return true iff the result of the feature is supposed to be zero.
      */
-    protected abstract boolean filter(RuleApp app, PosInOccurrence pos, Goal goal);
+    protected abstract boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryTacletAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryTacletAppFeature.java
@@ -28,7 +28,8 @@ public abstract class BinaryTacletAppFeature extends BinaryFeature {
     }
 
     @Override
-    final protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    final protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (app instanceof TacletApp) {
             return filter((TacletApp) app, pos, goal, mState);
         }
@@ -39,11 +40,12 @@ public abstract class BinaryTacletAppFeature extends BinaryFeature {
      * Compute whether the result of the feature is zero (<code>true</code>) or infinity
      * (<code>false</code>)
      *
-     * @param app    the TacletApp
-     * @param pos    position where <code>app</code> is to be applied
-     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param app the TacletApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
      * @param mState the MutableState used to store modifiable information
      * @return true iff the the result of the feature is supposed to be zero.
      */
-    protected abstract boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState);
+    protected abstract boolean filter(TacletApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryTacletAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/BinaryTacletAppFeature.java
@@ -27,9 +27,10 @@ public abstract class BinaryTacletAppFeature extends BinaryFeature {
         nonTacletValue = p_nonTacletValue;
     }
 
-    final protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    @Override
+    final protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (app instanceof TacletApp) {
-            return filter((TacletApp) app, pos, goal);
+            return filter((TacletApp) app, pos, goal, mState);
         }
         return nonTacletValue;
     }
@@ -38,10 +39,11 @@ public abstract class BinaryTacletAppFeature extends BinaryFeature {
      * Compute whether the result of the feature is zero (<code>true</code>) or infinity
      * (<code>false</code>)
      *
-     * @param app the TacletApp
-     * @param pos position where <code>app</code> is to be applied
-     * @param goal the goal on which <code>app</code> is to be applied
+     * @param app    the TacletApp
+     * @param pos    position where <code>app</code> is to be applied
+     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param mState the MutableState used to store modifiable information
      * @return true iff the the result of the feature is supposed to be zero.
      */
-    protected abstract boolean filter(TacletApp app, PosInOccurrence pos, Goal goal);
+    protected abstract boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CheckApplyEqFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CheckApplyEqFeature.java
@@ -24,7 +24,7 @@ public class CheckApplyEqFeature extends BinaryTacletAppFeature {
 
     private CheckApplyEqFeature() {}
 
-    protected boolean filter(TacletApp p_app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp p_app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertTrue(pos != null,
             "Need to know the position of " + "the application of the taclet");
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CompareCostsFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CompareCostsFeature.java
@@ -18,24 +18,30 @@ public abstract class CompareCostsFeature extends BinaryFeature {
 
     public static Feature less(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-                return a.computeCost(app, pos, goal, mState).compareTo(b.computeCost(app, pos, goal, mState)) < 0;
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
+                return a.computeCost(app, pos, goal, mState)
+                        .compareTo(b.computeCost(app, pos, goal, mState)) < 0;
             }
         };
     }
 
     public static Feature leq(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-                return a.computeCost(app, pos, goal, mState).compareTo(b.computeCost(app, pos, goal, mState)) <= 0;
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
+                return a.computeCost(app, pos, goal, mState)
+                        .compareTo(b.computeCost(app, pos, goal, mState)) <= 0;
             }
         };
     }
 
     public static Feature eq(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-                return a.computeCost(app, pos, goal, mState).equals(b.computeCost(app, pos, goal, mState));
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
+                return a.computeCost(app, pos, goal, mState)
+                        .equals(b.computeCost(app, pos, goal, mState));
             }
         };
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CompareCostsFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CompareCostsFeature.java
@@ -18,24 +18,24 @@ public abstract class CompareCostsFeature extends BinaryFeature {
 
     public static Feature less(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
-                return a.computeCost(app, pos, goal).compareTo(b.computeCost(app, pos, goal)) < 0;
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return a.computeCost(app, pos, goal, mState).compareTo(b.computeCost(app, pos, goal, mState)) < 0;
             }
         };
     }
 
     public static Feature leq(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
-                return a.computeCost(app, pos, goal).compareTo(b.computeCost(app, pos, goal)) <= 0;
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return a.computeCost(app, pos, goal, mState).compareTo(b.computeCost(app, pos, goal, mState)) <= 0;
             }
         };
     }
 
     public static Feature eq(Feature a, Feature b) {
         return new CompareCostsFeature(a, b) {
-            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
-                return a.computeCost(app, pos, goal).equals(b.computeCost(app, pos, goal));
+            protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return a.computeCost(app, pos, goal, mState).equals(b.computeCost(app, pos, goal, mState));
             }
         };
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ComprehendedSumFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ComprehendedSumFeature.java
@@ -41,19 +41,19 @@ public class ComprehendedSumFeature implements Feature {
         this.body = body;
     }
 
+    @Override
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term outerVarContent = var.getContent(mState);
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term outerVarContent = var.getContent();
-
-        final Iterator<Term> it = generator.generate(app, pos, goal);
+        final Iterator<Term> it = generator.generate(app, pos, goal, mState);
         RuleAppCost res = NumberRuleAppCost.getZeroCost();
         while (it.hasNext() && !(res instanceof TopRuleAppCost)) {
-            var.setContent(it.next());
+            var.setContent(it.next(), mState);
 
-            res = res.add(body.computeCost(app, pos, goal));
+            res = res.add(body.computeCost(app, pos, goal, mState));
         }
 
-        var.setContent(outerVarContent);
+        var.setContent(outerVarContent, mState);
         return res;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ComprehendedSumFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ComprehendedSumFeature.java
@@ -42,7 +42,8 @@ public class ComprehendedSumFeature implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Term outerVarContent = var.getContent(mState);
 
         final Iterator<Term> it = generator.generate(app, pos, goal, mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConditionalFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConditionalFeature.java
@@ -22,11 +22,11 @@ public class ConditionalFeature implements Feature {
         elseFeature = p_elseFeature;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (cond.filter(app.rule())) {
-            return thenFeature.computeCost(app, pos, goal);
+            return thenFeature.computeCost(app, pos, goal, mState);
         } else {
-            return elseFeature.computeCost(app, pos, goal);
+            return elseFeature.computeCost(app, pos, goal, mState);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConditionalFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConditionalFeature.java
@@ -22,7 +22,8 @@ public class ConditionalFeature implements Feature {
         elseFeature = p_elseFeature;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (cond.filter(app.rule())) {
             return thenFeature.computeCost(app, pos, goal, mState);
         } else {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConstFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConstFeature.java
@@ -12,7 +12,8 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
  * A feature that returns a constant value
  */
 public class ConstFeature implements Feature {
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return val;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConstFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ConstFeature.java
@@ -12,7 +12,7 @@ import de.uka.ilkd.key.strategy.RuleAppCost;
  * A feature that returns a constant value
  */
 public class ConstFeature implements Feature {
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return val;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ContainsTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ContainsTermFeature.java
@@ -51,7 +51,8 @@ public class ContainsTermFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Term t1 = proj1.toTerm(app, pos, goal, mState);
         final Term t2 = proj2.toTerm(app, pos, goal, mState);
         ContainsTermVisitor visitor = new ContainsTermVisitor(t2);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ContainsTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ContainsTermFeature.java
@@ -51,9 +51,9 @@ public class ContainsTermFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term t1 = proj1.toTerm(app, pos, goal);
-        final Term t2 = proj2.toTerm(app, pos, goal);
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term t1 = proj1.toTerm(app, pos, goal, mState);
+        final Term t2 = proj2.toTerm(app, pos, goal, mState);
         ContainsTermVisitor visitor = new ContainsTermVisitor(t2);
         t1.execPreOrder(visitor);
         if (visitor.found) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CountBranchFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CountBranchFeature.java
@@ -24,12 +24,13 @@ public class CountBranchFeature implements Feature {
     /**
      * Compute the cost of a RuleApp.
      *
-     * @param app the RuleApp
-     * @param pos position where <code>app</code> is to be applied
-     * @param goal the goal on which <code>app</code> is to be applied
+     * @param app    the RuleApp
+     * @param pos    position where <code>app</code> is to be applied
+     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param mState
      * @return the cost of <code>app</code>
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (app.rule() instanceof Taclet tac) {
             final long branches = tac.goalTemplates().size();
             return NumberRuleAppCost.create(branches);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CountBranchFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/CountBranchFeature.java
@@ -24,13 +24,14 @@ public class CountBranchFeature implements Feature {
     /**
      * Compute the cost of a RuleApp.
      *
-     * @param app    the RuleApp
-     * @param pos    position where <code>app</code> is to be applied
-     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param app the RuleApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
      * @param mState
      * @return the cost of <code>app</code>
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (app.rule() instanceof Taclet tac) {
             final long branches = tac.goalTemplates().size();
             return NumberRuleAppCost.create(branches);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DeleteMergePointRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DeleteMergePointRuleFeature.java
@@ -30,7 +30,8 @@ public class DeleteMergePointRuleFeature implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return goal.node().parent().getAppliedRuleApp() instanceof MergeRuleBuiltInRuleApp
                 ? NumberRuleAppCost.create(-50000)
                 : TopRuleAppCost.INSTANCE;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DeleteMergePointRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DeleteMergePointRuleFeature.java
@@ -30,7 +30,7 @@ public class DeleteMergePointRuleFeature implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return goal.node().parent().getAppliedRuleApp() instanceof MergeRuleBuiltInRuleApp
                 ? NumberRuleAppCost.create(-50000)
                 : TopRuleAppCost.INSTANCE;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
@@ -32,7 +32,7 @@ public final class DependencyContractFeature extends BinaryFeature {
     }
 
     @Override
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         IBuiltInRuleApp bapp = (IBuiltInRuleApp) app;
         final Term focus = pos.subTerm();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DiffFindAndIfFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DiffFindAndIfFeature.java
@@ -24,7 +24,7 @@ public class DiffFindAndIfFeature extends BinaryTacletAppFeature {
 
     private DiffFindAndIfFeature() {}
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         ImmutableList<IfFormulaInstantiation> list = app.ifFormulaInstantiations();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DiffFindAndReplacewithFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DiffFindAndReplacewithFeature.java
@@ -23,7 +23,7 @@ public class DiffFindAndReplacewithFeature extends BinaryTacletAppFeature {
     private DiffFindAndReplacewithFeature() {}
 
     @Override
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null && app.rule() instanceof RewriteTaclet
                 : "Feature is only applicable to rewrite taclets";
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DirectlyBelowFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DirectlyBelowFeature.java
@@ -26,7 +26,7 @@ public abstract class DirectlyBelowFeature extends BinaryFeature {
         this.index = index;
     }
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (pos == null) {
             return false;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/EqNonDuplicateAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/EqNonDuplicateAppFeature.java
@@ -20,7 +20,7 @@ public class EqNonDuplicateAppFeature extends AbstractNonDuplicateAppFeature {
 
     private EqNonDuplicateAppFeature() {}
 
-    public boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         if (!app.ifInstsComplete()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/Feature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/Feature.java
@@ -16,12 +16,15 @@ public interface Feature {
     /**
      * Evaluate the cost of a <code>RuleApp</code>.
      *
-     * @param app the RuleApp
-     * @param pos position where <code>app</code> is to be applied
-     * @param goal the goal on which <code>app</code> is to be applied
+     * @param app    the RuleApp
+     * @param pos    position where <code>app</code> is to be applied
+     * @param goal   the goal on which <code>app</code> is to be applied
+     * @param mState  variable bank / local storage for feature who might require to store temporary information
+     *                that changes during computation, e.g.
+     *               {@link de.uka.ilkd.key.strategy.termProjection.TermBuffer}s
      * @return the cost of the rule application expressed as a <code>RuleAppCost</code> object.
-     *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
-     *         all (it is discarded by the strategy).
+     * <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
+     * all (it is discarded by the strategy).
      */
-    RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal);
+    RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/Feature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/Feature.java
@@ -16,15 +16,16 @@ public interface Feature {
     /**
      * Evaluate the cost of a <code>RuleApp</code>.
      *
-     * @param app    the RuleApp
-     * @param pos    position where <code>app</code> is to be applied
-     * @param goal   the goal on which <code>app</code> is to be applied
-     * @param mState  variable bank / local storage for feature who might require to store temporary information
-     *                that changes during computation, e.g.
-     *               {@link de.uka.ilkd.key.strategy.termProjection.TermBuffer}s
+     * @param app the RuleApp
+     * @param pos position where <code>app</code> is to be applied
+     * @param goal the goal on which <code>app</code> is to be applied
+     * @param mState variable bank / local storage for feature who might require to store temporary
+     *        information
+     *        that changes during computation, e.g.
+     *        {@link de.uka.ilkd.key.strategy.termProjection.TermBuffer}s
      * @return the cost of the rule application expressed as a <code>RuleAppCost</code> object.
-     * <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
-     * all (it is discarded by the strategy).
+     *         <code>TopRuleAppCost.INSTANCE</code> indicates that the rule shall not be applied at
+     *         all (it is discarded by the strategy).
      */
     RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindDepthFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindDepthFeature.java
@@ -22,7 +22,7 @@ public class FindDepthFeature implements Feature {
 
     private FindDepthFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         // assert pos != null : "Feature is only applicable to rules with find";
 
         return NumberRuleAppCost.create(pos == null ? 0 : pos.depth());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindDepthFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindDepthFeature.java
@@ -22,7 +22,8 @@ public class FindDepthFeature implements Feature {
 
     private FindDepthFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         // assert pos != null : "Feature is only applicable to rules with find";
 
         return NumberRuleAppCost.create(pos == null ? 0 : pos.depth());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindRightishFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindRightishFeature.java
@@ -31,7 +31,8 @@ public class FindRightishFeature implements Feature {
         add = numbers.getAdd();
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         RuleAppCost res = NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindRightishFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FindRightishFeature.java
@@ -31,7 +31,7 @@ public class FindRightishFeature implements Feature {
         add = numbers.getAdd();
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         RuleAppCost res = NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusInAntecFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusInAntecFeature.java
@@ -13,7 +13,7 @@ public class FocusInAntecFeature extends BinaryFeature {
 
     public static final Feature INSTANCE = new FocusInAntecFeature();
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
         return pos.isInAntec();
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusIsSubFormulaOfInfFlowContractAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusIsSubFormulaOfInfFlowContractAppFeature.java
@@ -34,7 +34,7 @@ public class FocusIsSubFormulaOfInfFlowContractAppFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find.";
         assert ruleApp instanceof TacletApp : "Feature is only applicable " + "to Taclets.";
         TacletApp app = (TacletApp) ruleApp;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusIsSubFormulaOfInfFlowContractAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FocusIsSubFormulaOfInfFlowContractAppFeature.java
@@ -34,7 +34,8 @@ public class FocusIsSubFormulaOfInfFlowContractAppFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find.";
         assert ruleApp instanceof TacletApp : "Feature is only applicable " + "to Taclets.";
         TacletApp app = (TacletApp) ruleApp;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FormulaAddedByRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/FormulaAddedByRuleFeature.java
@@ -28,7 +28,7 @@ public class FormulaAddedByRuleFeature extends BinaryFeature {
         return new FormulaAddedByRuleFeature(p_filter);
     }
 
-    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final SequentFormula cfma = pos.sequentFormula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/IfThenElseMalusFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/IfThenElseMalusFeature.java
@@ -26,7 +26,7 @@ public class IfThenElseMalusFeature implements Feature {
 
     private IfThenElseMalusFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (pos == null) {
             return NumberRuleAppCost.getZeroCost();
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/IfThenElseMalusFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/IfThenElseMalusFeature.java
@@ -26,7 +26,8 @@ public class IfThenElseMalusFeature implements Feature {
 
     private IfThenElseMalusFeature() {}
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (pos == null) {
             return NumberRuleAppCost.getZeroCost();
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ImplicitCastNecessary.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ImplicitCastNecessary.java
@@ -18,14 +18,14 @@ public class ImplicitCastNecessary extends BinaryFeature {
         this.projection = projection;
     }
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null && pos.depth() >= 1;
 
         int subPos = pos.getIndex();
 
         final Sort maxSort =
             TermHelper.getMaxSort(pos.up().subTerm(), subPos, goal.proof().getServices());
-        return projection.toTerm(app, pos, goal).sort().extendsTrans(maxSort);
+        return projection.toTerm(app, pos, goal, mState).sort().extendsTrans(maxSort);
     }
 
     public static Feature create(ProjectionToTerm s1) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InEquationMultFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InEquationMultFeature.java
@@ -72,11 +72,11 @@ public abstract class InEquationMultFeature extends BinaryTacletAppFeature {
         this.targetCandidate = targetCandidate;
     }
 
-    protected final boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected final boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
-        final Monomial targetM = Monomial.create(targetCandidate.toTerm(app, pos, goal), services);
-        final Monomial mult1M = Monomial.create(mult1Candidate.toTerm(app, pos, goal), services);
-        final Monomial mult2M = Monomial.create(mult2Candidate.toTerm(app, pos, goal), services);
+        final Monomial targetM = Monomial.create(targetCandidate.toTerm(app, pos, goal, mState), services);
+        final Monomial mult1M = Monomial.create(mult1Candidate.toTerm(app, pos, goal, mState), services);
+        final Monomial mult2M = Monomial.create(mult2Candidate.toTerm(app, pos, goal, mState), services);
 
         return filter(targetM, mult1M, mult2M);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InEquationMultFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InEquationMultFeature.java
@@ -72,11 +72,15 @@ public abstract class InEquationMultFeature extends BinaryTacletAppFeature {
         this.targetCandidate = targetCandidate;
     }
 
-    protected final boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    protected final boolean filter(TacletApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Services services = goal.proof().getServices();
-        final Monomial targetM = Monomial.create(targetCandidate.toTerm(app, pos, goal, mState), services);
-        final Monomial mult1M = Monomial.create(mult1Candidate.toTerm(app, pos, goal, mState), services);
-        final Monomial mult2M = Monomial.create(mult2Candidate.toTerm(app, pos, goal, mState), services);
+        final Monomial targetM =
+            Monomial.create(targetCandidate.toTerm(app, pos, goal, mState), services);
+        final Monomial mult1M =
+            Monomial.create(mult1Candidate.toTerm(app, pos, goal, mState), services);
+        final Monomial mult2M =
+            Monomial.create(mult2Candidate.toTerm(app, pos, goal, mState), services);
 
         return filter(targetM, mult1M, mult2M);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InfFlowContractAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InfFlowContractAppFeature.java
@@ -202,7 +202,8 @@ public class InfFlowContractAppFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find.";
         assert ruleApp instanceof TacletApp : "Feature is only applicable " + "to Taclets.";
         TacletApp app = (TacletApp) ruleApp;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InfFlowContractAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InfFlowContractAppFeature.java
@@ -202,7 +202,7 @@ public class InfFlowContractAppFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp ruleApp, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find.";
         assert ruleApp instanceof TacletApp : "Feature is only applicable " + "to Taclets.";
         TacletApp app = (TacletApp) ruleApp;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InstantiatedSVFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/InstantiatedSVFeature.java
@@ -26,8 +26,8 @@ public class InstantiatedSVFeature extends BinaryTacletAppFeature {
         instProj = SVInstantiationProjection.create(svName, false);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        return instProj.toTerm(app, pos, goal) != null;
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return instProj.toTerm(app, pos, goal, mState) != null;
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/LetFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/LetFeature.java
@@ -33,7 +33,8 @@ public class LetFeature implements Feature {
         this.body = body;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Term outerVarContent = var.getContent(mState);
 
         var.setContent(value.toTerm(app, pos, goal, mState), mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/LetFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/LetFeature.java
@@ -33,13 +33,13 @@ public class LetFeature implements Feature {
         this.body = body;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term outerVarContent = var.getContent();
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term outerVarContent = var.getContent(mState);
 
-        var.setContent(value.toTerm(app, pos, goal));
-        final RuleAppCost res = body.computeCost(app, pos, goal);
+        var.setContent(value.toTerm(app, pos, goal, mState), mState);
+        final RuleAppCost res = body.computeCost(app, pos, goal, mState);
 
-        var.setContent(outerVarContent);
+        var.setContent(outerVarContent, mState);
         return res;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MatchedIfFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MatchedIfFeature.java
@@ -17,7 +17,7 @@ public final class MatchedIfFeature extends BinaryTacletAppFeature {
 
     private MatchedIfFeature() {}
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return app.ifInstsComplete();
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MergeRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MergeRuleFeature.java
@@ -29,7 +29,7 @@ public class MergeRuleFeature implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Term t = pos.subTerm();
         if (!pos.isTopLevel() || !t.containsJavaBlockRecursive()) {
             return TopRuleAppCost.INSTANCE;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MergeRuleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MergeRuleFeature.java
@@ -29,7 +29,8 @@ public class MergeRuleFeature implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Term t = pos.subTerm();
         if (!pos.isTopLevel() || !t.containsJavaBlockRecursive()) {
             return TopRuleAppCost.INSTANCE;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MonomialsSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MonomialsSmallerThanFeature.java
@@ -58,11 +58,12 @@ public class MonomialsSmallerThanFeature extends AbstractMonomialSmallerThanFeat
         return new MonomialsSmallerThanFeature(left, right, numbers);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    @Override
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final MonomialCollector m1 = new MonomialCollector();
-        m1.collect(left.toTerm(app, pos, goal), goal.proof().getServices());
+        m1.collect(left.toTerm(app, pos, goal, mState), mState, goal.proof().getServices());
         final MonomialCollector m2 = new MonomialCollector();
-        m2.collect(right.toTerm(app, pos, goal), goal.proof().getServices());
+        m2.collect(right.toTerm(app, pos, goal, mState), mState, goal.proof().getServices());
 
         return lessThan(m1.getResult(), m2.getResult(), pos, goal);
 
@@ -158,17 +159,17 @@ public class MonomialsSmallerThanFeature extends AbstractMonomialSmallerThanFeat
     }
 
     private class MonomialCollector extends Collector {
-        protected void collect(Term te, Services services) {
+        protected void collect(Term te, MutableState mState, Services services) {
             if (te.op() == add) {
-                collect(te.sub(0), services);
-                collect(te.sub(1), services);
+                collect(te.sub(0), mState, services);
+                collect(te.sub(1), mState, services);
             } else if (te.op() != Z) {
-                addTerm(stripOffLiteral(te, services));
+                addTerm(stripOffLiteral(te, mState, services));
             }
         }
 
-        private Term stripOffLiteral(Term te, Services services) {
-            if (!(hasCoeff.compute(te, services) instanceof TopRuleAppCost))
+        private Term stripOffLiteral(Term te, MutableState mState, Services services) {
+            if (!(hasCoeff.compute(te, mState, services) instanceof TopRuleAppCost))
             // we leave out literals/coefficients on the right, because we
             // do not want to compare these literals
             {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MutableState.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MutableState.java
@@ -1,0 +1,67 @@
+package de.uka.ilkd.key.strategy.feature;
+
+import java.util.HashMap;
+
+import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.instantiator.BackTrackingManager;
+import de.uka.ilkd.key.strategy.feature.instantiator.ChoicePoint;
+import de.uka.ilkd.key.strategy.termProjection.TermBuffer;
+
+/**
+ * <p>
+ * Realizes a variable bank for strategy features such that each feature
+ * computation can be done in parallel.
+ * </p><p>
+ * When the strategy computes the costs for a {@link RuleApp} it creates
+ * a new MutableState object and passes it on. This is then used by features
+ * to query for the value of {@link TermBuffer}s.
+ * </p><p>
+ * This mutable state should not be abused and strategy features should be stateless.
+ * </p>
+ *
+ * @author Richard Bubel
+ */
+public class MutableState {
+
+    /** maps a term buffer to its value */
+    private HashMap<TermBuffer, Term> content;
+
+    /** manages backtracking for features that create {@link ChoicePoint}s */
+    private BackTrackingManager btManager;
+
+    /**
+     * assign the given {@link TermBuffer} the provided value
+     * @param v the {@link TermBuffer}
+     * @param value the Term which is assigned as the value
+     */
+    public void assign(TermBuffer v, Term value) {
+        if (content == null) {
+            content = new HashMap<>();
+        }
+        content.put(v, value);
+    }
+
+    /**
+     * retrieves the current value of the given {@link TermBuffer}
+     * @param v the TermBuffer whose value is asked for
+     * @return the current value of the {@link TermBuffer} or {@code null} if there is none
+     */
+    public Term read(TermBuffer v) {
+        if (content == null) {
+            return null;
+        }
+        return content.get(v);
+    }
+
+    /**
+     * returns the backtracking manager to access {@link ChoicePoint}s
+     * @return the backtracking manager
+     */
+    public BackTrackingManager getBacktrackingManager() {
+        if (btManager == null) {
+            btManager = new BackTrackingManager();
+        }
+        return btManager;
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MutableState.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/MutableState.java
@@ -1,3 +1,6 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.strategy.feature;
 
 import java.util.HashMap;
@@ -12,11 +15,13 @@ import de.uka.ilkd.key.strategy.termProjection.TermBuffer;
  * <p>
  * Realizes a variable bank for strategy features such that each feature
  * computation can be done in parallel.
- * </p><p>
+ * </p>
+ * <p>
  * When the strategy computes the costs for a {@link RuleApp} it creates
  * a new MutableState object and passes it on. This is then used by features
  * to query for the value of {@link TermBuffer}s.
- * </p><p>
+ * </p>
+ * <p>
  * This mutable state should not be abused and strategy features should be stateless.
  * </p>
  *
@@ -32,6 +37,7 @@ public class MutableState {
 
     /**
      * assign the given {@link TermBuffer} the provided value
+     *
      * @param v the {@link TermBuffer}
      * @param value the Term which is assigned as the value
      */
@@ -44,6 +50,7 @@ public class MutableState {
 
     /**
      * retrieves the current value of the given {@link TermBuffer}
+     *
      * @param v the TermBuffer whose value is asked for
      * @return the current value of the {@link TermBuffer} or {@code null} if there is none
      */
@@ -56,6 +63,7 @@ public class MutableState {
 
     /**
      * returns the backtracking manager to access {@link ChoicePoint}s
+     *
      * @return the backtracking manager
      */
     public BackTrackingManager getBacktrackingManager() {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NoSelfApplicationFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NoSelfApplicationFeature.java
@@ -22,7 +22,7 @@ public class NoSelfApplicationFeature extends BinaryTacletAppFeature {
     private NoSelfApplicationFeature() {}
 
     @Override
-    protected boolean filter(TacletApp p_app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp p_app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertTrue(pos != null,
             "NoSelfApplicationFeature: Need to know the position of the application of the taclet");
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NonDuplicateAppFeature.java
@@ -16,7 +16,7 @@ public class NonDuplicateAppFeature extends AbstractNonDuplicateAppFeature {
 
     public static final Feature INSTANCE = new NonDuplicateAppFeature();
 
-    public boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (!app.ifInstsComplete()) {
             return true;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotBelowBinderFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotBelowBinderFeature.java
@@ -21,7 +21,7 @@ public class NotBelowBinderFeature extends BinaryFeature {
 
     private NotBelowBinderFeature() {}
 
-    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertFalse(pos == null, "Feature is only applicable to rules with find");
 
         return !belowBinder(pos);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotBelowQuantifierFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotBelowQuantifierFeature.java
@@ -23,7 +23,7 @@ public class NotBelowQuantifierFeature extends BinaryFeature {
 
     private NotBelowQuantifierFeature() {}
 
-    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertFalse(pos == null, "Feature is only applicable to rules with find");
 
         return !belowQuantifier(pos);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotInScopeOfModalityFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/NotInScopeOfModalityFeature.java
@@ -24,7 +24,7 @@ public class NotInScopeOfModalityFeature extends BinaryFeature {
 
     private NotInScopeOfModalityFeature() {}
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         Debug.assertFalse(pos == null, "Feature is only applicable to rules with find");
 
         return !inScopeOfModality(pos);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/OnlyInScopeOfQuantifiersFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/OnlyInScopeOfQuantifiersFeature.java
@@ -21,7 +21,7 @@ public class OnlyInScopeOfQuantifiersFeature extends BinaryTacletAppFeature {
 
     private OnlyInScopeOfQuantifiersFeature() {}
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final PIOPathIterator it = pos.iterator();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PolynomialValuesCmpFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PolynomialValuesCmpFeature.java
@@ -93,22 +93,22 @@ public abstract class PolynomialValuesCmpFeature extends BinaryTacletAppFeature 
         };
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        return compare(getPolynomial(left, leftCoeff, app, pos, goal),
-            getPolynomial(right, rightCoeff, app, pos, goal));
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return compare(getPolynomial(left, leftCoeff, app, pos, goal, mState),
+            getPolynomial(right, rightCoeff, app, pos, goal, mState));
     }
 
     protected abstract boolean compare(Polynomial leftPoly, Polynomial rightPoly);
 
     private Polynomial getPolynomial(ProjectionToTerm polyProj, ProjectionToTerm coeffProj,
-            TacletApp app, PosInOccurrence pos, Goal goal) {
+            TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
-        final Polynomial poly = Polynomial.create(polyProj.toTerm(app, pos, goal), services);
+        final Polynomial poly = Polynomial.create(polyProj.toTerm(app, pos, goal, mState), services);
 
         if (coeffProj == null) {
             return poly;
         }
-        final Term coeffT = coeffProj.toTerm(app, pos, goal);
+        final Term coeffT = coeffProj.toTerm(app, pos, goal, mState);
         if (coeffT == null) {
             return poly;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PolynomialValuesCmpFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PolynomialValuesCmpFeature.java
@@ -103,7 +103,8 @@ public abstract class PolynomialValuesCmpFeature extends BinaryTacletAppFeature 
     private Polynomial getPolynomial(ProjectionToTerm polyProj, ProjectionToTerm coeffProj,
             TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
-        final Polynomial poly = Polynomial.create(polyProj.toTerm(app, pos, goal, mState), services);
+        final Polynomial poly =
+            Polynomial.create(polyProj.toTerm(app, pos, goal, mState), services);
 
         if (coeffProj == null) {
             return poly;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PrintFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PrintFeature.java
@@ -31,7 +31,8 @@ public class PrintFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         RuleAppCost cost = f.computeCost(app, pos, goal, mState);
         LOGGER.debug("{}:{}:{}{}", prefix, cost.toString(), pos != null ? pos.subTerm() + ":" : "",
             app.rule().name());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PrintFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/PrintFeature.java
@@ -31,8 +31,8 @@ public class PrintFeature implements Feature {
 
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        RuleAppCost cost = f.computeCost(app, pos, goal);
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        RuleAppCost cost = f.computeCost(app, pos, goal, mState);
         LOGGER.debug("{}:{}:{}{}", prefix, cost.toString(), pos != null ? pos.subTerm() + ":" : "",
             app.rule().name());
         return cost;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/QueryExpandCost.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/QueryExpandCost.java
@@ -73,7 +73,7 @@ public class QueryExpandCost implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
         final IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
         final Term t = pos.subTerm();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/QueryExpandCost.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/QueryExpandCost.java
@@ -73,7 +73,8 @@ public class QueryExpandCost implements Feature {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Services services = goal.proof().getServices();
         final IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
         final Term t = pos.subTerm();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ReducibleMonomialsFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ReducibleMonomialsFeature.java
@@ -40,9 +40,9 @@ public abstract class ReducibleMonomialsFeature extends BinaryTacletAppFeature {
         };
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        final Term dividendT = dividend.toTerm(app, pos, goal);
-        final Term divisorT = divisor.toTerm(app, pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term dividendT = dividend.toTerm(app, pos, goal, mState);
+        final Term divisorT = divisor.toTerm(app, pos, goal, mState);
 
         final Services services = goal.proof().getServices();
         final Monomial mDividend = Monomial.create(dividendT, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/RuleSetDispatchFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/RuleSetDispatchFeature.java
@@ -28,7 +28,7 @@ public class RuleSetDispatchFeature implements Feature {
 
     private final Map<RuleSet, Feature> rulesetToFeature = new LinkedHashMap<>();
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (!(app instanceof TacletApp)) {
             return NumberRuleAppCost.getZeroCost();
         }
@@ -45,7 +45,7 @@ public class RuleSetDispatchFeature implements Feature {
 
             final Feature partialF = rulesetToFeature.get(rs);
             if (partialF != null) {
-                res = res.add(partialF.computeCost(app, pos, goal));
+                res = res.add(partialF.computeCost(app, pos, goal, mState));
                 if (res instanceof TopRuleAppCost) {
                     break;
                 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/RuleSetDispatchFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/RuleSetDispatchFeature.java
@@ -28,7 +28,8 @@ public class RuleSetDispatchFeature implements Feature {
 
     private final Map<RuleSet, Feature> rulesetToFeature = new LinkedHashMap<>();
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (!(app instanceof TacletApp)) {
             return NumberRuleAppCost.getZeroCost();
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SVNeedsInstantiation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SVNeedsInstantiation.java
@@ -23,8 +23,8 @@ public class SVNeedsInstantiation extends InstantiatedSVFeature {
     }
 
     @Override
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        boolean res = super.filter(app, pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        boolean res = super.filter(app, pos, goal, mState);
         if (!res) {
             for (SchemaVariable sv : app.uninstantiatedVars()) {
                 if (sv.name().equals(svName)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ScaleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ScaleFeature.java
@@ -159,7 +159,8 @@ public abstract class ScaleFeature implements Feature {
             offset = p_offset;
         }
 
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+                MutableState mState) {
             final RuleAppCost cost = getFeature().computeCost(app, pos, goal, mState);
             long costVal;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ScaleFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ScaleFeature.java
@@ -159,8 +159,8 @@ public abstract class ScaleFeature implements Feature {
             offset = p_offset;
         }
 
-        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-            final RuleAppCost cost = getFeature().computeCost(app, pos, goal);
+        public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+            final RuleAppCost cost = getFeature().computeCost(app, pos, goal, mState);
             long costVal;
 
             if (cost instanceof TopRuleAppCost) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SeqContainsExecutableCodeFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SeqContainsExecutableCodeFeature.java
@@ -30,13 +30,17 @@ public class SeqContainsExecutableCodeFeature extends BinaryFeature {
     public final static Feature PROGRAMS_OR_QUERIES = new SeqContainsExecutableCodeFeature(true);
 
     protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-        return containsExec(goal.sequent().succedent().iterator(), mState, goal.proof().getServices())
-                || containsExec(goal.sequent().antecedent().iterator(), mState, goal.proof().getServices());
+        return containsExec(goal.sequent().succedent().iterator(), mState,
+            goal.proof().getServices())
+                || containsExec(goal.sequent().antecedent().iterator(), mState,
+                    goal.proof().getServices());
     }
 
-    private boolean containsExec(Iterator<SequentFormula> it, MutableState mState, Services services) {
+    private boolean containsExec(Iterator<SequentFormula> it, MutableState mState,
+            Services services) {
         while (it.hasNext()) {
-            if (tf.compute(it.next().formula(), mState, services).equals(BinaryTermFeature.ZERO_COST)) {
+            if (tf.compute(it.next().formula(), mState, services)
+                    .equals(BinaryTermFeature.ZERO_COST)) {
                 return true;
             }
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SeqContainsExecutableCodeFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SeqContainsExecutableCodeFeature.java
@@ -29,14 +29,14 @@ public class SeqContainsExecutableCodeFeature extends BinaryFeature {
     public final static Feature PROGRAMS = new SeqContainsExecutableCodeFeature(false);
     public final static Feature PROGRAMS_OR_QUERIES = new SeqContainsExecutableCodeFeature(true);
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return containsExec(goal.sequent().succedent().iterator(), goal.proof().getServices())
-                || containsExec(goal.sequent().antecedent().iterator(), goal.proof().getServices());
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return containsExec(goal.sequent().succedent().iterator(), mState, goal.proof().getServices())
+                || containsExec(goal.sequent().antecedent().iterator(), mState, goal.proof().getServices());
     }
 
-    private boolean containsExec(Iterator<SequentFormula> it, Services services) {
+    private boolean containsExec(Iterator<SequentFormula> it, MutableState mState, Services services) {
         while (it.hasNext()) {
-            if (tf.compute(it.next().formula(), services).equals(BinaryTermFeature.ZERO_COST)) {
+            if (tf.compute(it.next().formula(), mState, services).equals(BinaryTermFeature.ZERO_COST)) {
                 return true;
             }
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SetsSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SetsSmallerThanFeature.java
@@ -35,9 +35,9 @@ public class SetsSmallerThanFeature extends SmallerThanFeature {
 
 
     @Override
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        final Term leftTerm = left.toTerm(app, pos, goal);
-        final Term rightTerm = right.toTerm(app, pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term leftTerm = left.toTerm(app, pos, goal, mState);
+        final Term rightTerm = right.toTerm(app, pos, goal, mState);
 
         return origLessThan(leftTerm, rightTerm, pos, goal);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ShannonFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ShannonFeature.java
@@ -46,7 +46,8 @@ public class ShannonFeature implements Feature {
         elseFeature = p_elseFeature;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (cond.computeCost(app, pos, goal, mState).equals(trueCost)) {
             return thenFeature.computeCost(app, pos, goal, mState);
         } else {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ShannonFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ShannonFeature.java
@@ -46,11 +46,11 @@ public class ShannonFeature implements Feature {
         elseFeature = p_elseFeature;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        if (cond.computeCost(app, pos, goal).equals(trueCost)) {
-            return thenFeature.computeCost(app, pos, goal);
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        if (cond.computeCost(app, pos, goal, mState).equals(trueCost)) {
+            return thenFeature.computeCost(app, pos, goal, mState);
         } else {
-            return elseFeature.computeCost(app, pos, goal);
+            return elseFeature.computeCost(app, pos, goal, mState);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SortComparisonFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SortComparisonFeature.java
@@ -22,7 +22,7 @@ public class SortComparisonFeature extends BinaryFeature {
     private final int comparator;
 
     /**
-     * creates a new comparision term feature
+     * creates a new comparison term feature
      */
     private SortComparisonFeature(ProjectionToTerm s1, ProjectionToTerm s2, int comparator) {
         this.s1 = s1;
@@ -30,9 +30,9 @@ public class SortComparisonFeature extends BinaryFeature {
         this.comparator = comparator;
     }
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Sort sort1 = s1.toTerm(app, pos, goal).sort();
-        final Sort sort2 = s2.toTerm(app, pos, goal).sort();
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Sort sort1 = s1.toTerm(app, pos, goal, mState).sort();
+        final Sort sort2 = s2.toTerm(app, pos, goal, mState).sort();
 
         return compare(sort1, sort2);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SumFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SumFeature.java
@@ -19,13 +19,13 @@ import de.uka.ilkd.key.util.Debug;
 public class SumFeature implements Feature {
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         // We require that there is at least one feature (in method
         // <code>createSum</code>)
-        RuleAppCost res = features[0].computeCost(app, pos, goal);
+        RuleAppCost res = features[0].computeCost(app, pos, goal, mState);
 
         for (int i = 1; i < features.length && !(res instanceof TopRuleAppCost); i++) {
-            res = res.add(features[i].computeCost(app, pos, goal));
+            res = res.add(features[i].computeCost(app, pos, goal, mState));
         }
 
         return res;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SumFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SumFeature.java
@@ -19,7 +19,8 @@ import de.uka.ilkd.key.util.Debug;
 public class SumFeature implements Feature {
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         // We require that there is at least one feature (in method
         // <code>createSum</code>)
         RuleAppCost res = features[0].computeCost(app, pos, goal, mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TacletRequiringInstantiationFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TacletRequiringInstantiationFeature.java
@@ -22,7 +22,7 @@ public class TacletRequiringInstantiationFeature extends BinaryTacletAppFeature 
         super(false);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final ImmutableSet<SchemaVariable> neededVars = app.uninstantiatedVars();
         final ImmutableSet<SchemaVariable> ifFindVars = app.taclet().getIfFindVariables();
         for (SchemaVariable neededVar : neededVars) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TermSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TermSmallerThanFeature.java
@@ -25,7 +25,8 @@ public class TermSmallerThanFeature extends SmallerThanFeature {
     }
 
     protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-        return lessThan(left.toTerm(app, pos, goal, mState), right.toTerm(app, pos, goal, mState), pos, goal);
+        return lessThan(left.toTerm(app, pos, goal, mState), right.toTerm(app, pos, goal, mState),
+            pos, goal);
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TermSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TermSmallerThanFeature.java
@@ -24,8 +24,8 @@ public class TermSmallerThanFeature extends SmallerThanFeature {
         this.right = right;
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        return lessThan(left.toTerm(app, pos, goal), right.toTerm(app, pos, goal), pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return lessThan(left.toTerm(app, pos, goal, mState), right.toTerm(app, pos, goal, mState), pos, goal);
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ThrownExceptionFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/ThrownExceptionFeature.java
@@ -60,7 +60,7 @@ public class ThrownExceptionFeature extends BinaryFeature {
         return false;
     }
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return app instanceof TacletApp && filter(pos.subTerm(), goal.proof().getServices(),
             ((TacletApp) app).instantiations().getExecutionContext());
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TopLevelFindFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TopLevelFindFeature.java
@@ -76,7 +76,7 @@ public abstract class TopLevelFindFeature extends BinaryTacletAppFeature {
         }
     };
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
         return checkPosition(pos);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TriggerVarInstantiatedFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TriggerVarInstantiatedFeature.java
@@ -15,13 +15,13 @@ public class TriggerVarInstantiatedFeature extends BinaryTacletAppFeature {
     private TriggerVarInstantiatedFeature() {
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert app.taclet().hasTrigger();
 
         SVInstantiationProjection instProj = SVInstantiationProjection
                 .create(app.taclet().getTrigger().triggerVar().name(), false);
 
-        return instProj.toTerm(app, pos, goal) != null;
+        return instProj.toTerm(app, pos, goal, mState) != null;
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TrivialMonomialLCRFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/TrivialMonomialLCRFeature.java
@@ -29,10 +29,10 @@ public class TrivialMonomialLCRFeature extends BinaryTacletAppFeature {
         return new TrivialMonomialLCRFeature(a, b);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
-        final Monomial aMon = Monomial.create(a.toTerm(app, pos, goal), services);
-        final Monomial bMon = Monomial.create(b.toTerm(app, pos, goal), services);
+        final Monomial aMon = Monomial.create(a.toTerm(app, pos, goal, mState), services);
+        final Monomial bMon = Monomial.create(b.toTerm(app, pos, goal, mState), services);
 
         /*
          * final BigInteger ac = aMon.getCoefficient (); final BigInteger bc = bMon.getCoefficient

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/findprefix/FindPrefixRestrictionFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/findprefix/FindPrefixRestrictionFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.strategy.feature.BinaryTacletAppFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -106,7 +107,7 @@ public class FindPrefixRestrictionFeature extends BinaryTacletAppFeature {
     }
 
     @Override
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         // apply the position modifiers

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/ForEachCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/ForEachCP.java
@@ -44,7 +44,8 @@ public class ForEachCP implements Feature {
         this.body = body;
     }
 
-    public RuleAppCost computeCost(final RuleApp app, final PosInOccurrence pos, final Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(final RuleApp app, final PosInOccurrence pos, final Goal goal,
+            MutableState mState) {
         final Term outerVarContent = var.getContent(mState);
         var.setContent(null, mState);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/ForEachCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/ForEachCP.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.TermBuffer;
 import de.uka.ilkd.key.strategy.termgenerator.TermGenerator;
 
@@ -23,8 +24,6 @@ import de.uka.ilkd.key.strategy.termgenerator.TermGenerator;
  */
 public class ForEachCP implements Feature {
 
-    private final BackTrackingManager manager;
-
     private final TermBuffer var;
     private final TermGenerator generator;
     private final Feature body;
@@ -35,33 +34,31 @@ public class ForEachCP implements Feature {
      * @param body a feature that is supposed to be evaluated repeatedly for the possible values of
      *        <code>var</code>
      */
-    public static Feature create(TermBuffer var, TermGenerator generator, Feature body,
-            BackTrackingManager manager) {
-        return new ForEachCP(var, generator, body, manager);
+    public static Feature create(TermBuffer var, TermGenerator generator, Feature body) {
+        return new ForEachCP(var, generator, body);
     }
 
-    private ForEachCP(TermBuffer var, TermGenerator generator, Feature body,
-            BackTrackingManager manager) {
+    private ForEachCP(TermBuffer var, TermGenerator generator, Feature body) {
         this.var = var;
         this.generator = generator;
         this.body = body;
-        this.manager = manager;
     }
 
-    public RuleAppCost computeCost(final RuleApp app, final PosInOccurrence pos, final Goal goal) {
-        final Term outerVarContent = var.getContent();
-        var.setContent(null);
+    public RuleAppCost computeCost(final RuleApp app, final PosInOccurrence pos, final Goal goal, MutableState mState) {
+        final Term outerVarContent = var.getContent(mState);
+        var.setContent(null, mState);
 
-        manager.passChoicePoint(new CP(app, pos, goal), this);
+        final BackTrackingManager manager = mState.getBacktrackingManager();
+        manager.passChoicePoint(new CP(app, pos, goal, mState), this);
 
         final RuleAppCost res;
-        if (var.getContent() != null) {
-            res = body.computeCost(app, pos, goal);
+        if (var.getContent(mState) != null) {
+            res = body.computeCost(app, pos, goal, mState);
         } else {
             res = NumberRuleAppCost.getZeroCost();
         }
 
-        var.setContent(outerVarContent);
+        var.setContent(outerVarContent, mState);
         return res;
     }
 
@@ -70,9 +67,12 @@ public class ForEachCP implements Feature {
             private final Iterator<Term> terms;
             private final RuleApp oldApp;
 
-            private BranchIterator(Iterator<Term> terms, RuleApp oldApp) {
+            private final MutableState mState;
+
+            private BranchIterator(Iterator<Term> terms, RuleApp oldApp, MutableState mState) {
                 this.terms = terms;
                 this.oldApp = oldApp;
+                this.mState = mState;
             }
 
             public boolean hasNext() {
@@ -83,7 +83,7 @@ public class ForEachCP implements Feature {
                 final Term generatedTerm = terms.next();
                 return new CPBranch() {
                     public void choose() {
-                        var.setContent(generatedTerm);
+                        var.setContent(generatedTerm, mState);
                     }
 
                     public RuleApp getRuleAppForBranch() {
@@ -100,15 +100,17 @@ public class ForEachCP implements Feature {
         private final PosInOccurrence pos;
         private final RuleApp app;
         private final Goal goal;
+        private final MutableState mState;
 
-        private CP(RuleApp app, PosInOccurrence pos, Goal goal) {
+        private CP(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
             this.pos = pos;
             this.app = app;
             this.goal = goal;
+            this.mState = mState;
         }
 
         public Iterator<CPBranch> getBranches(RuleApp oldApp) {
-            return new BranchIterator(generator.generate(app, pos, goal), oldApp);
+            return new BranchIterator(generator.generate(app, pos, goal, mState), oldApp, mState);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/OneOfCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/OneOfCP.java
@@ -27,7 +27,8 @@ public class OneOfCP implements Feature {
         return new OneOfCP(features);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final BackTrackingManager manager = mState.getBacktrackingManager();
         manager.passChoicePoint(cp, this);
         return features[theChosenOne].computeCost(app, pos, goal, mState);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/OneOfCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/OneOfCP.java
@@ -10,27 +10,27 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class OneOfCP implements Feature {
 
-    private final BackTrackingManager manager;
     private final Feature[] features;
 
     private int theChosenOne;
     private final ChoicePoint cp = new CP();
 
-    private OneOfCP(BackTrackingManager manager, Feature[] features) {
-        this.manager = manager;
+    private OneOfCP(Feature[] features) {
         this.features = features;
     }
 
-    public static Feature create(Feature[] features, BackTrackingManager manager) {
-        return new OneOfCP(manager, features);
+    public static Feature create(Feature[] features) {
+        return new OneOfCP(features);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final BackTrackingManager manager = mState.getBacktrackingManager();
         manager.passChoicePoint(cp, this);
-        return features[theChosenOne].computeCost(app, pos, goal);
+        return features[theChosenOne].computeCost(app, pos, goal, mState);
     }
 
     private final class CP implements ChoicePoint {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 import de.uka.ilkd.key.util.Debug;
 
@@ -30,31 +31,26 @@ import org.key_project.util.collection.ImmutableSet;
  */
 public class SVInstantiationCP implements Feature {
 
-    private final BackTrackingManager manager;
-
     private final Name svToInstantiate;
     private final ProjectionToTerm value;
 
-    public static Feature create(Name svToInstantiate, ProjectionToTerm value,
-            BackTrackingManager manager) {
-        return new SVInstantiationCP(svToInstantiate, value, manager);
+    public static Feature create(Name svToInstantiate, ProjectionToTerm value) {
+        return new SVInstantiationCP(svToInstantiate, value);
     }
 
-    public static Feature createTriggeredVarCP(ProjectionToTerm value,
-            BackTrackingManager manager) {
-        return new SVInstantiationCP(null, value, manager);
+    public static Feature createTriggeredVarCP(ProjectionToTerm value) {
+        return new SVInstantiationCP(null, value);
     }
 
 
-    private SVInstantiationCP(Name svToInstantiate, ProjectionToTerm value,
-            BackTrackingManager manager) {
+    private SVInstantiationCP(Name svToInstantiate, ProjectionToTerm value) {
         this.svToInstantiate = svToInstantiate;
         this.value = value;
-        this.manager = manager;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
-        manager.passChoicePoint(new CP(app, pos, goal), this);
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final BackTrackingManager manager = mState.getBacktrackingManager();
+        manager.passChoicePoint(new CP(app, pos, goal, mState), this);
         return NumberRuleAppCost.getZeroCost();
     }
 
@@ -65,8 +61,7 @@ public class SVInstantiationCP implements Feature {
         }
 
         final ImmutableSet<SchemaVariable> vars = app.uninstantiatedVars();
-        for (SchemaVariable var : vars) {
-            final SchemaVariable svt = var;
+        for (SchemaVariable svt : vars) {
             if (svt.name().equals(svToInstantiate)) {
                 return svt;
             }
@@ -85,11 +80,13 @@ public class SVInstantiationCP implements Feature {
         private final PosInOccurrence pos;
         private final RuleApp app;
         private final Goal goal;
+        private final MutableState mState;
 
-        private CP(RuleApp app, PosInOccurrence pos, Goal goal) {
+        private CP(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
             this.pos = pos;
             this.app = app;
             this.goal = goal;
+            this.mState = mState;
         }
 
         public Iterator<CPBranch> getBranches(RuleApp oldApp) {
@@ -101,7 +98,7 @@ public class SVInstantiationCP implements Feature {
             }
 
             final SchemaVariable sv = findSVWithName(tapp);
-            final Term instTerm = value.toTerm(app, pos, goal);
+            final Term instTerm = value.toTerm(app, pos, goal, mState);
 
             final RuleApp newApp =
                 tapp.addCheckedInstantiation(sv, instTerm, goal.proof().getServices(), true);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
@@ -48,7 +48,8 @@ public class SVInstantiationCP implements Feature {
         this.value = value;
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final BackTrackingManager manager = mState.getBacktrackingManager();
         manager.passChoicePoint(new CP(app, pos, goal, mState), this);
         return NumberRuleAppCost.getZeroCost();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ClausesSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ClausesSmallerThanFeature.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.feature.SmallerThanFeature;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
@@ -40,9 +41,9 @@ public class ClausesSmallerThanFeature extends SmallerThanFeature {
         return new ClausesSmallerThanFeature(left, right, numbers);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        final Term leftTerm = left.toTerm(app, pos, goal);
-        final Term rightTerm = right.toTerm(app, pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term leftTerm = left.toTerm(app, pos, goal, mState);
+        final Term rightTerm = right.toTerm(app, pos, goal, mState);
 
         final ClauseCollector m1 = new ClauseCollector();
         m1.collect(leftTerm);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Constraint.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Constraint.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.strategy.quantifierHeuristics;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.BooleanContainer;
 import de.uka.ilkd.key.logic.Term;
-import de.uka.ilkd.key.logic.TermServices;
 
 /**
  * Abstract constraint interface for constraints offering unification of terms and joins. There are
@@ -65,7 +64,7 @@ public interface Constraint {
      *
      * @return TOP if not possible, else a new constraint with after unification of t1 and t2
      */
-    Constraint unify(Term t1, Term t2, TermServices services);
+    Constraint unify(Term t1, Term t2, Services services);
 
     /**
      * tries to unify terms t1 and t2.
@@ -76,7 +75,7 @@ public interface Constraint {
      * @param unchanged true iff the new constraint equals this one
      * @return TOP if not possible, else a new constraint with after unification of t1 and t2
      */
-    Constraint unify(Term t1, Term t2, TermServices services, BooleanContainer unchanged);
+    Constraint unify(Term t1, Term t2, Services services, BooleanContainer unchanged);
 
     /**
      * @return true iff this constraint is as strong as "co", i.e. every instantiation satisfying
@@ -108,7 +107,7 @@ public interface Constraint {
      * @param services the Services providing access to the type model
      * @return the joined constraint
      */
-    Constraint join(Constraint co, TermServices services);
+    Constraint join(Constraint co, Services services);
 
     /**
      * joins constraint co with this constraint and returns the joint new constraint. The
@@ -121,7 +120,7 @@ public interface Constraint {
      * @param unchanged the BooleanContainers value set true, if this constraint is as strong as co
      * @return the joined constraint
      */
-    Constraint join(Constraint co, TermServices services, BooleanContainer unchanged);
+    Constraint join(Constraint co, Services services, BooleanContainer unchanged);
 
     /** @return String representation of the constraint */
     @Override
@@ -166,12 +165,12 @@ public interface Constraint {
          * @return always this
          */
         @Override
-        public Constraint unify(Term t1, Term t2, TermServices services) {
+        public Constraint unify(Term t1, Term t2, Services services) {
             return this;
         }
 
         @Override
-        public Constraint unify(Term t1, Term t2, TermServices services,
+        public Constraint unify(Term t1, Term t2, Services services,
                 BooleanContainer unchanged) {
             unchanged.setVal(true);
             return this;
@@ -201,7 +200,7 @@ public interface Constraint {
          * @return this
          */
         @Override
-        public Constraint join(Constraint co, TermServices services) {
+        public Constraint join(Constraint co, Services services) {
             return this;
         }
 
@@ -211,7 +210,7 @@ public interface Constraint {
          * @return this
          */
         @Override
-        public Constraint join(Constraint co, TermServices services, BooleanContainer c) {
+        public Constraint join(Constraint co, Services services, BooleanContainer c) {
             c.setVal(true);
             return this;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ConstraintAwareSyntacticalReplaceVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ConstraintAwareSyntacticalReplaceVisitor.java
@@ -34,7 +34,7 @@ public class ConstraintAwareSyntacticalReplaceVisitor extends SyntacticalReplace
     }
 
     protected Term toTerm(Term t) {
-        if (EqualityConstraint.metaVars(t).size() != 0 && !metavariableInst.isBottom()) {
+        if (!EqualityConstraint.metaVars(t, services).isEmpty() && !metavariableInst.isBottom()) {
             // use the visitor recursively for replacing metavariables that
             // might occur in the term (if possible)
             final ConstraintAwareSyntacticalReplaceVisitor srv =
@@ -48,9 +48,9 @@ public class ConstraintAwareSyntacticalReplaceVisitor extends SyntacticalReplace
     }
 
     public void visited(Term visited) {
-        if (visited.op() instanceof Metavariable && metavariableInst
-                .getInstantiation((Metavariable) visited.op(), services).op() != visited.op()) {
-            pushNew(metavariableInst.getInstantiation((Metavariable) visited.op(), services));
+        if (visited.op() instanceof Metavariable mv &&
+                metavariableInst.getInstantiation(mv, services).op() != visited.op()) {
+            pushNew(metavariableInst.getInstantiation(mv, services));
         } else {
             super.visit(visited);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/EliminableQuantifierTF.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/EliminableQuantifierTF.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.op.Quantifier;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termfeature.BinaryTermFeature;
 import de.uka.ilkd.key.strategy.termfeature.TermFeature;
 
@@ -19,7 +20,8 @@ public class EliminableQuantifierTF extends BinaryTermFeature {
 
     private EliminableQuantifierTF() {}
 
-    protected boolean filter(Term term, Services services) {
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
         final Operator op = term.op();
         assert op == Quantifier.ALL || op == Quantifier.EX;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ExistentiallyConnectedFormulasFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ExistentiallyConnectedFormulasFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.strategy.feature.BinaryTacletAppFeature;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 /**
@@ -26,13 +27,13 @@ public class ExistentiallyConnectedFormulasFeature extends BinaryTacletAppFeatur
         return new ExistentiallyConnectedFormulasFeature(for0, for1);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final ClausesGraph graph = ClausesGraph.create(pos.sequentFormula().formula(),
             goal.proof().getServices().getCaches());
 
-        return graph.connected(for0.toTerm(app, pos, goal), for1.toTerm(app, pos, goal));
+        return graph.connected(for0.toTerm(app, pos, goal, mState), for1.toTerm(app, pos, goal, mState));
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ExistentiallyConnectedFormulasFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/ExistentiallyConnectedFormulasFeature.java
@@ -33,7 +33,8 @@ public class ExistentiallyConnectedFormulasFeature extends BinaryTacletAppFeatur
         final ClausesGraph graph = ClausesGraph.create(pos.sequentFormula().formula(),
             goal.proof().getServices().getCaches());
 
-        return graph.connected(for0.toTerm(app, pos, goal, mState), for1.toTerm(app, pos, goal, mState));
+        return graph.connected(for0.toTerm(app, pos, goal, mState),
+            for1.toTerm(app, pos, goal, mState));
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HeuristicInstantiation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HeuristicInstantiation.java
@@ -24,7 +24,8 @@ public class HeuristicInstantiation implements TermGenerator {
     private HeuristicInstantiation() {}
 
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final Term qf = pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HeuristicInstantiation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HeuristicInstantiation.java
@@ -13,6 +13,7 @@ import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termgenerator.TermGenerator;
 
 
@@ -22,7 +23,8 @@ public class HeuristicInstantiation implements TermGenerator {
 
     private HeuristicInstantiation() {}
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    @Override
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final Term qf = pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCost.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCost.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 /**
@@ -29,11 +30,11 @@ public class InstantiationCost implements Feature {
     /**
      * Compute the cost of a RuleApp.
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Projection is only applicable to rules with find";
 
         final Term formula = pos.sequentFormula().formula();
-        final Term instance = varInst.toTerm(app, pos, goal);
+        final Term instance = varInst.toTerm(app, pos, goal, mState);
 
         return Instantiation.computeCost(instance, formula, goal.sequent(),
             goal.proof().getServices());

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCost.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCost.java
@@ -30,7 +30,8 @@ public class InstantiationCost implements Feature {
     /**
      * Compute the cost of a RuleApp.
      */
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         assert pos != null : "Projection is only applicable to rules with find";
 
         final Term formula = pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCostScalerFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCostScalerFeature.java
@@ -29,7 +29,8 @@ public class InstantiationCostScalerFeature implements Feature {
         return new InstantiationCostScalerFeature(costFeature, allowSplitting);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
 
         final RuleAppCost cost = costFeature.computeCost(app, pos, goal, mState);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCostScalerFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/InstantiationCostScalerFeature.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class InstantiationCostScalerFeature implements Feature {
 
@@ -28,9 +29,9 @@ public class InstantiationCostScalerFeature implements Feature {
         return new InstantiationCostScalerFeature(costFeature, allowSplitting);
     }
 
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
 
-        final RuleAppCost cost = costFeature.computeCost(app, pos, goal);
+        final RuleAppCost cost = costFeature.computeCost(app, pos, goal, mState);
 
         if (cost.equals(NumberRuleAppCost.getZeroCost())) {
             return MINUS_3000_COST;
@@ -39,7 +40,7 @@ public class InstantiationCostScalerFeature implements Feature {
             return NumberRuleAppCost.getZeroCost();
         }
 
-        final RuleAppCost as = allowSplitting.computeCost(app, pos, goal);
+        final RuleAppCost as = allowSplitting.computeCost(app, pos, goal, mState);
         if (!as.equals(NumberRuleAppCost.getZeroCost())) {
             return TopRuleAppCost.INSTANCE;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/LiteralsSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/LiteralsSmallerThanFeature.java
@@ -16,6 +16,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Polynomial;
 import de.uka.ilkd.key.strategy.feature.Feature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.feature.SmallerThanFeature;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
@@ -39,9 +40,9 @@ public class LiteralsSmallerThanFeature extends SmallerThanFeature {
         return new LiteralsSmallerThanFeature(left, right, numbers);
     }
 
-    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal) {
-        final Term leftTerm = left.toTerm(app, pos, goal);
-        final Term rightTerm = right.toTerm(app, pos, goal);
+    protected boolean filter(TacletApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term leftTerm = left.toTerm(app, pos, goal, mState);
+        final Term rightTerm = right.toTerm(app, pos, goal, mState);
 
         return compareTerms(leftTerm, rightTerm, pos, goal);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Metavariable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Metavariable.java
@@ -43,7 +43,6 @@ public final class Metavariable extends AbstractSortedOperator
         return name() + ":" + sort();
     }
 
-
     @Override
     public int compareTo(Metavariable p_mr) {
         if (p_mr == this) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/RecAndExistentiallyConnectedClausesFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/RecAndExistentiallyConnectedClausesFeature.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.strategy.quantifierHeuristics;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termfeature.BinaryTermFeature;
 import de.uka.ilkd.key.strategy.termfeature.TermFeature;
 
@@ -18,7 +19,8 @@ public class RecAndExistentiallyConnectedClausesFeature extends BinaryTermFeatur
 
     private RecAndExistentiallyConnectedClausesFeature() {}
 
-    protected boolean filter(Term term, Services services) {
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
         final ClausesGraph graph = ClausesGraph.create(term, services.getCaches());
         return graph.isFullGraph();
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/SplittableQuantifiedFormulaFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/SplittableQuantifiedFormulaFeature.java
@@ -14,6 +14,7 @@ import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
 import de.uka.ilkd.key.strategy.feature.Feature;
 
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableSet;
 
@@ -23,7 +24,7 @@ public class SplittableQuantifiedFormulaFeature extends BinaryFeature {
 
     public static final Feature INSTANCE = new SplittableQuantifiedFormulaFeature();
 
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert pos != null : "Feature is only applicable to rules with find";
 
         final Analyser analyser = new Analyser();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/SplittableQuantifiedFormulaFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/SplittableQuantifiedFormulaFeature.java
@@ -13,8 +13,8 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
 import de.uka.ilkd.key.strategy.feature.Feature;
-
 import de.uka.ilkd.key.strategy.feature.MutableState;
+
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableSet;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AbstractDividePolynomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AbstractDividePolynomialsProjection.java
@@ -13,6 +13,7 @@ import de.uka.ilkd.key.logic.op.Function;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public abstract class AbstractDividePolynomialsProjection implements ProjectionToTerm {
 
@@ -24,9 +25,9 @@ public abstract class AbstractDividePolynomialsProjection implements ProjectionT
         this.polynomial = polynomial;
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term coeffT = leftCoefficient.toTerm(app, pos, goal);
-        final Term polyT = polynomial.toTerm(app, pos, goal);
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term coeffT = leftCoefficient.toTerm(app, pos, goal, mState);
+        final Term polyT = polynomial.toTerm(app, pos, goal, mState);
 
         final Services services = goal.proof().getServices();
         final BigInteger coeff =

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -26,7 +27,7 @@ public class AssumptionProjection implements ProjectionToTerm {
         return new AssumptionProjection(no);
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mutableState) {
         assert app instanceof TacletApp
                 : "Projection is only applicable to taclet apps," + " but got " + app;
         final TacletApp tapp = (TacletApp) app;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Polynomial;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Given a monomial and a polynomial, this projection computes the gcd of all numerical
@@ -33,11 +34,11 @@ public class CoeffGcdProjection implements ProjectionToTerm {
         return new CoeffGcdProjection(monomialLeft, polynomialRight);
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
 
-        final Term monoT = monomialLeft.toTerm(app, pos, goal);
-        final Term polyT = polynomialRight.toTerm(app, pos, goal);
+        final Term monoT = monomialLeft.toTerm(app, pos, goal, mState);
+        final Term polyT = polynomialRight.toTerm(app, pos, goal, mState);
 
         final Monomial mono = Monomial.create(monoT, services);
         final Polynomial poly = Polynomial.create(polyT, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class FocusFormulaProjection implements ProjectionToTerm {
 
@@ -14,7 +15,7 @@ public class FocusFormulaProjection implements ProjectionToTerm {
 
     private FocusFormulaProjection() {}
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mutableState) {
         assert pos != null : "Projection is only applicable to rules with find";
 
         return pos.sequentFormula().formula();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Projection of a rule application to its focus (the term or formula that the rule operates on,
@@ -29,7 +30,7 @@ public class FocusProjection implements ProjectionToTerm {
     }
 
     @Override
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mutableState) {
         assert pos != null : "Projection is only applicable to rules with find";
 
         int n = stepsUpwards;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ProjectionToTerm.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ProjectionToTerm.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Interface for mappings from rule applications to terms. This is used, for instance, for
@@ -14,5 +15,5 @@ import de.uka.ilkd.key.rule.RuleApp;
  * which is signalled by <code>toTerm</code> returning <code>null</code>
  */
 public interface ProjectionToTerm {
-    Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal);
+    Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Projection for dividing one monomial by another.
@@ -26,9 +27,9 @@ public class ReduceMonomialsProjection implements ProjectionToTerm {
         return new ReduceMonomialsProjection(dividend, divisor);
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
-        final Term dividendT = dividend.toTerm(app, pos, goal);
-        final Term divisorT = divisor.toTerm(app, pos, goal);
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        final Term dividendT = dividend.toTerm(app, pos, goal, mState);
+        final Term divisorT = divisor.toTerm(app, pos, goal, mState);
 
         final Services services = goal.proof().getServices();
         final Monomial mDividend = Monomial.create(dividendT, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.util.Debug;
 
 /**
@@ -31,7 +32,7 @@ public class SVInstantiationProjection implements ProjectionToTerm {
     }
 
     @Override
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mutableState) {
         if (!(app instanceof final TacletApp tapp)) {
             Debug.fail("Projection is only applicable to taclet apps," + " but got " + app);
             throw new IllegalArgumentException(

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.PosInTerm;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Projection for computing a subterm of a given term. The position of the subterm within the
@@ -27,7 +28,7 @@ public class SubtermProjection implements ProjectionToTerm {
         this.pit = pit;
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return pit.getSubTerm(completeTerm.toTerm(app, pos, goal));
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return pit.getSubTerm(completeTerm.toTerm(app, pos, goal, mState));
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermBuffer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermBuffer.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Projection that can store and returns an arbitrary term or formula. Objects of this class are
@@ -15,18 +16,18 @@ import de.uka.ilkd.key.rule.RuleApp;
  */
 public class TermBuffer implements ProjectionToTerm {
 
-    private Term t = null;
 
-    public Term getContent() {
-        return t;
+
+    public Term getContent(MutableState mState) {
+        return mState.read(this);
     }
 
-    public void setContent(Term t) {
-        this.t = t;
+    public void setContent(Term t, MutableState mState) {
+        mState.assign(this, t);
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return t;
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return getContent(mState);
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.logic.op.Modality;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Term projection for constructing a bigger term from a sequence of direct subterms and an
@@ -34,10 +35,10 @@ public class TermConstructionProjection implements ProjectionToTerm {
         return new TermConstructionProjection(op, subTerms);
     }
 
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Term[] subs = new Term[subTerms.length];
         for (int i = 0; i != subTerms.length; ++i) {
-            subs[i] = subTerms[i].toTerm(app, pos, goal);
+            subs[i] = subTerms[i].toTerm(app, pos, goal, mState);
         }
         return goal.proof().getServices().getTermFactory().createTerm(op, subs, null, null);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
@@ -8,17 +8,18 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.Taclet;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class TriggerVariableInstantiationProjection implements ProjectionToTerm {
 
     @Override
-    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         assert app.rule() instanceof Taclet;
         final Taclet t = (Taclet) app.rule();
 
         final SVInstantiationProjection instProj =
             SVInstantiationProjection.create(t.getTrigger().triggerVar().name(), true);
-        return instProj.toTerm(app, pos, goal);
+        return instProj.toTerm(app, pos, goal, mState);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/AnonHeapTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/AnonHeapTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 public final class AnonHeapTermFeature extends BinaryTermFeature {
@@ -17,7 +18,7 @@ public final class AnonHeapTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         return // the heap term is an anon heap symbol
                // (for instance an anonHeap function)
         t.hasLabels() && t.containsLabel(ParameterlessTermLabel.ANON_HEAP_LABEL)

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/AtomTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/AtomTermFeature.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.logic.op.IfThenElse;
 import de.uka.ilkd.key.logic.op.Junctor;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.Quantifier;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class AtomTermFeature extends BinaryTermFeature {
 
@@ -17,7 +18,7 @@ public class AtomTermFeature extends BinaryTermFeature {
 
     private AtomTermFeature() {}
 
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         final Operator op = term.op();
         return !(op instanceof Junctor || op == Equality.EQV || op instanceof IfThenElse
                 || op instanceof Quantifier);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/BinarySumTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/BinarySumTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * A feature that computes the sum of two given features (faster than the more general class
@@ -14,12 +15,12 @@ import de.uka.ilkd.key.strategy.TopRuleAppCost;
  */
 public class BinarySumTermFeature implements TermFeature {
 
-    public RuleAppCost compute(Term term, Services services) {
-        RuleAppCost f0Cost = f0.compute(term, services);
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
+        RuleAppCost f0Cost = f0.compute(term, mState, services);
         if (f0Cost instanceof TopRuleAppCost) {
             return f0Cost;
         }
-        return f0Cost.add(f1.compute(term, services));
+        return f0Cost.add(f1.compute(term, mState, services));
     }
 
     private BinarySumTermFeature(TermFeature f0, TermFeature f1) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/BinaryTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/BinaryTermFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Abstract superclass for features that have either zero cost or top cost.
@@ -21,10 +22,10 @@ public abstract class BinaryTermFeature implements TermFeature {
     /** Constant that represents the boolean value false */
     public static final RuleAppCost TOP_COST = TopRuleAppCost.INSTANCE;
 
-    final public RuleAppCost compute(Term term, Services services) {
-        return filter(term, services) ? ZERO_COST : TOP_COST;
+    final public RuleAppCost compute(Term term, MutableState mState, Services services) {
+        return filter(term, mState, services) ? ZERO_COST : TOP_COST;
     }
 
-    protected abstract boolean filter(Term term, Services services);
+    protected abstract boolean filter(Term term, MutableState mState, Services services);
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ClosedExpressionTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ClosedExpressionTermFeature.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * return zero cost if given term does not contain any free variables.
@@ -15,7 +16,7 @@ public class ClosedExpressionTermFeature extends BinaryTermFeature {
 
     private ClosedExpressionTermFeature() {}
 
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return term.freeVars().size() == 0;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ConstTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ConstTermFeature.java
@@ -6,12 +6,13 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.RuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * A feature that returns a constant value
  */
 public class ConstTermFeature implements TermFeature {
-    public RuleAppCost compute(Term term, Services services) {
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
         return val;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ConstantTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ConstantTermFeature.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class ConstantTermFeature extends BinaryTermFeature {
 
@@ -15,7 +16,7 @@ public class ConstantTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return term.op() instanceof Function && term.arity() == 0;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsExecutableCodeTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsExecutableCodeTermFeature.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.logic.op.Modality;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.logic.op.Quantifier;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -26,11 +27,12 @@ public class ContainsExecutableCodeTermFeature extends BinaryTermFeature {
     public final static TermFeature PROGRAMS_OR_QUERIES =
         new ContainsExecutableCodeTermFeature(true);
 
-    protected boolean filter(Term t, Services services) {
-        return containsExec(t, services);
+    @Override
+    protected boolean filter(Term t, MutableState mState, Services services) {
+        return containsExec(t, mState, services);
     }
 
-    private boolean containsExec(Term t, Services services) {
+    private boolean containsExec(Term t, MutableState mState, Services services) {
         if (t.isRigid()) {
             return false;
         }
@@ -49,7 +51,7 @@ public class ContainsExecutableCodeTermFeature extends BinaryTermFeature {
         }
 
         for (int i = 0; i != op.arity(); ++i) {
-            final boolean res = filter(t.sub(i), services);
+            final boolean res = filter(t.sub(i), mState, services);
             if (res) {
                 return true;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsLabelFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsLabelFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class ContainsLabelFeature extends BinaryFeature {
 
@@ -21,7 +22,7 @@ public class ContainsLabelFeature extends BinaryFeature {
 
 
     @Override
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return pos != null && pos.subTerm().containsLabel(label);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsLabelNameFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ContainsLabelNameFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.feature.BinaryFeature;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class ContainsLabelNameFeature extends BinaryFeature {
     private final Name labelName;
@@ -17,7 +18,7 @@ public class ContainsLabelNameFeature extends BinaryFeature {
     }
 
     @Override
-    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal) {
+    protected boolean filter(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return pos != null && pos.subTerm().getLabel(labelName) != null;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/EqTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/EqTermFeature.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.TermBuffer;
 
 /**
@@ -26,7 +27,8 @@ public class EqTermFeature extends BinaryTermFeature {
         this.pattern = pattern;
     }
 
-    protected boolean filter(Term term, Services services) {
-        return term.equalsModRenaming(pattern.getContent());
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
+        return term.equalsModRenaming(pattern.getContent(mState));
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsHeapFunctionTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsHeapFunctionTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 public final class IsHeapFunctionTermFeature extends BinaryTermFeature {
@@ -22,7 +23,7 @@ public final class IsHeapFunctionTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         if (t.op() instanceof Function) {
             Function op = t.op(Function.class);
             return op.arity() == 0 && op.sort() == heapLDT.targetSort();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsInductionVariable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsInductionVariable.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -24,7 +25,7 @@ public class IsInductionVariable extends BinaryTermFeature {
     private IsInductionVariable() {}
 
     @Override
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         // this has been copied from the former InductionVariableCondition
         // TODO: use termlabels instead of names?
         final String name = term.op().toString();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsNonRigidTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsNonRigidTermFeature.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * this termfeature returns <tt>ZERO</tt> costs if the given term is non-rigid
@@ -15,7 +16,8 @@ public class IsNonRigidTermFeature extends BinaryTermFeature {
 
     private IsNonRigidTermFeature() {}
 
-    protected boolean filter(Term term, Services services) {
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return !term.isRigid();
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsPostConditionTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsPostConditionTermFeature.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -21,7 +22,7 @@ public final class IsPostConditionTermFeature extends BinaryTermFeature {
 
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         return t.hasLabels() && t.containsLabel(ParameterlessTermLabel.POST_CONDITION_LABEL);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsSelectSkolemConstantTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/IsSelectSkolemConstantTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -23,7 +24,7 @@ public final class IsSelectSkolemConstantTermFeature extends BinaryTermFeature {
 
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         return t.hasLabels() && t.containsLabel(ParameterlessTermLabel.SELECT_SKOLEM_LABEL)
                 && t.op().arity() == 0 && t.op() instanceof Function;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/OperatorClassTF.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/OperatorClassTF.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Operator;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Term feature for checking whether the top operator of a term has an instance of a certain class
@@ -22,7 +23,8 @@ public class OperatorClassTF extends BinaryTermFeature {
         return new OperatorClassTF(op);
     }
 
-    protected boolean filter(Term term, Services services) {
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return opClass.isInstance(term.op());
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/OperatorTF.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/OperatorTF.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Operator;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Term feature for checking whether the top operator of a term is identical to a given one
@@ -22,7 +23,7 @@ public class OperatorTF extends BinaryTermFeature {
         return new OperatorTF(op);
     }
 
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return op == term.op();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/PrimitiveHeapTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/PrimitiveHeapTermFeature.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.LocationVariable;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 public final class PrimitiveHeapTermFeature extends BinaryTermFeature {
@@ -24,7 +25,7 @@ public final class PrimitiveHeapTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         // t.op() is the base heap or another primitive heap variable
         boolean isPrimitive = false;
         Iterator<LocationVariable> it = heapLDT.getAllHeaps().iterator();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/PrintTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/PrintTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 public class PrintTermFeature implements TermFeature {
 
@@ -14,7 +15,7 @@ public class PrintTermFeature implements TermFeature {
 
     private PrintTermFeature() {}
 
-    public RuleAppCost compute(Term term, Services services) {
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
         return NumberRuleAppCost.getZeroCost();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/RecSubTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/RecSubTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -27,16 +28,16 @@ public class RecSubTermFeature implements TermFeature {
         return new RecSubTermFeature(cond, summand);
     }
 
-    public RuleAppCost compute(Term term, Services services) {
-        RuleAppCost res = summand.compute(term, services);
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
+        RuleAppCost res = summand.compute(term, mState, services);
 
         if (res instanceof TopRuleAppCost
-                || cond.compute(term, services) instanceof TopRuleAppCost) {
+                || cond.compute(term, mState, services) instanceof TopRuleAppCost) {
             return res;
         }
 
         for (int i = 0; i != term.arity() && !(res instanceof TopRuleAppCost); ++i) {
-            res = res.add(compute(term.sub(i), services));
+            res = res.add(compute(term.sub(i), mState, services));
         }
 
         return res;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ShannonTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/ShannonTermFeature.java
@@ -7,6 +7,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * A conditional feature, in which the condition itself is a (binary) feature. The general notion is
@@ -44,11 +45,11 @@ public class ShannonTermFeature implements TermFeature {
         elseFeature = p_elseFeature;
     }
 
-    public RuleAppCost compute(Term term, Services services) {
-        if (cond.compute(term, services).equals(trueCost)) {
-            return thenFeature.compute(term, services);
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
+        if (cond.compute(term, mState, services).equals(trueCost)) {
+            return thenFeature.compute(term, mState, services);
         } else {
-            return elseFeature.compute(term, services);
+            return elseFeature.compute(term, mState, services);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SimplifiedSelectTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SimplifiedSelectTermFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.op.Function;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 public final class SimplifiedSelectTermFeature extends BinaryTermFeature {
@@ -25,13 +26,13 @@ public final class SimplifiedSelectTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term t, Services services) {
+    protected boolean filter(Term t, MutableState mState, Services services) {
         boolean isSelectOp = heapLDT.getSortOfSelect(t.op()) != null;
         return // either the operator is not a select operator
         !isSelectOp ||
         // or the heap term of the select operator is the base heap
         // or another primitive heap variable
-                primitiveHeapTermFeature.filter(t.sub(0), services) ||
+                primitiveHeapTermFeature.filter(t.sub(0), mState, services) ||
                 // or the heap term of the select operator is an anon heap symbol
                 // (for instance an anonHeap function)
                 (t.sub(0).op() instanceof Function && t.sub(0).op().arity() == 0

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SortExtendsTransTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SortExtendsTransTermFeature.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.sort.Sort;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -24,7 +25,8 @@ public class SortExtendsTransTermFeature extends BinaryTermFeature {
         this.sort = sort;
     }
 
-    protected boolean filter(Term term, Services services) {
+    @Override
+    protected boolean filter(Term term, MutableState mState, Services services) {
         return term.sort().extendsTrans(sort);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SubTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/SubTermFeature.java
@@ -8,6 +8,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.NumberRuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -36,7 +37,7 @@ public class SubTermFeature implements TermFeature {
     private final TermFeature[] features;
     private final RuleAppCost arityMismatchCost;
 
-    public RuleAppCost compute(Term term, Services services) {
+    public RuleAppCost compute(Term term, MutableState mState, Services services) {
         if (term.arity() != features.length) {
             return arityMismatchCost;
         }
@@ -44,7 +45,7 @@ public class SubTermFeature implements TermFeature {
         RuleAppCost res = NumberRuleAppCost.getZeroCost();
 
         for (int i = 0; i < features.length && !(res instanceof TopRuleAppCost); i++) {
-            res = res.add(features[i].compute(term.sub(i), services));
+            res = res.add(features[i].compute(term.sub(i), mState, services));
         }
 
         return res;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/TermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/TermFeature.java
@@ -6,11 +6,12 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.strategy.RuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Interface for computing a cost for a given term or formula
  */
 public interface TermFeature {
 
-    RuleAppCost compute(Term term, Services services);
+    RuleAppCost compute(Term term, MutableState mState, Services services);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/TermLabelTermFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termfeature/TermLabelTermFeature.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.strategy.termfeature;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.label.TermLabel;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * A termfeature that can be used to check whether a term has a specific label
@@ -27,7 +28,7 @@ public class TermLabelTermFeature extends BinaryTermFeature {
     }
 
     @Override
-    protected boolean filter(Term term, Services services) {
+    protected boolean filter(Term term, MutableState mState, Services services) {
         if (label == null) {
             return term.hasLabels();
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/AllowedCutPositionsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/AllowedCutPositionsGenerator.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.logic.op.Junctor;
 import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Enumerate potential subformulas of a formula that could be used for a cut (taclet cut_direct).
@@ -23,7 +24,7 @@ public class AllowedCutPositionsGenerator implements TermGenerator {
 
     public final static TermGenerator INSTANCE = new AllowedCutPositionsGenerator();
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return new ACPIterator(pos.sequentFormula().formula(), pos.isInAntec());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/AllowedCutPositionsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/AllowedCutPositionsGenerator.java
@@ -24,7 +24,8 @@ public class AllowedCutPositionsGenerator implements TermGenerator {
 
     public final static TermGenerator INSTANCE = new AllowedCutPositionsGenerator();
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return new ACPIterator(pos.sequentFormula().formula(), pos.isInAntec());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/HeapGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/HeapGenerator.java
@@ -14,6 +14,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.UpdateApplication;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * The heap generator returns an iterator over all terms of sort heap that
@@ -35,7 +36,7 @@ public class HeapGenerator implements TermGenerator {
     }
 
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         LinkedHashSet<Term> heaps = new LinkedHashSet<>();
         Sequent seq = goal.sequent();
         for (SequentFormula sf : seq) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/HeapGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/HeapGenerator.java
@@ -36,7 +36,8 @@ public class HeapGenerator implements TermGenerator {
     }
 
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         LinkedHashSet<Term> heaps = new LinkedHashSet<>();
         Sequent seq = goal.sequent();
         for (SequentFormula sf : seq) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
@@ -18,6 +18,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Polynomial;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 import org.key_project.util.collection.ImmutableList;
@@ -51,11 +52,11 @@ public class MultiplesModEquationsGenerator implements TermGenerator {
         return new MultiplesModEquationsGenerator(source, target);
     }
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
 
-        final Monomial sourceM = Monomial.create(source.toTerm(app, pos, goal), services);
-        final Monomial targetM = Monomial.create(target.toTerm(app, pos, goal), services);
+        final Monomial sourceM = Monomial.create(source.toTerm(app, pos, goal, mState), services);
+        final Monomial targetM = Monomial.create(target.toTerm(app, pos, goal, mState), services);
 
         if (targetM.divides(sourceM)) {
             return toIterator(targetM.reduce(sourceM).toTerm(services));
@@ -135,7 +136,7 @@ public class MultiplesModEquationsGenerator implements TermGenerator {
      * Extract all integer equations of the antecedent and convert them into
      * <code>Polynomial</code>s.
      *
-     * @returns a list of polynomials, stored in objects of <code>CofactorPolynomial</code>. The
+     * @return a list of polynomials, stored in objects of <code>CofactorPolynomial</code>. The
      *          initial cofactor is set to zero.
      */
     private List<CofactorPolynomial> extractPolys(Goal goal, Services services) {
@@ -214,7 +215,7 @@ public class MultiplesModEquationsGenerator implements TermGenerator {
             if (res.poly.getParts().size() == 1 && res.poly.getConstantTerm().signum() == 0) {
                 return new CofactorMonomial(res.poly.getParts().head(), res.cofactor);
             }
-            if (res.poly.getParts().size() == 0 && res.poly.getConstantTerm().signum() != 0) {
+            if (res.poly.getParts().isEmpty() && res.poly.getConstantTerm().signum() != 0) {
                 return new CofactorMonomial(Monomial.ONE.multiply(res.poly.getConstantTerm()),
                     res.cofactor);
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
@@ -52,7 +52,8 @@ public class MultiplesModEquationsGenerator implements TermGenerator {
         return new MultiplesModEquationsGenerator(source, target);
     }
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Services services = goal.proof().getServices();
 
         final Monomial sourceM = Monomial.create(source.toTerm(app, pos, goal, mState), services);
@@ -137,7 +138,7 @@ public class MultiplesModEquationsGenerator implements TermGenerator {
      * <code>Polynomial</code>s.
      *
      * @return a list of polynomials, stored in objects of <code>CofactorPolynomial</code>. The
-     *          initial cofactor is set to zero.
+     *         initial cofactor is set to zero.
      */
     private List<CofactorPolynomial> extractPolys(Goal goal, Services services) {
         final IntegerLDT numbers = services.getTypeConverter().getIntegerLDT();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
@@ -49,7 +49,8 @@ public class RootsGenerator implements TermGenerator {
     }
 
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         final Services services = goal.proof().getServices();
         final IntegerLDT numbers = services.getTypeConverter().getIntegerLDT();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
@@ -18,6 +18,7 @@ import de.uka.ilkd.key.logic.op.Operator;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 
 import org.key_project.util.collection.ImmutableSLList;
@@ -48,11 +49,11 @@ public class RootsGenerator implements TermGenerator {
     }
 
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         final Services services = goal.proof().getServices();
         final IntegerLDT numbers = services.getTypeConverter().getIntegerLDT();
 
-        final Term powerRel = powerRelation.toTerm(app, pos, goal);
+        final Term powerRel = powerRelation.toTerm(app, pos, goal, mState);
 
         final Operator op = powerRel.op();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SequentFormulasGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SequentFormulasGenerator.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.logic.SequentFormula;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Term generator that enumerates the formulas of the current sequent/antecedent/succedent.
@@ -44,7 +45,7 @@ public abstract class SequentFormulasGenerator implements TermGenerator {
 
     protected abstract Iterator<SequentFormula> generateForIt(Goal goal);
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         return new SFIterator(generateForIt(goal));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SequentFormulasGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SequentFormulasGenerator.java
@@ -45,7 +45,8 @@ public abstract class SequentFormulasGenerator implements TermGenerator {
 
     protected abstract Iterator<SequentFormula> generateForIt(Goal goal);
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return new SFIterator(generateForIt(goal));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SubtermGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SubtermGenerator.java
@@ -39,8 +39,10 @@ public abstract class SubtermGenerator implements TermGenerator {
      */
     public static TermGenerator leftTraverse(ProjectionToTerm cTerm, TermFeature cond) {
         return new SubtermGenerator(cTerm, cond) {
-            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-                return new LeftIterator(getTermInst(app, pos, goal, mState), mState, goal.proof().getServices());
+            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
+                return new LeftIterator(getTermInst(app, pos, goal, mState), mState,
+                    goal.proof().getServices());
             }
         };
     }
@@ -51,8 +53,10 @@ public abstract class SubtermGenerator implements TermGenerator {
      */
     public static TermGenerator rightTraverse(ProjectionToTerm cTerm, TermFeature cond) {
         return new SubtermGenerator(cTerm, cond) {
-            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
-                return new RightIterator(getTermInst(app, pos, goal, mState), mState, goal.proof().getServices());
+            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+                    MutableState mState) {
+                return new RightIterator(getTermInst(app, pos, goal, mState), mState,
+                    goal.proof().getServices());
             }
         };
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SubtermGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SubtermGenerator.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termProjection.ProjectionToTerm;
 import de.uka.ilkd.key.strategy.termfeature.TermFeature;
 
@@ -38,8 +39,8 @@ public abstract class SubtermGenerator implements TermGenerator {
      */
     public static TermGenerator leftTraverse(ProjectionToTerm cTerm, TermFeature cond) {
         return new SubtermGenerator(cTerm, cond) {
-            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
-                return new LeftIterator(getTermInst(app, pos, goal), goal.proof().getServices());
+            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return new LeftIterator(getTermInst(app, pos, goal, mState), mState, goal.proof().getServices());
             }
         };
     }
@@ -50,27 +51,28 @@ public abstract class SubtermGenerator implements TermGenerator {
      */
     public static TermGenerator rightTraverse(ProjectionToTerm cTerm, TermFeature cond) {
         return new SubtermGenerator(cTerm, cond) {
-            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
-                return new RightIterator(getTermInst(app, pos, goal), goal.proof().getServices());
+            public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+                return new RightIterator(getTermInst(app, pos, goal, mState), mState, goal.proof().getServices());
             }
         };
     }
 
-    protected Term getTermInst(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return completeTerm.toTerm(app, pos, goal);
+    protected Term getTermInst(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return completeTerm.toTerm(app, pos, goal, mState);
     }
 
-    private boolean descendFurther(Term t, Services services) {
-        return !(cond.compute(t, services) instanceof TopRuleAppCost);
+    private boolean descendFurther(Term t, MutableState mState, Services services) {
+        return !(cond.compute(t, mState, services) instanceof TopRuleAppCost);
     }
 
     abstract static class SubIterator implements Iterator<Term> {
         protected ImmutableList<Term> termStack;
-
+        protected final MutableState mState;
         protected final Services services;
 
-        public SubIterator(Term t, Services services) {
+        public SubIterator(Term t, MutableState mState, Services services) {
             termStack = ImmutableSLList.<Term>nil().prepend(t);
+            this.mState = mState;
             this.services = services;
         }
 
@@ -80,15 +82,15 @@ public abstract class SubtermGenerator implements TermGenerator {
     }
 
     class LeftIterator extends SubIterator {
-        public LeftIterator(Term t, Services services) {
-            super(t, services);
+        public LeftIterator(Term t, MutableState mState, Services services) {
+            super(t, mState, services);
         }
 
         public Term next() {
             final Term res = termStack.head();
             termStack = termStack.tail();
 
-            if (descendFurther(res, services)) {
+            if (descendFurther(res, mState, services)) {
                 for (int i = res.arity() - 1; i >= 0; --i) {
                     termStack = termStack.prepend(res.sub(i));
                 }
@@ -107,15 +109,15 @@ public abstract class SubtermGenerator implements TermGenerator {
     }
 
     class RightIterator extends SubIterator {
-        public RightIterator(Term t, Services services) {
-            super(t, services);
+        public RightIterator(Term t, MutableState mState, Services services) {
+            super(t, mState, services);
         }
 
         public Term next() {
             final Term res = termStack.head();
             termStack = termStack.tail();
 
-            if (descendFurther(res, services)) {
+            if (descendFurther(res, mState, services)) {
                 for (int i = 0; i != res.arity(); ++i) {
                     termStack = termStack.prepend(res.sub(i));
                 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SuperTermGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SuperTermGenerator.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.TopRuleAppCost;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.termfeature.TermFeature;
 
 import org.key_project.util.collection.ImmutableArray;
@@ -31,32 +32,34 @@ public abstract class SuperTermGenerator implements TermGenerator {
 
     public static TermGenerator upwards(TermFeature cond, final Services services) {
         return new SuperTermGenerator(cond) {
-            protected Iterator<Term> createIterator(PosInOccurrence focus) {
-                return new UpwardsIterator(focus, services);
+            @Override
+            protected Iterator<Term> createIterator(PosInOccurrence focus, MutableState mState) {
+                return new UpwardsIterator(focus, mState, services);
             }
         };
     }
 
     public static TermGenerator upwardsWithIndex(TermFeature cond, final Services services) {
         return new SuperTermWithIndexGenerator(cond) {
-            protected Iterator<Term> createIterator(PosInOccurrence focus) {
-                return new UpwardsIterator(focus, services);
+            @Override
+            protected Iterator<Term> createIterator(PosInOccurrence focus, MutableState mState) {
+                return new UpwardsIterator(focus, mState, services);
             }
         };
     }
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
-        return createIterator(pos);
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        return createIterator(pos, mState);
     }
 
-    protected abstract Iterator<Term> createIterator(PosInOccurrence focus);
+    protected abstract Iterator<Term> createIterator(PosInOccurrence focus, MutableState mState);
 
     protected Term generateOneTerm(Term superterm, int child) {
         return superterm;
     }
 
-    private boolean generateFurther(Term t, Services services) {
-        return !(cond.compute(t, services) instanceof TopRuleAppCost);
+    private boolean generateFurther(Term t, MutableState mState, Services services) {
+        return !(cond.compute(t, mState, services) instanceof TopRuleAppCost);
     }
 
     abstract static class SuperTermWithIndexGenerator extends SuperTermGenerator {
@@ -67,7 +70,8 @@ public abstract class SuperTermGenerator implements TermGenerator {
             super(cond);
         }
 
-        public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+        @Override
+        public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
             if (services == null) {
                 services = goal.proof().getServices();
                 final IntegerLDT numbers = services.getTypeConverter().getIntegerLDT();
@@ -122,7 +126,7 @@ public abstract class SuperTermGenerator implements TermGenerator {
                 // new Sort[] { Sort.ANY, numbers.getNumberSymbol ().sort () } );
             }
 
-            return createIterator(pos);
+            return createIterator(pos, mState);
         }
 
         protected Term generateOneTerm(Term superterm, int child) {
@@ -133,23 +137,26 @@ public abstract class SuperTermGenerator implements TermGenerator {
 
     class UpwardsIterator implements Iterator<Term> {
         private PosInOccurrence currentPos;
-
+        private final MutableState mState;
         private final Services services;
 
-        private UpwardsIterator(PosInOccurrence startPos, Services services) {
+        private UpwardsIterator(PosInOccurrence startPos, MutableState mState, Services services) {
             this.currentPos = startPos;
+            this.mState = mState;
             this.services = services;
         }
 
+        @Override
         public boolean hasNext() {
             return currentPos != null && !currentPos.isTopLevel();
         }
 
+        @Override
         public Term next() {
             final int child = currentPos.getIndex();
             currentPos = currentPos.up();
             final Term res = generateOneTerm(currentPos.subTerm(), child);
-            if (!generateFurther(res, services)) {
+            if (!generateFurther(res, mState, services)) {
                 currentPos = null;
             }
             return res;
@@ -158,6 +165,7 @@ public abstract class SuperTermGenerator implements TermGenerator {
         /**
          * throw an unsupported operation exception as generators do not remove
          */
+        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SuperTermGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/SuperTermGenerator.java
@@ -48,7 +48,8 @@ public abstract class SuperTermGenerator implements TermGenerator {
         };
     }
 
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         return createIterator(pos, mState);
     }
 
@@ -71,7 +72,8 @@ public abstract class SuperTermGenerator implements TermGenerator {
         }
 
         @Override
-        public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+        public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+                MutableState mState) {
             if (services == null) {
                 services = goal.proof().getServices();
                 final IntegerLDT numbers = services.getTypeConverter().getIntegerLDT();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TermGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TermGenerator.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.RuleApp;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 
 /**
@@ -17,5 +18,5 @@ import de.uka.ilkd.key.rule.RuleApp;
  * terms/formulas.
  */
 public interface TermGenerator {
-    Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal);
+    Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
@@ -65,7 +65,8 @@ public class TriggeredInstantiations implements TermGenerator {
      * Generates all instances
      */
     @Override
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
+            MutableState mState) {
         if (app instanceof TacletApp tapp) {
 
             final Services services = goal.proof().getServices();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
@@ -28,6 +28,7 @@ import de.uka.ilkd.key.rule.SyntacticalReplaceVisitor;
 import de.uka.ilkd.key.rule.Taclet;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.Constraint;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.EqualityConstraint;
 import de.uka.ilkd.key.strategy.quantifierHeuristics.Metavariable;
@@ -60,11 +61,11 @@ public class TriggeredInstantiations implements TermGenerator {
         this.checkConditions = checkConditions;
     }
 
-    @Override
     /**
      * Generates all instances
      */
-    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal) {
+    @Override
+    public Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState) {
         if (app instanceof TacletApp tapp) {
 
             final Services services = goal.proof().getServices();

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/DataRecordingStrategy.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/DataRecordingStrategy.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.strategy.JavaCardDLStrategy;
 import de.uka.ilkd.key.strategy.RuleAppCost;
 import de.uka.ilkd.key.strategy.RuleAppCostCollector;
+import de.uka.ilkd.key.strategy.feature.MutableState;
 
 /**
  * Modification of {@link JavaCardDLStrategy} so that profiling data gets collected during strategy
@@ -39,9 +40,9 @@ class DataRecordingStrategy extends JavaCardDLStrategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
         long begin = System.nanoTime();
-        RuleAppCost result = super.computeCost(app, pio, goal);
+        RuleAppCost result = super.computeCost(app, pio, goal, mState);
         long end = System.nanoTime();
         computeCostData.addDurationToData(app, goal, end - begin);
         return result;

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/DataRecordingStrategy.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/DataRecordingStrategy.java
@@ -40,7 +40,8 @@ class DataRecordingStrategy extends JavaCardDLStrategy {
     }
 
     @Override
-    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal, MutableState mState) {
+    public RuleAppCost computeCost(RuleApp app, PosInOccurrence pio, Goal goal,
+            MutableState mState) {
         long begin = System.nanoTime();
         RuleAppCost result = super.computeCost(app, pio, goal, mState);
         long end = System.nanoTime();

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/RunAllProofsTestWithComputeCostProfiling.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/RunAllProofsTestWithComputeCostProfiling.java
@@ -13,13 +13,13 @@ import de.uka.ilkd.key.proof.runallproofs.ProofCollections;
 import de.uka.ilkd.key.proof.runallproofs.RunAllProofsFunctional;
 import de.uka.ilkd.key.proof.runallproofs.RunAllProofsTest;
 import de.uka.ilkd.key.proof.runallproofs.proofcollection.ProofCollection;
-import de.uka.ilkd.key.strategy.JavaCardDLStrategy;
 
+import de.uka.ilkd.key.strategy.feature.Feature;
 import org.junit.jupiter.api.*;
 
 /**
  * Same as {@link RunAllProofsFunctional} but we alter
- * {@link JavaCardDLStrategy#computeCost(de.uka.ilkd.key.rule.RuleApp, de.uka.ilkd.key.logic.PosInOccurrence, de.uka.ilkd.key.proof.Goal)}
+ * {@link Feature#computeCost(de.uka.ilkd.key.rule.RuleApp, de.uka.ilkd.key.logic.PosInOccurrence, de.uka.ilkd.key.proof.Goal, de.uka.ilkd.key.strategy.feature.MutableState)}
  * so that statistical data about that method can be recorded (time duration, number of invocations
  * and potentially other stuff).
  */

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/RunAllProofsTestWithComputeCostProfiling.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/performance/RunAllProofsTestWithComputeCostProfiling.java
@@ -13,8 +13,8 @@ import de.uka.ilkd.key.proof.runallproofs.ProofCollections;
 import de.uka.ilkd.key.proof.runallproofs.RunAllProofsFunctional;
 import de.uka.ilkd.key.proof.runallproofs.RunAllProofsTest;
 import de.uka.ilkd.key.proof.runallproofs.proofcollection.ProofCollection;
-
 import de.uka.ilkd.key.strategy.feature.Feature;
+
 import org.junit.jupiter.api.*;
 
 /**

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
@@ -47,15 +47,17 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
     @SuppressWarnings("unchecked")
     public ImmutableArray(S[] arr, int lower, int upper) {
         content = (S[]) Array.newInstance(arr.getClass().getComponentType(), upper - lower);
-        System.arraycopy(arr, lower, content, 0, upper-lower);
+        System.arraycopy(arr, lower, content, 0, upper - lower);
     }
 
     /**
      * <p>
-     *     creates a new immutable array with the contents of the given collection.
-     * </p><p>
+     * creates a new immutable array with the contents of the given collection.
+     * </p>
+     * <p>
      * The order of elements is defined by the collection.
      * </p>
+     *
      * @param list a non-null collection (order is preserved)
      */
     @SuppressWarnings("unchecked")

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
@@ -44,12 +44,18 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
         System.arraycopy(arr, 0, content, 0, arr.length);
     }
 
+    @SuppressWarnings("unchecked")
+    public ImmutableArray(S[] arr, int lower, int upper) {
+        content = (S[]) Array.newInstance(arr.getClass().getComponentType(), upper - lower);
+        System.arraycopy(arr, lower, content, 0, upper-lower);
+    }
 
     /**
-     * creates a new immutable array with the contents of the given collection.
-     *
+     * <p>
+     *     creates a new immutable array with the contents of the given collection.
+     * </p><p>
      * The order of elements is defined by the collection.
-     *
+     * </p>
      * @param list a non-null collection (order is preserved)
      */
     @SuppressWarnings("unchecked")
@@ -127,7 +133,8 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
         if (o == this) {
             return true;
         }
-        S[] cmp = null;
+
+        final S[] cmp;
         if (o instanceof ImmutableArray) {
             cmp = ((ImmutableArray<S>) o).content;
         } else {

--- a/keyext.slicing/src/main/java/org/key_project/slicing/DependencyTracker.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/DependencyTracker.java
@@ -268,16 +268,14 @@ public class DependencyTracker implements RuleAppListener, ProofTreeListener {
         // record any rules added by this rule application
         for (NodeReplacement newNode : ruleAppInfo.getReplacementNodes()) {
             for (NoPosTacletApp newRule : newNode.getNode().getLocalIntroducedRules()) {
-                if (newRule.rule() instanceof Taclet taclet) {
-                    final var justification =
-                        newNode.getNode().proof().getInitConfig().getJustifInfo()
-                                .getJustification(taclet);
-                    if (justification instanceof RuleJustificationByAddRules justAddRule &&
-                            justAddRule.node() == n) {
-                        AddedRule ruleNode = new AddedRule(newRule.rule().name().toString());
-                        output.add(ruleNode);
-                        dynamicRules.put((Taclet) newRule.rule(), ruleNode);
-                    }
+                final var justification =
+                    newNode.getNode().proof().getInitConfig().getJustifInfo()
+                            .getJustification(newRule.taclet());
+                if (justification instanceof RuleJustificationByAddRules justAddRule &&
+                        justAddRule.node() == n) {
+                    AddedRule ruleNode = new AddedRule(newRule.rule().name().toString());
+                    output.add(ruleNode);
+                    dynamicRules.put((Taclet) newRule.rule(), ruleNode);
                 }
             }
         }
@@ -352,17 +350,16 @@ public class DependencyTracker implements RuleAppListener, ProofTreeListener {
         List<GraphNode> output = new ArrayList<>();
 
         // record any rules added by this rule application
-        for (Node newNode : goalList) {
+        for (final Node newNode : goalList) {
             for (NoPosTacletApp newRule : newNode.getLocalIntroducedRules()) {
-                if (newRule.rule() instanceof Taclet taclet) {
-                    var justification =
-                        newNode.proof().getInitConfig().getJustifInfo().getJustification(taclet);
-                    if (justification instanceof RuleJustificationByAddRules justAddRule
-                            && justAddRule.node() == n) {
-                        AddedRule ruleNode = new AddedRule(newRule.rule().name().toString());
-                        output.add(ruleNode);
-                        dynamicRules.put((Taclet) newRule.rule(), ruleNode);
-                    }
+                final Taclet newTaclet = newRule.taclet();
+                var justification =
+                    newNode.proof().getInitConfig().getJustifInfo().getJustification(newTaclet);
+                if (justification instanceof RuleJustificationByAddRules justAddRule
+                        && justAddRule.node() == n) {
+                    AddedRule ruleNode = new AddedRule(newTaclet.name().toString());
+                    output.add(ruleNode);
+                    dynamicRules.put(newTaclet, ruleNode);
                 }
             }
         }


### PR DESCRIPTION
This PR prepares KeY for more parallelisation in an upcoming PR

The changes are relatively low risk and improve code quality in general
- Make strategies stateless
- Move static cache to instance cache managed by ServiceCaches


No introduction of synchronization primitives in this PR.
