### PR TITLE
Minor refactoring of Proof to reduce dependencies (for instance to MergeRule)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -5,11 +5,8 @@ package de.uka.ilkd.key.proof;
 
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
-import javax.swing.*;
 
 import de.uka.ilkd.key.java.JavaInfo;
 import de.uka.ilkd.key.java.Services;
@@ -19,17 +16,9 @@ import de.uka.ilkd.key.proof.event.ProofDisposedEvent;
 import de.uka.ilkd.key.proof.event.ProofDisposedListener;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.proof.init.Profile;
-import de.uka.ilkd.key.proof.io.IntermediateProofReplayer;
-import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.proof.mgt.ProofCorrectnessMgt;
 import de.uka.ilkd.key.proof.mgt.ProofEnvironment;
-import de.uka.ilkd.key.proof.reference.ClosedBy;
-import de.uka.ilkd.key.proof.replay.CopyingProofReplayer;
-import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.OneStepSimplifier;
-import de.uka.ilkd.key.rule.merge.MergePartner;
-import de.uka.ilkd.key.rule.merge.MergeRule;
-import de.uka.ilkd.key.rule.merge.MergeRuleBuiltInRuleApp;
 import de.uka.ilkd.key.settings.GeneralSettings;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ProofSettings;
@@ -543,7 +532,7 @@ public class Proof implements Named {
      * Opens a previously closed node (the one corresponding to p_goal) and all its closed parents.
      * <p>
      *
-     * This is, for instance, needed for the {@link MergeRule}: In a situation where a merge node
+     * This is, for instance, needed for the {@code MergeRule}: In a situation where a merge node
      * and its associated partners have been closed and the merge node is then pruned away, the
      * partners have to be reopened again. Otherwise, we have a soundness issue.
      * <p>
@@ -631,182 +620,31 @@ public class Proof implements Named {
         }
     }
 
+    void removeOpenGoals(Collection<Node> toBeRemoved) {
+        ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
+        for (Goal openGoal : openGoals()) {
+            if (!toBeRemoved.contains(openGoal.node())) {
+                newGoalList = newGoalList.append(openGoal);
+            }
+        }
+        openGoals = newGoalList;
+    }
 
     /**
-     * This class is responsible for pruning a proof tree at a certain cutting point. It has been
-     * introduced to encapsulate the methods that are needed for pruning. Since the class has
-     * influence on the internal state of the proof it should not be moved to a new file, in order
-     * to restrict the access to it.
+     * Removes the given collection of Nodes from the closedGoals. Nodes in the given collection
+     * which are not member of closedGoals are ignored. This method does not reopen the goals!
+     * This has to be done via the method reOpenGoal() if desired.
+     *
+     * @param toBeRemoved the goals to remove
      */
-    private class ProofPruner {
-        private Node firstLeaf = null;
-
-        public ImmutableList<Node> prune(final Node cuttingPoint) {
-
-            // there is only one leaf containing an open goal that is interesting for pruning the
-            // subtree of <code>node</code>, namely the first leave that is found by a breadth
-            // first search.
-            // The other leaves containing open goals are only important for removing the open goals
-            // from the open goal list.
-            // To that end, those leaves are stored in residualLeaves. For increasing the
-            // performance,
-            // a tree structure has been chosen, because it offers the operation
-            // <code>contains</code> in O(log n).
-            final Set<Node> residualLeaves = new TreeSet<>(Comparator.comparingInt(Node::serialNr));
-
-
-            // First, make a breadth first search, in order to find the leaf
-            // with the shortest distance to the cutting point and to remove
-            // the rule applications from the proof management system.
-            // Furthermore, store the residual leaves.
-            breadthFirstSearch(cuttingPoint, (proof, visitedNode) -> {
-                if (visitedNode.leaf()) {
-                    // pruning in closed branches (can be disabled via "--no-pruning-closed")
-                    if (!visitedNode.isClosed() || !GeneralSettings.noPruningClosed) {
-                        if (firstLeaf == null) {
-                            firstLeaf = visitedNode;
-                        } else {
-                            residualLeaves.add(visitedNode);
-                        }
-                    }
-                }
-
-                if (initConfig != null && visitedNode.parent() != null) {
-                    Proof.this.mgt().ruleUnApplied(visitedNode.parent().getAppliedRuleApp());
-                    for (final NoPosTacletApp app : visitedNode.parent()
-                            .getLocalIntroducedRules()) {
-                        initConfig.getJustifInfo().removeJustificationFor(app.taclet());
-                    }
-                }
-
-                // Merge rule applications: Unlink all merge partners.
-                if (visitedNode.getAppliedRuleApp() instanceof MergeRuleBuiltInRuleApp mergeApp) {
-
-                    for (MergePartner mergePartner : mergeApp.getMergePartners()) {
-                        final Goal linkedGoal = mergePartner.getGoal();
-
-                        if (linkedGoal.node().isClosed()) {
-                            // The partner node has already been closed; we
-                            // have to add the goal again.
-                            proof.reOpenGoal(linkedGoal);
-                        }
-
-                        linkedGoal.setLinkedGoal(null);
-                        SwingUtilities.invokeLater(() -> pruneProof(linkedGoal));
-                    }
-                }
-            });
-
-            // first leaf is closed -> add as goal and reopen
-            final Goal firstGoal =
-                firstLeaf.isClosed() ? getClosedGoal(firstLeaf) : getOpenGoal(firstLeaf);
-            assert firstGoal != null;
-            if (firstLeaf.isClosed()) {
-                reOpenGoal(firstGoal);
-            }
-
-            // TODO: WP: test interplay with merge rules
-            // Cutting a linked goal (linked by a "defocusing" merge
-            // operation, see {@link MergeRule}) unlinks this goal again.
-            if (firstGoal.isLinked()) {
-                firstGoal.setLinkedGoal(null);
-            }
-
-            // Go from the first leaf that has been found to the cutting point. For each node on the
-            // path,
-            // remove the local rules from firstGoal that have been added by the considered node.
-            traverseFromChildToParent(firstLeaf, cuttingPoint, (proof, visitedNode) -> {
-                for (final NoPosTacletApp app : visitedNode.getLocalIntroducedRules()) {
-                    firstGoal.ruleAppIndex().removeNoPosTacletApp(app);
-                    initConfig.getJustifInfo().removeJustificationFor(app.taclet());
-                }
-
-                firstGoal.pruneToParent();
-
-                final List<StrategyInfoUndoMethod> undoMethods =
-                    visitedNode.getStrategyInfoUndoMethods();
-                for (StrategyInfoUndoMethod undoMethod : undoMethods) {
-                    firstGoal.undoStrategyInfoAdd(undoMethod);
-                }
-            });
-
-
-            // do some cleaning and refreshing: Clearing indices, caches....
-            refreshGoal(firstGoal, cuttingPoint);
-
-            // cut the subtree, it is not needed anymore.
-            ImmutableList<Node> subtrees = cut(cuttingPoint);
-
-
-            // remove the goals of the residual leaves.
-            removeOpenGoals(residualLeaves);
-            removeClosedGoals(residualLeaves);
-
-            /*
-             * this ensures that the open goals are in interactive mode and thus all rules are
-             * available in the just pruned goal (see GitLab #1480)
-             */
-            setRuleAppIndexToInteractiveMode();
-
-            return subtrees;
-
-        }
-
-        private void refreshGoal(Goal goal, Node node) {
-            goal.getRuleAppManager().clearCache();
-            goal.ruleAppIndex().clearIndexes();
-            goal.node().setAppliedRuleApp(null);
-            node.clearNameCache();
-
-            // delete NodeInfo, but preserve potentially existing branch label
-            String branchLabel = node.getNodeInfo().getBranchLabel();
-            node.clearNodeInfo();
-            if (branchLabel != null) {
-                node.getNodeInfo().setBranchLabel(branchLabel);
+    void removeClosedGoals(Collection<Node> toBeRemoved) {
+        ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
+        for (Goal closedGoal : closedGoals) {
+            if (!toBeRemoved.contains(closedGoal.node())) {
+                newGoalList = newGoalList.prepend(closedGoal);
             }
         }
-
-        private void removeOpenGoals(Collection<Node> toBeRemoved) {
-            ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
-            for (Goal openGoal : openGoals) {
-                if (!toBeRemoved.contains(openGoal.node())) {
-                    newGoalList = newGoalList.append(openGoal);
-                }
-            }
-            openGoals = newGoalList;
-        }
-
-        /**
-         * Removes the given collection of Nodes from the closedGoals. Nodes in the given collection
-         * which are not member of closedGoals are ignored. This method does not reopen the goals!
-         * This has to be done via the method reOpenGoal() if desired.
-         *
-         * @param toBeRemoved the goals to remove
-         */
-        private void removeClosedGoals(Collection<Node> toBeRemoved) {
-            ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
-            for (Goal closedGoal : closedGoals) {
-                if (!toBeRemoved.contains(closedGoal.node())) {
-                    newGoalList = newGoalList.prepend(closedGoal);
-                }
-            }
-            closedGoals = newGoalList;
-        }
-
-        private ImmutableList<Node> cut(Node node) {
-            ImmutableList<Node> children = ImmutableSLList.nil();
-            Iterator<Node> it = node.childrenIterator();
-
-            while (it.hasNext()) {
-                children = children.append(it.next());
-
-            }
-            for (Node child : children) {
-                node.remove(child);
-            }
-            return children;
-        }
-
+        closedGoals = newGoalList;
     }
 
     /**
@@ -843,7 +681,7 @@ public class Proof implements Named {
             return null;
         }
 
-        ProofPruner pruner = new ProofPruner();
+        ProofPruner pruner = new ProofPruner(this);
         if (fireChanges) {
             fireProofIsBeingPruned(cuttingPoint);
         }
@@ -1343,23 +1181,6 @@ public class Proof implements Named {
         this.proofFile = proofFile;
     }
 
-    public void saveToFile(File file) throws IOException {
-        ProofSaver saver = new ProofSaver(this, file);
-        saver.save();
-    }
-
-    /**
-     * Save this proof to a file whilst omitting all proof steps.
-     * In effect, this only saves the proof obligation.
-     *
-     * @param file file to save proof in
-     * @throws IOException on any I/O error
-     */
-    public void saveProofObligationToFile(File file) throws IOException {
-        ProofSaver saver = new ProofSaver(this, file, false);
-        saver.save();
-    }
-
     /**
      *
      * @return the current profile's factory for the active strategy, or the default factory if
@@ -1432,47 +1253,5 @@ public class Proof implements Named {
 
     public void setMutedProofCloseEvents(boolean mutedProofCloseEvents) {
         this.mutedProofCloseEvents = mutedProofCloseEvents;
-    }
-
-    /**
-     * For each branch closed by reference to another proof,
-     * copy the relevant proof steps into this proof.
-     *
-     * @param referencedFrom filter, if not null copy only from that proof
-     * @param callbackTotal callback that gets the total number of branches to complete
-     * @param callbackBranch callback notified every time a branch has been copied
-     */
-    public void copyCachedGoals(Proof referencedFrom, Consumer<Integer> callbackTotal,
-            Runnable callbackBranch) {
-        // first, ensure that all cached goals are copied over
-        List<Goal> goals = closedGoals().toList();
-        List<Goal> todo = new ArrayList<>();
-        for (Goal g : goals) {
-            Node node = g.node();
-            ClosedBy c = node.lookup(ClosedBy.class);
-            if (c == null) {
-                continue;
-            }
-            if (referencedFrom != null && referencedFrom != c.proof()) {
-                continue;
-            }
-            todo.add(g);
-        }
-        if (callbackTotal != null) {
-            callbackTotal.accept(todo.size());
-        }
-        for (Goal g : todo) {
-            reOpenGoal(g);
-            ClosedBy c = g.node().lookup(ClosedBy.class);
-            g.node().deregister(c, ClosedBy.class);
-            try {
-                new CopyingProofReplayer(c.proof(), this).copy(c.node(), g);
-            } catch (IntermediateProofReplayer.BuiltInConstructionException e) {
-                throw new RuntimeException(e);
-            }
-            if (callbackBranch != null) {
-                callbackBranch.run();
-            }
-        }
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
@@ -1,0 +1,177 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof;
+
+import java.util.*;
+import javax.swing.*;
+
+import de.uka.ilkd.key.proof.init.InitConfig;
+import de.uka.ilkd.key.rule.NoPosTacletApp;
+import de.uka.ilkd.key.rule.merge.MergePartner;
+import de.uka.ilkd.key.rule.merge.MergeRuleBuiltInRuleApp;
+import de.uka.ilkd.key.settings.GeneralSettings;
+
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSLList;
+
+/**
+ * This class is responsible for pruning a proof tree at a certain cutting point. It has been
+ * introduced to encapsulate the methods that are needed for pruning. Since the class has
+ * influence on the internal state of the proof it should not be moved to a new file, in order
+ * to restrict the access to it.
+ */
+class ProofPruner {
+    private final Proof proof;
+    private Node firstLeaf = null;
+
+    ProofPruner(Proof proof) {
+        this.proof = proof;
+    }
+
+    /**
+     * prunes the proof at the given node
+     *
+     * @param cuttingPoint the node where to prune
+     * @return the subtrees whose common root was the given {@code cuttingPoint}
+     */
+    public ImmutableList<Node> prune(final Node cuttingPoint) {
+
+        // there is only one leaf containing an open goal that is interesting for pruning the
+        // subtree of <code>node</code>, namely the first leave that is found by a breadth
+        // first search.
+        // The other leaves containing open goals are only important for removing the open goals
+        // from the open goal list.
+        // To that end, those leaves are stored in residualLeaves. For increasing the
+        // performance,
+        // a tree structure has been chosen, because it offers the operation
+        // <code>contains</code> in O(log n).
+        final Set<Node> residualLeaves = new TreeSet<>(Comparator.comparingInt(Node::serialNr));
+
+        final InitConfig initConfig = proof.getInitConfig();
+
+        // First, make a breadth first search, in order to find the leaf
+        // with the shortest distance to the cutting point and to remove
+        // the rule applications from the proof management system.
+        // Furthermore, store the residual leaves.
+        proof.breadthFirstSearch(cuttingPoint, (proof, visitedNode) -> {
+            if (visitedNode.leaf()) {
+                // pruning in closed branches (can be disabled via "--no-pruning-closed")
+                if (!visitedNode.isClosed() || !GeneralSettings.noPruningClosed) {
+                    if (firstLeaf == null) {
+                        firstLeaf = visitedNode;
+                    } else {
+                        residualLeaves.add(visitedNode);
+                    }
+                }
+            }
+
+            if (initConfig != null && visitedNode.parent() != null) {
+                proof.mgt().ruleUnApplied(visitedNode.parent().getAppliedRuleApp());
+                for (final NoPosTacletApp app : visitedNode.parent()
+                        .getLocalIntroducedRules()) {
+                    initConfig.getJustifInfo().removeJustificationFor(app.taclet());
+                }
+            }
+
+            // Merge rule applications: Unlink all merge partners.
+            if (visitedNode.getAppliedRuleApp() instanceof MergeRuleBuiltInRuleApp mergeApp) {
+
+                for (MergePartner mergePartner : mergeApp.getMergePartners()) {
+                    final Goal linkedGoal = mergePartner.getGoal();
+
+                    if (linkedGoal.node().isClosed()) {
+                        // The partner node has already been closed; we
+                        // have to add the goal again.
+                        proof.reOpenGoal(linkedGoal);
+                    }
+
+                    linkedGoal.setLinkedGoal(null);
+                    SwingUtilities.invokeLater(() -> proof.pruneProof(linkedGoal));
+                }
+            }
+        });
+
+        // first leaf is closed -> add as goal and reopen
+        final Goal firstGoal =
+            firstLeaf.isClosed() ? proof.getClosedGoal(firstLeaf) : proof.getOpenGoal(firstLeaf);
+        assert firstGoal != null;
+        if (firstLeaf.isClosed()) {
+            proof.reOpenGoal(firstGoal);
+        }
+
+        // TODO: WP: test interplay with merge rules
+        // Cutting a linked goal (linked by a "defocusing" merge
+        // operation, see {@link MergeRule}) unlinks this goal again.
+        if (firstGoal.isLinked()) {
+            firstGoal.setLinkedGoal(null);
+        }
+
+        // Go from the first leaf that has been found to the cutting point. For each node on the
+        // path,
+        // remove the local rules from firstGoal that have been added by the considered node.
+        proof.traverseFromChildToParent(firstLeaf, cuttingPoint, (proof, visitedNode) -> {
+            for (final NoPosTacletApp app : visitedNode.getLocalIntroducedRules()) {
+                firstGoal.ruleAppIndex().removeNoPosTacletApp(app);
+                proof.getInitConfig().getJustifInfo().removeJustificationFor(app.taclet());
+            }
+
+            firstGoal.pruneToParent();
+
+            final List<StrategyInfoUndoMethod> undoMethods =
+                visitedNode.getStrategyInfoUndoMethods();
+            for (StrategyInfoUndoMethod undoMethod : undoMethods) {
+                firstGoal.undoStrategyInfoAdd(undoMethod);
+            }
+        });
+
+
+        // do some cleaning and refreshing: Clearing indices, caches....
+        refreshGoal(firstGoal, cuttingPoint);
+
+        // cut the subtree, it is not needed anymore.
+        ImmutableList<Node> subtrees = cut(cuttingPoint);
+
+
+        // remove the goals of the residual leaves.
+        proof.removeOpenGoals(residualLeaves);
+        proof.removeClosedGoals(residualLeaves);
+
+        /*
+         * this ensures that the open goals are in interactive mode and thus all rules are
+         * available in the just pruned goal (see GitLab #1480)
+         */
+        proof.setRuleAppIndexToInteractiveMode();
+
+        return subtrees;
+    }
+
+    private void refreshGoal(Goal goal, Node node) {
+        goal.getRuleAppManager().clearCache();
+        goal.ruleAppIndex().clearIndexes();
+        goal.node().setAppliedRuleApp(null);
+        node.clearNameCache();
+
+        // delete NodeInfo, but preserve potentially existing branch label
+        String branchLabel = node.getNodeInfo().getBranchLabel();
+        node.clearNodeInfo();
+        if (branchLabel != null) {
+            node.getNodeInfo().setBranchLabel(branchLabel);
+        }
+    }
+
+    private ImmutableList<Node> cut(Node node) {
+        ImmutableList<Node> children = ImmutableSLList.nil();
+        Iterator<Node> it = node.childrenIterator();
+
+        while (it.hasNext()) {
+            children = children.append(it.next());
+
+        }
+        for (Node child : children) {
+            node.remove(child);
+        }
+        return children;
+    }
+
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
@@ -31,6 +31,7 @@ import de.uka.ilkd.key.proof.init.ProofOblInput;
 import de.uka.ilkd.key.proof.io.IProofFileParser.ProofElementID;
 import de.uka.ilkd.key.proof.mgt.RuleJustification;
 import de.uka.ilkd.key.proof.mgt.RuleJustificationBySpec;
+import de.uka.ilkd.key.proof.reference.CopyReferenceResolver;
 import de.uka.ilkd.key.rule.*;
 import de.uka.ilkd.key.rule.inst.InstantiationEntry;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
@@ -152,7 +153,7 @@ public class OutputStreamProofSaver {
     }
 
     public void save(OutputStream out) throws IOException {
-        proof.copyCachedGoals(null, null, null);
+        CopyReferenceResolver.copyCachedGoals(proof, null, null, null);
         try (var ps = new PrintWriter(out, true, StandardCharsets.UTF_8)) {
             final ProofOblInput po =
                 proof.getServices().getSpecificationRepository().getProofOblInput(proof);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/ProofSaver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/ProofSaver.java
@@ -23,6 +23,32 @@ import org.slf4j.LoggerFactory;
 public class ProofSaver extends OutputStreamProofSaver {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofSaver.class);
 
+    /**
+     * Save this proof to a file
+     *
+     * @param file file to save proof in
+     * @param proof the {@link Proof} to be saved
+     * @throws IOException on any I/O error
+     */
+    public static void saveToFile(File file, Proof proof) throws IOException {
+        ProofSaver saver = new ProofSaver(proof, file);
+        saver.save();
+    }
+
+    /**
+     * Save this proof to a file whilst omitting all proof steps.
+     * In effect, this only saves the proof obligation.
+     *
+     * @param file file to save proof in
+     * @param proof the {@link Proof} to be saved
+     * @throws IOException on any I/O error
+     */
+    public static void saveProofObligationToFile(File file, Proof proof) throws IOException {
+        ProofSaver saver = new ProofSaver(proof, file, false);
+        saver.save();
+    }
+
+
     private final File file;
 
     /**
@@ -162,4 +188,5 @@ public class ProofSaver extends OutputStreamProofSaver {
     private String filename() {
         return file.getAbsolutePath();
     }
+
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/reference/CopyReferenceResolver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/reference/CopyReferenceResolver.java
@@ -1,0 +1,63 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof.reference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Node;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.io.IntermediateProofReplayer;
+import de.uka.ilkd.key.proof.replay.CopyingProofReplayer;
+
+public class CopyReferenceResolver {
+    /**
+     * For each branch closed by reference to another proof,
+     * copy the relevant proof steps into this proof.
+     *
+     * @param toComplete the proof whose references to closed branched shall be resolved by
+     *        copying the branches
+     * @param referencedFrom filter, if not null copy only from that proof
+     * @param callbackTotal callback that gets the total number of branches to complete
+     * @param callbackBranch callback notified every time a branch has been copied
+     */
+    public static void copyCachedGoals(
+            Proof toComplete,
+            Proof referencedFrom,
+            Consumer<Integer> callbackTotal,
+            Runnable callbackBranch) {
+        // first, ensure that all cached goals are copied over
+        List<Goal> goals = toComplete.closedGoals().toList();
+        List<Goal> todo = new ArrayList<>();
+        for (Goal g : goals) {
+            Node node = g.node();
+            ClosedBy c = node.lookup(ClosedBy.class);
+            if (c == null) {
+                continue;
+            }
+            if (referencedFrom != null && referencedFrom != c.proof()) {
+                continue;
+            }
+            todo.add(g);
+        }
+        if (callbackTotal != null) {
+            callbackTotal.accept(todo.size());
+        }
+        for (Goal g : todo) {
+            toComplete.reOpenGoal(g);
+            ClosedBy c = g.node().lookup(ClosedBy.class);
+            g.node().deregister(c, ClosedBy.class);
+            try {
+                new CopyingProofReplayer(c.proof(), toComplete).copy(c.node(), g);
+            } catch (IntermediateProofReplayer.BuiltInConstructionException e) {
+                throw new RuntimeException(e);
+            }
+            if (callbackBranch != null) {
+                callbackBranch.run();
+            }
+        }
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/reference/TestReferenceSearcher.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/reference/TestReferenceSearcher.java
@@ -76,7 +76,8 @@ class TestReferenceSearcher {
         p.pruneProof(foundReference);
         p.closeGoal(p.getOpenGoal(foundReference));
         assertTrue(p.closed());
-        foundReference.proof().copyCachedGoals(p2, null, null);
+        Proof proof = foundReference.proof();
+        CopyReferenceResolver.copyCachedGoals(proof, p2, null, null);
         assertTrue(p.closed());
         GeneralSettings.noPruningClosed = true;
         p.dispose();

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProveTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProveTest.java
@@ -14,6 +14,7 @@ import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.proof.runallproofs.proofcollection.StatisticsFile;
 import de.uka.ilkd.key.proof.runallproofs.proofcollection.TestProperty;
 import de.uka.ilkd.key.settings.ProofSettings;
@@ -153,7 +154,7 @@ public class ProveTest {
         if (reloadEnabled) {
             System.err.println("Test reloadability.");
             // Save the available proof to a temporary file.
-            loadedProof.saveToFile(proofFile);
+            ProofSaver.saveToFile(proofFile, loadedProof);
             boolean reloadedClosed = reloadProof(proofFile);
 
             assertEquals(loadedProof.closed(), reloadedClosed,

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.io.AbstractProblemLoader.ReplayResult;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.proof.runallproofs.RunAllProofsTest;
 import de.uka.ilkd.key.proof.runallproofs.TestResult;
 import de.uka.ilkd.key.settings.ProofSettings;
@@ -203,7 +204,8 @@ public class TestFile implements Serializable {
 
                 if (testProperty == TestProperty.PROVABLE
                         || testProperty == TestProperty.NOTPROVABLE) {
-                    loadedProof.saveToFile(new File(keyFile.getAbsolutePath() + ".save.proof"));
+                    ProofSaver.saveToFile(new File(keyFile.getAbsolutePath() + ".save.proof"),
+                        loadedProof);
                 }
                 boolean closed = loadedProof.closed();
                 success = (testProperty == TestProperty.PROVABLE) == closed;
@@ -247,7 +249,7 @@ public class TestFile implements Serializable {
             throws Exception {
         if (settings.reloadEnabled() && (testProperty == TestProperty.PROVABLE) && success) {
             // Save the available proof to a temporary file.
-            loadedProof.saveToFile(proofFile);
+            ProofSaver.saveToFile(proofFile, loadedProof);
             reloadProof(proofFile);
             if (verbose) {
                 LOGGER.debug("... success: reloaded.");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
@@ -31,6 +31,7 @@ import de.uka.ilkd.key.proof.RuleAppListener;
 import de.uka.ilkd.key.proof.event.ProofDisposedEvent;
 import de.uka.ilkd.key.proof.event.ProofDisposedListener;
 import de.uka.ilkd.key.proof.reference.ClosedBy;
+import de.uka.ilkd.key.proof.reference.CopyReferenceResolver;
 import de.uka.ilkd.key.proof.reference.ReferenceSearcher;
 import de.uka.ilkd.key.proof.replay.CopyingProofReplayer;
 import de.uka.ilkd.key.prover.ProverTaskListener;
@@ -245,7 +246,7 @@ public class CachingExtension
                     .equals(ProofCachingSettings.DISPOSE_COPY)) {
                 mediator.initiateAutoMode(newProof, true, false);
                 try {
-                    newProof.copyCachedGoals(referencedProof, null, null);
+                    CopyReferenceResolver.copyCachedGoals(newProof, referencedProof, null, null);
                 } finally {
                     mediator.finishAutoMode(newProof, true, true,
                         /* do not select a different node */ () -> {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/DefaultReferenceSearchDialogListener.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/DefaultReferenceSearchDialogListener.java
@@ -11,13 +11,15 @@ import de.uka.ilkd.key.gui.IssueDialog;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.ShowProofStatistics;
 import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.reference.CopyReferenceResolver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * The default controller for the {@link ReferenceSearchDialog}.
- * When the copy button is clicked, {@link Proof#copyCachedGoals(Proof, Consumer, Runnable)}
+ * When the copy button is clicked,
+ * {@link de.uka.ilkd.key.proof.reference.CopyReferenceResolver#copyCachedGoals(Proof, Proof, Consumer, Runnable)}
  * is started.
  *
  * @author Arne Keller
@@ -43,7 +45,7 @@ public class DefaultReferenceSearchDialogListener implements ReferenceSearchDial
         new Thread(() -> {
             try {
                 mediator.initiateAutoMode(p, true, false);
-                p.copyCachedGoals(null,
+                CopyReferenceResolver.copyCachedGoals(p, null,
                     total -> SwingUtilities.invokeLater(() -> dialog.setMaximum(total)),
                     () -> SwingUtilities.invokeLater(() -> {
                         if (dialog.incrementProgress()) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
@@ -31,6 +31,7 @@ import de.uka.ilkd.key.proof.init.ProblemInitializer;
 import de.uka.ilkd.key.proof.init.Profile;
 import de.uka.ilkd.key.proof.init.ProofOblInput;
 import de.uka.ilkd.key.proof.io.ProblemLoader;
+import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.prover.ProverCore;
 import de.uka.ilkd.key.prover.TaskFinishedInfo;
 import de.uka.ilkd.key.prover.TaskStartedInfo;
@@ -382,9 +383,9 @@ public class ConsoleUserInterfaceControl extends AbstractMediatorUserInterfaceCo
 
         try {
             // a copy with running number to compare different runs
-            proof.saveToFile(new File(f.getAbsolutePath()));
+            ProofSaver.saveToFile(new File(f.getAbsolutePath()), proof);
             // save current proof under common name as well
-            proof.saveToFile(new File(baseName + ".auto.proof"));
+            ProofSaver.saveToFile(new File(baseName + ".auto.proof"), proof);
 
             // save proof statistics
             ShowProofStatistics.getCSVStatisticsMessage(proof);

--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingProofReplayer.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingProofReplayer.java
@@ -19,11 +19,7 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.ProofInputException;
-import de.uka.ilkd.key.proof.io.AbstractProblemLoader;
-import de.uka.ilkd.key.proof.io.IntermediateProofReplayer;
-import de.uka.ilkd.key.proof.io.ProblemLoaderControl;
-import de.uka.ilkd.key.proof.io.ProblemLoaderException;
-import de.uka.ilkd.key.proof.io.SingleThreadProblemLoader;
+import de.uka.ilkd.key.proof.io.*;
 import de.uka.ilkd.key.proof.replay.AbstractProofReplayer;
 import de.uka.ilkd.key.rule.RuleApp;
 import de.uka.ilkd.key.util.MiscTools;
@@ -109,7 +105,7 @@ public final class SlicingProofReplayer extends AbstractProofReplayer {
                 "Preparing proof slicing", 2);
         }
         Path tmpFile = Files.createTempFile("proof", ".proof");
-        originalProof.saveProofObligationToFile(tmpFile.toFile());
+        ProofSaver.saveProofObligationToFile(tmpFile.toFile(), originalProof);
         if (progressMonitor != null) {
             progressMonitor.setProgress(1);
         }
@@ -245,7 +241,7 @@ public final class SlicingProofReplayer extends AbstractProofReplayer {
         }
         filename = filename + ".proof";
         File tempFile = tempDir.resolve(filename).toFile();
-        proof.saveToFile(tempFile);
+        ProofSaver.saveToFile(tempFile, proof);
         proof.dispose();
         return tempFile;
     }


### PR DESCRIPTION
This commit factors out pruning, saving and reference resolving functionality to reduce the dependencies of Proof and to make it later easier to realise correct synchronization as well as saving proofs.

Not for this PR, but we should have a discussion about what our proof object should have as basic data structure. My idea:
- merge references and linked goals to once concept independent of merge rule or proof caching
- allow to register reference resolvers that can deal with references
- ask before saving (in the GUI) if references should be resolved
  - if yes, resolve and then pass the proof to the `OutputStreamProofSaver`
  - if not, the proof is passed to `OutputStreamProofSaver` which just saves the references (and does not resolve)
  - this allows to remove the line 
        `CopyReferenceResolver.copyCachedGoals(proof, null, null, null);`
   from `OutputStreamProofSaver`. As the saver should not have specific knowledge and it should not change the proof object while saving

