### PR TITLE
Configurable enabled keys for JML condition evaluation

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
+import java.util.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 
 public class GeneralSettings extends AbstractSettings {
@@ -206,11 +206,11 @@ public class GeneralSettings extends AbstractSettings {
         }
 
         {
-            var sysProp = System.getProperty(KEY_JML_ENABLED_KEYS);
+            String sysProp = System.getProperty(KEY_JML_ENABLED_KEYS);
             if (sysProp != null) {
                 val = sysProp;
                 LOGGER.warn("Use system property -P{}={}", KEY_JML_ENABLED_KEYS, sysProp);
-            }else {
+            } else {
                 val = props.getProperty(prefix + KEY_JML_ENABLED_KEYS);
             }
 
@@ -261,7 +261,7 @@ public class GeneralSettings extends AbstractSettings {
         if (sysProp != null) {
             LOGGER.warn("Use system property -P{}={}", KEY_JML_ENABLED_KEYS, sysProp);
             setJmlEnabledKeys(new TreeSet<>(Arrays.stream(sysProp.split(",")).toList()));
-        }else {
+        } else {
             setJmlEnabledKeys(new TreeSet<>(props.getStringList(KEY_JML_ENABLED_KEYS)));
         }
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
-import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 
 public class GeneralSettings extends AbstractSettings {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeneralSettings.class);
+
     /**
      * This parameter disables the possibility to prune in closed branches. It is meant as a
      * fallback solution if storing all closed goals needs too much memory or is not needed. Pruning
@@ -32,6 +37,9 @@ public class GeneralSettings extends AbstractSettings {
     private static final String TACLET_FILTER = "StupidMode";
     private static final String DND_DIRECTION_SENSITIVE_KEY = "DnDDirectionSensitive";
     private static final String USE_JML_KEY = "UseJML";
+
+    private static final String KEY_JML_ENABLED_KEYS = "JML_ENABLED_KEYS";
+
     private static final String RIGHT_CLICK_MACROS_KEY = "RightClickMacros";
     private static final String AUTO_SAVE = "AutoSavePeriod";
 
@@ -39,6 +47,8 @@ public class GeneralSettings extends AbstractSettings {
      * The key for storing the ensureSourceConsistency flag in settings
      */
     private static final String ENSURE_SOURCE_CONSISTENCY = "EnsureSourceConsistency";
+
+    private Set<String> jmlEnabledKeys = new TreeSet<>(Set.of("key"));
 
     /**
      * minimize interaction is on by default
@@ -75,7 +85,16 @@ public class GeneralSettings extends AbstractSettings {
         // addSettingsListener(AutoSaver.settingsListener);
     }
 
-    // getter
+    public Set<String> getJmlEnabledKeys() {
+        return jmlEnabledKeys;
+    }
+
+    public void setJmlEnabledKeys(Set<String> jmlEnabledKeys) {
+        var oldValue = this.jmlEnabledKeys;
+        this.jmlEnabledKeys = Objects.requireNonNull(jmlEnabledKeys);
+        firePropertyChange(KEY_JML_ENABLED_KEYS, oldValue, jmlEnabledKeys);
+    }
+
     public boolean getTacletFilter() {
         return tacletFilter;
     }
@@ -185,6 +204,20 @@ public class GeneralSettings extends AbstractSettings {
         if (val != null) {
             setEnsureSourceConsistency(Boolean.parseBoolean(val));
         }
+
+        {
+            var sysProp = System.getProperty(KEY_JML_ENABLED_KEYS);
+            if (sysProp != null) {
+                val = sysProp;
+                LOGGER.warn("Use system property -P{}={}", KEY_JML_ENABLED_KEYS, sysProp);
+            }else {
+                val = props.getProperty(prefix + KEY_JML_ENABLED_KEYS);
+            }
+
+            if (val != null) {
+                setJmlEnabledKeys(new TreeSet<>(Arrays.stream(val.split(",")).toList()));
+            }
+        }
     }
 
     /**
@@ -205,6 +238,7 @@ public class GeneralSettings extends AbstractSettings {
         props.setProperty(prefix + AUTO_SAVE, String.valueOf(autoSave));
         props.setProperty(prefix + ENSURE_SOURCE_CONSISTENCY,
             String.valueOf(ensureSourceConsistency));
+        props.setProperty(KEY_JML_ENABLED_KEYS, String.join(",", jmlEnabledKeys));
     }
 
     @Override
@@ -222,6 +256,14 @@ public class GeneralSettings extends AbstractSettings {
             setAutoSave(0);
         }
         setEnsureSourceConsistency(props.getBool(ENSURE_SOURCE_CONSISTENCY));
+
+        var sysProp = System.getProperty(KEY_JML_ENABLED_KEYS);
+        if (sysProp != null) {
+            LOGGER.warn("Use system property -P{}={}", KEY_JML_ENABLED_KEYS, sysProp);
+            setJmlEnabledKeys(new TreeSet<>(Arrays.stream(sysProp.split(",")).toList()));
+        }else {
+            setJmlEnabledKeys(new TreeSet<>(props.getStringList(KEY_JML_ENABLED_KEYS)));
+        }
     }
 
     @Override
@@ -232,5 +274,6 @@ public class GeneralSettings extends AbstractSettings {
         props.set(USE_JML_KEY, useJML);
         props.set(AUTO_SAVE, autoSave);
         props.set(ENSURE_SOURCE_CONSISTENCY, ensureSourceConsistency);
+        props.set(KEY_JML_ENABLED_KEYS, jmlEnabledKeys.stream().toList());
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlMarkerDecision.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlMarkerDecision.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -29,7 +30,7 @@ public class JmlMarkerDecision {
      */
     public JmlMarkerDecision(JmlLexer lexer) {
         this.lexer = lexer;
-        enabledKeys.add("key");
+        setEnabledKeys(ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings().getJmlEnabledKeys());
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlMarkerDecision.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlMarkerDecision.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
+
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -30,7 +31,8 @@ public class JmlMarkerDecision {
      */
     public JmlMarkerDecision(JmlLexer lexer) {
         this.lexer = lexer;
-        setEnabledKeys(ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings().getJmlEnabledKeys());
+        setEnabledKeys(
+            ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings().getJmlEnabledKeys());
     }
 
     /**


### PR DESCRIPTION
This PR allows you to configure the *enabled keys* in the processing of the JML conditions within the *JML conditional annotation texts*. Currently, the set is hard coded and only contains `key` as the only enabled key. This means, that KeY accepts the following JML annotation texts:

* `/*@ ...*/`
* `/*+key@ ...*/`
* `/*+key+openjml@ ...*/`

but ignores

* `/*+openjml@ ...*/`
* `/*-key@ ...*/`

## Intended Change

* This PR adds a new field to the `GeneralSettings` which contains a set of enabled keys.
* You can set this field either by `-PJML_ENABLED_KEYS=a,b,c` on the CLI, or 
* via the `$HOME/.key/proofIndependentSettings.json`.

Currently, there is no GUI element to configure this element. 

**The need** for this raises from case study where you want to have the same source code as the foundation, but you have different verification runs: e.g, functional behavior under overflow absence, and a second run to prove overflow absence. Now you can differentiate the specificaton between the runs. For example:

```
//+first@ assert x>0;
//+second@ assume x>0;
```

## Question to the reviewer 

* Should there be textbox in the settings dialog?
* Should there be label in the status bar stating the current enabled keys?


## Type of pull request

- *X* New feature (non-breaking change which adds functionality)
- *X* There are changes to the (Java) code
- *X* Changes to the settings 
