### PR TITLE
Fix update of proof tree in case of filter changes (fixes #3367)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -78,22 +78,22 @@ public class ViewSettings extends AbstractPropertiesSettings {
     /**
      * Pretty Syntax is true by default, use Unicode symbols not
      */
-    private static final String PRETTY_SYNTAX = "PrettySyntax";
+    public static final String PRETTY_SYNTAX = "PrettySyntax";
 
     /**
      *
      */
-    private static final String USE_UNICODE = "UseUnicodeSymbols";
+    public static final String USE_UNICODE = "UseUnicodeSymbols";
 
     /**
      *
      */
-    private static final String SYNTAX_HIGHLIGHTING = "SyntaxHighlighting";
+    public static final String SYNTAX_HIGHLIGHTING = "SyntaxHighlighting";
 
     /**
      *
      */
-    private static final String HIDE_PACKAGE_PREFIX = "HidePackagePrefix";
+    public static final String HIDE_PACKAGE_PREFIX = "HidePackagePrefix";
 
     /**
      * confirm exiting by default

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionModel.java
@@ -149,7 +149,7 @@ public class KeYSelectionModel {
         selectedNode = node;
         selectedSequent = sequent;
         selectedRuleApp = ruleApp;
-        fireSelectedNodeChanged(node);
+        fireSelectedNodeChanged(previousNode);
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -831,6 +831,7 @@ public final class MainWindow extends JFrame {
             getMediator().getNotationInfo().refresh(mediator.getServices());
             getMediator().getSelectedProof().fireProofGoalsChanged();
         }
+        SwingUtilities.invokeLater(this::updateSequentView);
     }
 
     private void addToProofList(de.uka.ilkd.key.proof.ProofAggregate plist) {
@@ -1791,5 +1792,4 @@ public final class MainWindow extends JFrame {
     public void setSequentView(SequentView sequentView) {
         sequentViewSearchBar.setSequentView(sequentView);
     }
-
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -829,7 +829,6 @@ public final class MainWindow extends JFrame {
     public void makePrettyView() {
         if (getMediator().ensureProofLoaded()) {
             getMediator().getNotationInfo().refresh(mediator.getServices());
-            getMediator().getSelectedProof().fireProofGoalsChanged();
         }
         SwingUtilities.invokeLater(this::updateSequentView);
     }
@@ -1726,7 +1725,6 @@ public final class MainWindow extends JFrame {
             }
 
             disableCurrentGoalView = false;
-            SwingUtilities.invokeLater(MainWindow.this::updateSequentView);
             makePrettyView();
         }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
@@ -59,10 +59,8 @@ public final class HidePackagePrefixToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (ViewSettings.HIDE_PACKAGE_PREFIX.equals(e.getPropertyName())) {
-            updateSelectedState();
-            mainWindow.makePrettyView();
-        }
+        updateSelectedState();
+        mainWindow.makePrettyView();
     }
 
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
@@ -4,8 +4,8 @@
 package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.EventObject;
 import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -55,16 +55,13 @@ public final class HidePackagePrefixToggleAction extends MainWindowAction {
                                                              // the UI will react on the settings
                                                              // change event!
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().setHidePackagePrefix(selected);
-        updateMainWindow();
     }
 
-    private void updateMainWindow() {
-        mainWindow.makePrettyView();
-    }
-
-    private void handleViewSettingsChanged(EventObject e) {
-        updateSelectedState();
-        updateMainWindow();
+    private void handleViewSettingsChanged(PropertyChangeEvent e) {
+        if (NAME.equals(e.getPropertyName())) {
+            updateSelectedState();
+            mainWindow.makePrettyView();
+        }
     }
 
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HidePackagePrefixToggleAction.java
@@ -11,6 +11,7 @@ import javax.swing.*;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.pp.NotationInfo;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
 
 public final class HidePackagePrefixToggleAction extends MainWindowAction {
     public static final String NAME = "Hide Package Prefix";
@@ -36,7 +37,7 @@ public final class HidePackagePrefixToggleAction extends MainWindowAction {
         // removed, because there is only one
         // MainWindow!
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                .addPropertyChangeListener(viewSettingsListener);
+                .addPropertyChangeListener(ViewSettings.HIDE_PACKAGE_PREFIX, viewSettingsListener);
         updateSelectedState();
     }
 
@@ -57,8 +58,8 @@ public final class HidePackagePrefixToggleAction extends MainWindowAction {
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().setHidePackagePrefix(selected);
     }
 
-    private void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (NAME.equals(e.getPropertyName())) {
+    protected void handleViewSettingsChanged(PropertyChangeEvent e) {
+        if (ViewSettings.HIDE_PACKAGE_PREFIX.equals(e.getPropertyName())) {
             updateSelectedState();
             mainWindow.makePrettyView();
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
@@ -5,8 +5,8 @@ package de.uka.ilkd.key.gui.actions;
 
 
 import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.EventObject;
 import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -67,10 +67,12 @@ public class PrettyPrintToggleAction extends MainWindowAction {
         mainWindow.makePrettyView();
     }
 
-    protected void handleViewSettingsChanged(EventObject e) {
-        updateSelectedState();
-        final boolean prettySyntax =
-            ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();
-        updateMainWindow(prettySyntax);
+    protected void handleViewSettingsChanged(PropertyChangeEvent e) {
+        if (NAME.equals(e.getPropertyName())) {
+            updateSelectedState();
+            final boolean prettySyntax =
+                ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();
+            updateMainWindow(prettySyntax);
+        }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
@@ -64,11 +64,9 @@ public class PrettyPrintToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (ViewSettings.PRETTY_SYNTAX.equals(e.getPropertyName())) {
-            updateSelectedState();
-            final boolean prettySyntax =
-                ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();
-            updateMainWindow(prettySyntax);
-        }
+        updateSelectedState();
+        final boolean prettySyntax =
+            ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();
+        updateMainWindow(prettySyntax);
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
@@ -7,7 +7,7 @@ package de.uka.ilkd.key.gui.actions;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
 import java.util.EventObject;
-import javax.swing.JCheckBoxMenuItem;
+import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.pp.NotationInfo;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/PrettyPrintToggleAction.java
@@ -12,6 +12,7 @@ import javax.swing.*;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.pp.NotationInfo;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
 
 public class PrettyPrintToggleAction extends MainWindowAction {
     public static final String NAME = "Use Pretty Syntax";
@@ -25,9 +26,6 @@ public class PrettyPrintToggleAction extends MainWindowAction {
 
     /**
      * Listens for changes on {@code ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()}.
-     * <p>
-     * Such changes can occur in the Eclipse context when settings are changed in for instance the
-     * KeYIDE.
      */
     private final PropertyChangeListener viewSettingsListener = this::handleViewSettingsChanged;
 
@@ -39,7 +37,7 @@ public class PrettyPrintToggleAction extends MainWindowAction {
         // removed, because there is only one
         // MainWindow!
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                .addPropertyChangeListener(viewSettingsListener);
+                .addPropertyChangeListener(ViewSettings.PRETTY_SYNTAX, viewSettingsListener);
         updateSelectedState();
     }
 
@@ -48,7 +46,6 @@ public class PrettyPrintToggleAction extends MainWindowAction {
             ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();
         NotationInfo.DEFAULT_PRETTY_SYNTAX = prettySyntax;
         setSelected(prettySyntax);
-        // setSelected(NotationInfo.PRETTY_SYNTAX);
     }
 
     @Override
@@ -58,7 +55,6 @@ public class PrettyPrintToggleAction extends MainWindowAction {
         // will react on the settings change event!
         NotationInfo.DEFAULT_PRETTY_SYNTAX = selected;
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().setUsePretty(selected);
-        updateMainWindow(selected);
     }
 
     protected void updateMainWindow(boolean prettySyntax) {
@@ -68,7 +64,7 @@ public class PrettyPrintToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (NAME.equals(e.getPropertyName())) {
+        if (ViewSettings.PRETTY_SYNTAX.equals(e.getPropertyName())) {
             updateSelectedState();
             final boolean prettySyntax =
                 ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUsePretty();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SyntaxHighlightingToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SyntaxHighlightingToggleAction.java
@@ -4,13 +4,23 @@
 package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import javax.swing.JCheckBoxMenuItem;
 
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
+import static de.uka.ilkd.key.settings.ViewSettings.SYNTAX_HIGHLIGHTING;
+
 public class SyntaxHighlightingToggleAction extends MainWindowAction {
     private static final long serialVersionUID = 6987252955535709994L;
+
+    /**
+     * Listens for changes on {@code ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()}.
+     */
+    private final PropertyChangeListener syntaxHighlightingListener =
+        this::handleViewSettingsChanged;
 
     public SyntaxHighlightingToggleAction(MainWindow window) {
         super(window);
@@ -20,6 +30,11 @@ public class SyntaxHighlightingToggleAction extends MainWindowAction {
             + "slow down the rendering of longer ones.");
         final boolean useSyntaxHighlighting =
             ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isUseSyntaxHighlighting();
+        // Attention: The listener is never
+        // removed, because there is only one
+        // MainWindow!
+        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                .addPropertyChangeListener(SYNTAX_HIGHLIGHTING, syntaxHighlightingListener);
         setSelected(useSyntaxHighlighting);
     }
 
@@ -28,7 +43,12 @@ public class SyntaxHighlightingToggleAction extends MainWindowAction {
         boolean useSyntaxHighlighting = ((JCheckBoxMenuItem) e.getSource()).isSelected();
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
                 .setUseSyntaxHighlighting(useSyntaxHighlighting);
-        mainWindow.makePrettyView();
+        setSelected(useSyntaxHighlighting);
     }
 
+    protected void handleViewSettingsChanged(PropertyChangeEvent e) {
+        if (SYNTAX_HIGHLIGHTING.equals(e.getPropertyName())) {
+            mainWindow.makePrettyView();
+        }
+    }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SyntaxHighlightingToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SyntaxHighlightingToggleAction.java
@@ -47,8 +47,6 @@ public class SyntaxHighlightingToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (SYNTAX_HIGHLIGHTING.equals(e.getPropertyName())) {
-            mainWindow.makePrettyView();
-        }
+        mainWindow.makePrettyView();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
@@ -4,8 +4,8 @@
 package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.EventObject;
 import javax.swing.JCheckBoxMenuItem;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -71,8 +71,10 @@ public class UnicodeToggleAction extends MainWindowAction {
         mainWindow.makePrettyView();
     }
 
-    protected void handleViewSettingsChanged(EventObject e) {
-        updateSelectedState();
-        updateMainWindow();
+    protected void handleViewSettingsChanged(PropertyChangeEvent e) {
+        if (NAME.equals(e.getPropertyName())) {
+            updateSelectedState();
+            updateMainWindow();
+        }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
@@ -72,9 +72,7 @@ public class UnicodeToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (ViewSettings.USE_UNICODE.equals(e.getPropertyName())) {
-            updateSelectedState();
-            updateMainWindow();
-        }
+        updateSelectedState();
+        updateMainWindow();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/UnicodeToggleAction.java
@@ -11,6 +11,7 @@ import javax.swing.JCheckBoxMenuItem;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.pp.NotationInfo;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
 import de.uka.ilkd.key.util.UnicodeHelper;
 
 public class UnicodeToggleAction extends MainWindowAction {
@@ -38,7 +39,7 @@ public class UnicodeToggleAction extends MainWindowAction {
         // Attention: The listener is never// removed, because there is only one
         // MainWindow!
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                .addPropertyChangeListener(viewSettingsListener);
+                .addPropertyChangeListener(ViewSettings.USE_UNICODE, viewSettingsListener);
         updateSelectedState();
     }
 
@@ -64,7 +65,6 @@ public class UnicodeToggleAction extends MainWindowAction {
                                                                         // UI will react on the
                                                                         // settings change event!
         ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().setUseUnicode(useUnicode);
-        updateMainWindow();
     }
 
     protected void updateMainWindow() {
@@ -72,7 +72,7 @@ public class UnicodeToggleAction extends MainWindowAction {
     }
 
     protected void handleViewSettingsChanged(PropertyChangeEvent e) {
-        if (NAME.equals(e.getPropertyName())) {
+        if (ViewSettings.USE_UNICODE.equals(e.getPropertyName())) {
             updateSelectedState();
             updateMainWindow();
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
@@ -2,9 +2,6 @@
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.prooftree;
-/**
- * this class implements a TreeModel that can be displayed using the JTree class framework
- */
 
 import java.util.ArrayList;
 import javax.swing.tree.TreeNode;
@@ -13,6 +10,9 @@ import de.uka.ilkd.key.proof.Node;
 
 import org.jspecify.annotations.NonNull;
 
+/**
+ * this class implements a TreeModel that can be displayed using the JTree class framework
+ */
 class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
 
     private final Object label;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.gui.prooftree;
  * this class implements a TreeModel that can be displayed using the JTree class framework
  */
 
+import java.util.ArrayList;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.proof.Node;
@@ -16,22 +17,17 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
 
     private final Object label;
 
+    private ArrayList<TreeNode> childrenCache = null;
+
+
     public GUIBranchNode(GUIProofTreeModel tree, Node subTree, Object label) {
         super(tree, subTree);
         this.label = label;
     }
 
-
-    private TreeNode[] childrenCache = null;
-
-    private void createChildrenCache() {
-        childrenCache = new TreeNode[getChildCountHelp()];
-    }
-
     public TreeNode getChildAt(int childIndex) {
-        fillChildrenCache();
-        return childrenCache[childIndex];
-
+        ensureChildrenCacheExists();
+        return childrenCache.get(childIndex);
         /*
          * int count = 0; Node n = subTree; while ( childIndex != count && n.childrenCount() == 1 )
          * { count++; n = n.child(0); } if ( childIndex == count ) { return getProofTreeModel
@@ -39,12 +35,10 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
          */
     }
 
-    private void fillChildrenCache() {
+    private void ensureChildrenCacheExists() {
         if (childrenCache == null) {
-            createChildrenCache();
-        }
-
-        if (childrenCache.length == 0 || childrenCache[0] != null) {
+            childrenCache = new ArrayList<>();
+        } else {
             return;
         }
 
@@ -56,7 +50,7 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
         }
 
         while (true) {
-            childrenCache[count] = getProofTreeModel().getProofTreeNode(n);
+            childrenCache.add(count, getProofTreeModel().getProofTreeNode(n));
             count++;
             final Node nextN = findChild(n);
             if (nextN == null) {
@@ -67,7 +61,7 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
 
         for (int i = 0; i != n.childrenCount(); ++i) {
             if (!ProofTreeViewFilter.hiddenByGlobalFilters(n.child(i))) {
-                childrenCache[count] = findBranch(n.child(i));
+                childrenCache.add(count, findBranch(n.child(i)));
                 count++;
             }
         }
@@ -86,37 +80,10 @@ class GUIBranchNode extends GUIAbstractTreeNode implements TreeNode {
 
     public int getChildCount() {
         if (childrenCache == null) {
-            createChildrenCache();
+            ensureChildrenCacheExists();
         }
-        return childrenCache.length;
+        return childrenCache.size();
     }
-
-    private int getChildCountHelp() {
-        int count = 0;
-        Node n = getNode();
-
-        if (n == null) {
-            return 0;
-        }
-
-        while (true) {
-            count++;
-            final Node nextN = findChild(n);
-            if (nextN == null) {
-                break;
-            }
-            n = nextN;
-        }
-
-        for (int i = 0; i != n.childrenCount(); ++i) {
-            if (!ProofTreeViewFilter.hiddenByGlobalFilters(n.child(i))) {
-                count++;
-            }
-        }
-
-        return count;
-    }
-
 
     public TreeNode getParent() {
         Node self = getNode();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -263,13 +263,17 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
      */
     public synchronized void setFilter(ProofTreeViewFilter filter, boolean active) {
         if (filter == null) {
-            activeNodeFilter = null;
+            if (activeNodeFilter != null) {
+                activeNodeFilter.setActive(false);
+                activeNodeFilter = null;
+            }
             updateTree((TreeNode) null);
             return;
         }
         if (!filter.global()) {
-            if (activeNodeFilter != null)
+            if (activeNodeFilter != null) {
                 activeNodeFilter.setActive(false);
+            }
             activeNodeFilter = active ? (NodeFilter) filter : null;
         }
         filter.setActive(active);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.proof.*;
 
 import org.key_project.util.collection.ImmutableList;
 
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -511,18 +510,6 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
             }
             return res;
         }
-    }
-
-
-    /** stores exactly the paths that are expanded in the proof tree */
-    private @NonNull Collection<TreePath> expansionState = Collections.emptySet();
-
-    public void setExpansionState(@NonNull Collection<TreePath> c) {
-        expansionState = c;
-    }
-
-    public @NonNull Collection<TreePath> getExpansionState() {
-        return expansionState;
     }
 
     TreePath selection;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -512,16 +512,6 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
         }
     }
 
-    TreePath selection;
-
-    public void storeSelection(TreePath t) {
-        selection = t;
-    }
-
-    public TreePath getSelection() {
-        return selection;
-    }
-
     public NodeFilter getActiveNodeFilter() {
         return activeNodeFilter;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -300,7 +300,11 @@ public class ProofTreePopupFactory {
                 }
             }
             if (sibling instanceof GUIBranchNode) {
-                context.proofTreeView.selectBranchNode((GUIBranchNode) sibling);
+                var tp = context.proofTreeView.selectBranchNode((GUIBranchNode) sibling);
+                if (tp != null) {
+                    context.delegateView.setSelectionPath(tp);
+                    context.delegateView.scrollPathToVisible(tp);
+                }
             }
         }
     }
@@ -333,7 +337,11 @@ public class ProofTreePopupFactory {
                 }
             }
             if (sibling instanceof GUIBranchNode) {
-                context.proofTreeView.selectBranchNode((GUIBranchNode) sibling);
+                var tp = context.proofTreeView.selectBranchNode((GUIBranchNode) sibling);
+                if (tp != null) {
+                    context.delegateView.setSelectionPath(tp);
+                    context.delegateView.scrollPathToVisible(tp);
+                }
             }
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
@@ -71,11 +71,12 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
             tp = new TreePath(node.getPath());
         }
         if (node instanceof GUIBranchNode) {
-            this.proofTreeView.selectBranchNode((GUIBranchNode) node);
-        } else {
-            this.proofTreeView.delegateView.scrollPathToVisible(tp);
-            this.proofTreeView.delegateView.setSelectionPath(tp);
+            tp = this.proofTreeView.selectBranchNode((GUIBranchNode) node);
         }
+
+        this.proofTreeView.delegateView.scrollPathToVisible(tp);
+        this.proofTreeView.delegateView.setSelectionPath(tp);
+
         return currentRow != -1;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -32,7 +32,6 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.PosInOccurrence;
-import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.pp.PrettyPrinter;
 import de.uka.ilkd.key.proof.*;
@@ -578,10 +577,10 @@ public class ProofTreeView extends JPanel implements TabPanel {
             // in this case we have to select a child of an OSS node
             ArrayList<TreeNode> pathToOSSChild = new ArrayList<>();
             pathToOSSChild.addAll(Arrays.asList(obs));
-            for (int i = 0; i<node.getChildCount(); i++) {
-                final var child = node.getChildAt(i);
-                if (child instanceof GUIOneStepChildTreeNode ossChild) {
-                    if (ossChild.getRuleApp() == mediator.getSelectionModel().getSelectedRuleApp()) {
+            for (int i = 0; i < node.getChildCount(); i++) {
+                if (node.getChildAt(i) instanceof GUIOneStepChildTreeNode ossChild) {
+                    if (ossChild.getRuleApp() == mediator.getSelectionModel()
+                            .getSelectedRuleApp()) {
                         pathToOSSChild.add(ossChild);
                         break;
                     }
@@ -622,7 +621,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
         Object node = path.getLastPathComponent();
 
-        if (node instanceof GUIBranchNode && ((GUIBranchNode) node).getNode().isClosed()) {
+        if (node instanceof GUIBranchNode branchNode && branchNode.getNode().isClosed()) {
             delegateView.collapsePath(path);
             return;
         }
@@ -720,7 +719,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             invokedNode = guiNode.getNode();
         } else {
             branch = selectedPath;
-            invokedNode = ((GUIAbstractTreeNode)lastPathComponent).getNode();
+            invokedNode = ((GUIAbstractTreeNode) lastPathComponent).getNode();
         }
 
         delegateModel.setFilter(filter, selected);
@@ -750,7 +749,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 if (tp.getPathComponent(i) instanceof GUIBranchNode pathComp) {
                     final Node n = pathComp.getNode();
                     newTp = newTp.pathByAddingChild(
-                            delegateModel.getBranchNode(n, n.getNodeInfo().getBranchLabel()));
+                        delegateModel.getBranchNode(n, n.getNodeInfo().getBranchLabel()));
                 }
             }
             delegateView.expandPath(newTp);
@@ -770,7 +769,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
         if (delegateModel.getRoot() instanceof GUIBranchNode rootNode) {
             final TreeNode node = rootNode.findBranch(invokedNode);
             if (node instanceof GUIBranchNode childAsBranchNode &&
-                !(defaultPath.getLastPathComponent() instanceof GUIOneStepChildTreeNode)) {
+                    !(defaultPath.getLastPathComponent() instanceof GUIOneStepChildTreeNode)) {
                 return selectBranchNode(childAsBranchNode);
             }
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -760,7 +760,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
      * if invoked node is modelled as branch node, select the branch node
      *
      * @param invokedNode the selected node in the proof
-     * @param defaultPath the {@link TreePath} to be returned if the invokedNode does not have an associated branch node
+     * @param defaultPath the {@link TreePath} to be returned if the invokedNode does not have an
+     *        associated branch node
      * @return the path to the branch node if available otherwise {@code defaultPath}
      */
     private TreePath getPathForBranchNode(Node invokedNode, TreePath defaultPath) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -654,13 +654,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
         proofListener.ignoreNodeSelectionChange = false;
         TreePath tp = new TreePath(node.getPath());
         treeSelectionListener.ignoreChange = true;
+        delegateModel.storeSelection(delegateView.getSelectionPath());
         delegateView.getSelectionModel().setSelectionPath(tp);
         delegateView.scrollPathToVisible(tp);
         delegateView.validate();
         treeSelectionListener.ignoreChange = false;
-
-        delegateModel.storeSelection(delegateView.getSelectionPath());
-
     }
 
     public void showSearchPanel() {
@@ -689,14 +687,14 @@ public class ProofTreeView extends JPanel implements TabPanel {
             return false;
         }
 
-        final TreePath selectedPath = delegateModel.getSelection();
+        final TreePath selectedPath = delegateView.getSelectionPath();
+
         if (selectedPath == null) {
             return false;
         }
 
         // Save expansion state to restore.
         List<TreePath> rowsToExpand = new ArrayList<>(expansionState);
-
 
         final TreePath branch;
         final Node invokedNode;
@@ -942,7 +940,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             TreePath newTP = e.getNewLeadSelectionPath();
             delegateModel.storeSelection(newTP);
-
 
             if (treeNode.getNode().proof().isDisposed()) {
                 setProof(null);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -491,8 +491,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 delegateModel.unregister();
                 delegateModel.removeTreeModelListener(proofTreeSearchPanel);
             }
-
-
         }
 
         proof = p;
@@ -524,6 +522,23 @@ public class ProofTreeView extends JPanel implements TabPanel {
             Collections.sort(rowsToExpand);
 
 
+
+            // Restore previous scroll position.
+            JScrollPane scroller = (JScrollPane) delegateView.getParent().getParent();
+            Integer scrollState = memorizedState.scrollState;
+            if (scrollState != null) {
+                scroller.getVerticalScrollBar().setValue(scrollState);
+            }
+
+            // restore filters
+            for (var viewFilter : ProofTreeViewFilter.ALL) {
+                setFilter(viewFilter,
+                    memorizedState.activeFilters.contains(viewFilter));
+            }
+
+            delegateModel.setFilter(memorizedState.nodeFilterState.first,
+                memorizedState.nodeFilterState.second);
+
             // Expand previously visible rows.
             for (int i : rowsToExpand) {
                 delegateView.expandRow(i);
@@ -540,23 +555,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
                     delegateView.setSelectionRow(1);
                 }
             }
-
-            // Restore previous scroll position.
-            JScrollPane scroller = (JScrollPane) delegateView.getParent().getParent();
-            Integer i = memorizedState.scrollState;
-            if (i != null) {
-                scroller.getVerticalScrollBar().setValue(i);
-            }
-
-            // restore filters
-            for (var viewFilter : ProofTreeViewFilter.ALL) {
-                setFilter(viewFilter,
-                    memorizedState.activeFilters.contains(viewFilter));
-            }
-
-            delegateModel.setFilter(memorizedState.nodeFilterState.first,
-                memorizedState.nodeFilterState.second);
-
         } else {
             delegateModel = null;
             delegateView
@@ -672,7 +670,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
         proofListener.ignoreNodeSelectionChange = false;
         TreePath tp = new TreePath(node.getPath());
         treeSelectionListener.ignoreChange = true;
-        delegateModel.storeSelection(delegateView.getSelectionPath());
         delegateView.getSelectionModel().setSelectionPath(tp);
         delegateView.scrollPathToVisible(tp);
         delegateView.validate();
@@ -957,7 +954,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
             }
 
             TreePath newTP = e.getNewLeadSelectionPath();
-            delegateModel.storeSelection(newTP);
 
             if (treeNode.getNode().proof().isDisposed()) {
                 setProof(null);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -535,6 +535,15 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 scroller.getVerticalScrollBar().setValue(scrollState);
             }
 
+
+            // this selection must happen before and later after restoring the filters
+            // as setting a filter immediately applies it and
+            if (memorizedState.selectionPath != null) {
+                delegateView.setSelectionPath(memorizedState.selectionPath);
+            } else {
+                delegateView.setSelectionRow(0);
+            }
+
             // restore filters
             for (var viewFilter : ProofTreeViewFilter.ALL) {
                 setFilter(viewFilter,

--- a/key.ui/src/main/java/de/uka/ilkd/key/proof/io/ProblemLoader.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/proof/io/ProblemLoader.java
@@ -143,7 +143,9 @@ public final class ProblemLoader extends AbstractProblemLoader { // TODO: Rename
                         mediator.getUI().reportStatus(this, errorMessage);
                     }
                     fireTaskFinished(runTime, message);
-                    mediator.getSelectionModel().defaultSelection();
+                    if (mediator.getSelectedProof() != null) {
+                        mediator.getSelectionModel().defaultSelection();
+                    }
                 }
             }
         };


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments may remain since they will be
invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->
This pull request addresses #3367

## Intended Change

Activating a filter works immediately. 

The underlying problem is that the GUIProofTreeModel stores the selection and does not update with the selection model in the ProofTreeView.

This PR does not maintain the consistency. The redundant information was seemingly only thought to be used to store the selected node when switching proofs and restoring it when switching back. The method setFilter should for that reason not query the model for the selection but the view to get an up-to-date path.

Previously it got null (despite a node being selected in the view) and  did not activate the filter.



<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: The steps for reproduction of #3367 do no longer reproduce the error. Playing around with multiple proofs and selecting filters seems to work.
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
