### PR TITLE
Fix consistency of proof status and tasktree icon

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
@@ -271,12 +271,16 @@ public class KeYMediator {
     public void setBack(Node node) {
         getUI().getProofControl().pruneTo(node);
         finishSetBack(node.proof());
+        keySelectionModel.setSelectedNode(node);
     }
 
     public void setBack(Goal goal) {
         if (getSelectedProof() != null) {
             getUI().getProofControl().pruneTo(goal);
-            finishSetBack(goal.proof());
+            final Proof proof = goal.proof();
+            finishSetBack(proof);
+            Node node = goal.node() == proof.root() ? goal.node() : goal.node().parent();
+            keySelectionModel.setSelectedNode(node);
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.notification.events.AbandonTaskEvent;
 import de.uka.ilkd.key.proof.Proof;
-import de.uka.ilkd.key.proof.ProofTreeAdapter;
 import de.uka.ilkd.key.proof.ProofTreeEvent;
 import de.uka.ilkd.key.proof.ProofTreeListener;
 import de.uka.ilkd.key.proof.mgt.BasicTask;
@@ -280,7 +279,7 @@ public class TaskTree extends JPanel {
     /**
      * a prooftree listener, so that it is known when the proof has closed
      */
-    class TaskTreeProofTreeListener extends ProofTreeAdapter {
+    class TaskTreeProofTreeListener implements ProofTreeListener {
 
         /**
          * invoked if all goals of the proof are closed
@@ -290,17 +289,19 @@ public class TaskTree extends JPanel {
         }
 
         /**
-         * invoked if the list of goals changed (goals were added, removed etc.
+         * invoked if a proof has been pruned, potentially reopening branches
          */
-        public void proofGoalRemoved(ProofTreeEvent e) {
+        public void proofPruned(ProofTreeEvent e) {
+            delegateView.repaint();
         }
 
-        /** invoked if the current goal of the proof changed */
-        public void proofGoalsAdded(ProofTreeEvent e) {
-        }
-
-        /** invoked if the current goal of the proof changed */
-        public void proofGoalsChanged(ProofTreeEvent e) {
+        /**
+         * The structure of the proof has changed radically. Any client should rescan the whole
+         * proof
+         * tree.
+         */
+        public void proofStructureChanged(ProofTreeEvent e) {
+            delegateView.repaint();
         }
     } // end of prooftreelistener
 


### PR DESCRIPTION
Pruning a closed proof (and reopening it) did not update the proof status in the task tree and also did not select any node/goal.


To reproduce before this PR:

1. Load a problem
2. Close the proof
3. Prune somewhere in the middle of the proof
4. The proof is open again, but still shown as closed in the task overview and no node of the proof tree is selected.

Should be considered for KeY 2.12.2 (PR #3328)