### PR TITLE
Add help buttons to extension settings

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
@@ -39,6 +39,7 @@ import de.uka.ilkd.key.util.ExceptionTools;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.IOUtil;
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.java.SwingUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -443,7 +444,7 @@ public final class IssueDialog extends JDialog {
             issueTextPane.addHyperlinkListener(hle -> {
                 if (hle.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                     try {
-                        Desktop.getDesktop().browse(hle.getURL().toURI());
+                        SwingUtil.browse(hle.getURL().toURI());
                     } catch (Exception ex) {
                         LOGGER.warn("Failed to browse", ex);
                     }
@@ -768,9 +769,9 @@ public final class IssueDialog extends JDialog {
             textPane.addHyperlinkListener(hle -> {
                 if (hle.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                     try {
-                        Desktop.getDesktop().browse(hle.getURL().toURI());
+                        SwingUtil.browse(hle.getURL().toURI());
                     } catch (Exception ex) {
-                        LOGGER.warn("Failed to browse", ex);
+                        LOGGER.warn("Failed to browse ", ex);
                     }
                 }
             });

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeYProjectHomepageAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeYProjectHomepageAction.java
@@ -14,6 +14,8 @@ import java.net.URL;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 
+import org.key_project.util.java.SwingUtil;
+
 /**
  * Open the KeY project homepage in the system default browser. May be inactive if Java 6 Desktop
  * system is not supported or internet connection missing.
@@ -22,9 +24,8 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
  *
  */
 public class KeYProjectHomepageAction extends MainWindowAction {
-
     private static final long serialVersionUID = 8657661861116034536L;
-    private final static String url = "http://www.key-project.org/";
+    private final static String url = "https://www.key-project.org/";
 
     public KeYProjectHomepageAction(MainWindow mainWindow) {
         super(mainWindow);
@@ -36,7 +37,7 @@ public class KeYProjectHomepageAction extends MainWindowAction {
     }
 
     private static boolean desktopEnabled() {
-        return Desktop.getDesktop().isSupported(Desktop.Action.BROWSE);
+        return SwingUtil.browseIsSupported();
     }
 
     private static URI getURI() {
@@ -52,9 +53,8 @@ public class KeYProjectHomepageAction extends MainWindowAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         try {
-            Desktop.getDesktop().browse(getURI());
-        } catch (IOException e1) {
-            // todo Auto-generated catch block
+            SwingUtil.browse(getURI());
+        } catch (IOException ignored) {
         }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/ExtensionManager.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/ExtensionManager.java
@@ -15,6 +15,8 @@ import de.uka.ilkd.key.gui.extension.impl.Extension;
 import de.uka.ilkd.key.gui.extension.impl.ExtensionSettings;
 import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
+import de.uka.ilkd.key.gui.help.HelpFacade;
+import de.uka.ilkd.key.gui.help.HelpInfo;
 import de.uka.ilkd.key.gui.settings.SettingsPanel;
 import de.uka.ilkd.key.gui.settings.SettingsProvider;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
@@ -22,6 +24,8 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import net.miginfocom.layout.CC;
 
 /**
+ * Settings panel where extensions are disabled / enabled.
+ *
  * @author Alexander Weigl
  * @version 1 (08.04.19)
  */
@@ -86,6 +90,14 @@ public class ExtensionManager extends SettingsPanel implements SettingsProvider 
                         pCenter.add(new JLabel(), new CC().newline());
                         pCenter.add(createInfoArea(it.getDescription()));
                         keywords += it.getDescription();
+                    }
+
+                    // add a help button if the relevant annotation is there
+                    var help = it.getType().getAnnotation(HelpInfo.class);
+                    var helpPath = help != null ? help.path() : null;
+                    if (helpPath != null) {
+                        var infoButton = createHelpButton(() -> HelpFacade.openHelp(helpPath));
+                        pCenter.add(infoButton);
                     }
                 });
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpFacade.java
@@ -72,11 +72,18 @@ public class HelpFacade {
     }
 
     /**
-     * Opens the specified sub page of the key documentation website in the default system browser.
+     * Opens the specified subpage of the KeY documentation website in the default system browser.
      *
      * @param path a valid suffix to the current URI
      */
     public static void openHelp(String path) {
+        if (path.startsWith("https://")) {
+            openHelpInBrowser(path);
+            return;
+        }
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
         openHelpInBrowser(HELP_BASE_URL + path);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpFacade.java
@@ -14,6 +14,8 @@ import javax.swing.*;
 import de.uka.ilkd.key.gui.actions.KeyAction;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 
+import org.key_project.util.java.SwingUtil;
+
 import bibliothek.gui.dock.common.action.CAction;
 import bibliothek.gui.dock.common.action.CButton;
 import org.slf4j.Logger;
@@ -56,8 +58,8 @@ public class HelpFacade {
 
     private static void openHelpInBrowser(String url) {
         try {
-            Desktop.getDesktop().browse(new URI(url));
-        } catch (IOException | URISyntaxException e) {
+            SwingUtil.browse(new URI(url));
+        } catch (IOException | URISyntaxException | UnsupportedOperationException e) {
             LOGGER.warn("Failed to open help in browser", e);
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpInfo.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/help/HelpInfo.java
@@ -9,19 +9,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Annotate the help page for your component.
+ *
+ * @see HelpFacade
  * @author Alexander Weigl
  * @version 1 (10.04.19)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
-/**
- * Annotate the help page for your component.
- *
- * @see HelpFacade
- */
 public @interface HelpInfo {
     /**
      * The relative part of the URL to the {@link HelpFacade#HELP_BASE_URL}.
+     * <p>
+     * May also be an absolute URL starting with {@code https://}.
+     * </p>
      *
      * @return non-null string
      */

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.KeyAction;
 import de.uka.ilkd.key.gui.extension.api.ContextMenuKind;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+import de.uka.ilkd.key.gui.help.HelpInfo;
 import de.uka.ilkd.key.gui.settings.SettingsProvider;
 import de.uka.ilkd.key.macros.ProofMacro;
 import de.uka.ilkd.key.macros.TryCloseMacro;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 @KeYGuiExtension.Info(name = "Proof Caching", optional = true,
     description = "Functionality related to reusing previous proof results in similar proofs",
     experimental = false)
+@HelpInfo(path = "/user/ProofCaching/")
 public class CachingExtension
         implements KeYGuiExtension, KeYGuiExtension.Startup, KeYGuiExtension.ContextMenu,
         KeYGuiExtension.StatusLine, KeYGuiExtension.Settings,

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
@@ -190,6 +190,14 @@ public class SimpleSettingsPanel extends JPanel {
         return infoButton;
     }
 
+    public static JButton createHelpButton(Runnable callback) {
+        var infoButton =
+            new JButton(IconFontSwing.buildIcon(FontAwesomeSolid.QUESTION_CIRCLE, 16f));
+        infoButton.setToolTipText("Open online help...");
+        infoButton.addActionListener(e -> callback.run());
+        return infoButton;
+    }
+
     @SuppressWarnings("unchecked")
     private class ValidatorSpinnerAdapter<T> implements ChangeListener {
         private final Validator<T> validator;

--- a/key.ui/src/main/java/org/key_project/util/java/SwingUtil.java
+++ b/key.ui/src/main/java/org/key_project/util/java/SwingUtil.java
@@ -5,6 +5,8 @@ package org.key_project.util.java;
 
 
 import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,6 +24,36 @@ import bibliothek.gui.dock.themes.basic.BasicDockableDisplayer;
  */
 public final class SwingUtil {
     private SwingUtil() {
+    }
+
+    /**
+     * Wrapper for {@link java.awt.Desktop#browse(URI)} that also works on Linux.
+     *
+     * @param uri the URI to be displayed in the user's default browser
+     */
+    public static void browse(URI uri) throws IOException {
+        try {
+            Desktop.getDesktop().browse(uri);
+        } catch (UnsupportedOperationException e) {
+            if (System.getProperty("os.name").startsWith("Linux")) {
+                // try fallback: xdg-open
+                Runtime.getRuntime().exec(new String[] { "xdg-open", uri.toString() });
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Wrapper for {@link Desktop#isSupported(Desktop.Action)} BROWSE that always returns true on
+     * Linux.
+     *
+     * @return whether BROWSE is supported
+     * @see #browse(URI)
+     */
+    public static boolean browseIsSupported() {
+        return Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+                || System.getProperty("os.name").startsWith("Linux");
     }
 
     /**

--- a/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/ExplorationExtension.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.gui.extension.api.ContextMenuAdapter;
 import de.uka.ilkd.key.gui.extension.api.ContextMenuKind;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
 import de.uka.ilkd.key.gui.extension.api.TabPanel;
+import de.uka.ilkd.key.gui.help.HelpInfo;
 import de.uka.ilkd.key.gui.prooftree.GUIAbstractTreeNode;
 import de.uka.ilkd.key.gui.prooftree.Style;
 import de.uka.ilkd.key.gui.prooftree.Styler;
@@ -44,6 +45,7 @@ import org.jspecify.annotations.NonNull;
 @KeYGuiExtension.Info(name = "Exploration",
     description = "Author: Sarah Grebing <grebing@ira.uka.de>, Alexander Weigl <weigl@ira.uka.de>",
     experimental = true, optional = true, priority = 10000)
+@HelpInfo(path = "/user/Exploration/")
 public class ExplorationExtension implements KeYGuiExtension, KeYGuiExtension.ContextMenu,
         KeYGuiExtension.Startup, KeYGuiExtension.Toolbar, KeYGuiExtension.MainMenu,
         KeYGuiExtension.LeftPanel, KeYGuiExtension.StatusLine, ProofDisposedListener {

--- a/keyext.proofmanagement/src/main/java/org/key_project/proofmanagement/ProofManagementExt.java
+++ b/keyext.proofmanagement/src/main/java/org/key_project/proofmanagement/ProofManagementExt.java
@@ -10,6 +10,7 @@ import javax.swing.*;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.KeyAction;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+import de.uka.ilkd.key.gui.help.HelpInfo;
 
 import org.jspecify.annotations.NonNull;
 
@@ -21,6 +22,7 @@ import org.jspecify.annotations.NonNull;
     optional = true,
     description = "Allows to run soundness checks on proof bundles.",
     experimental = false)
+@HelpInfo(path = "https://github.com/KeYProject/key/blob/main/keyext.proofmanagement/README.md")
 public class ProofManagementExt implements
         KeYGuiExtension, KeYGuiExtension.MainMenu {
 

--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingExtension.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingExtension.java
@@ -19,6 +19,7 @@ import de.uka.ilkd.key.gui.extension.api.ContextMenuAdapter;
 import de.uka.ilkd.key.gui.extension.api.ContextMenuKind;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
 import de.uka.ilkd.key.gui.extension.api.TabPanel;
+import de.uka.ilkd.key.gui.help.HelpInfo;
 import de.uka.ilkd.key.gui.settings.SettingsProvider;
 import de.uka.ilkd.key.logic.PosInOccurrence;
 import de.uka.ilkd.key.pp.PosInSequent;
@@ -46,6 +47,7 @@ import org.jspecify.annotations.NonNull;
     experimental = false,
     optional = true,
     priority = 9001)
+@HelpInfo(path = "/user/ProofSlicing/")
 public class SlicingExtension implements KeYGuiExtension,
         KeYGuiExtension.ContextMenu,
         KeYGuiExtension.Startup,


### PR DESCRIPTION
Purpose of this PR: make it easier to find the KeY docs. The help buttons seen below lead to the docs / the extension's readme.

TODO: write a one-line description for each extension


![image](https://github.com/KeYProject/key/assets/12560461/c9301c02-da1b-49f7-9cfa-ccde60f5fdaf)

Other changes:
- fixed the `BROWSE` action on Linux (see `SwingUtil`)