### PR TITLE
JML enabled keys indicator for the Status Line 

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
@@ -48,7 +48,10 @@ public class GeneralSettings extends AbstractSettings {
      */
     private static final String ENSURE_SOURCE_CONSISTENCY = "EnsureSourceConsistency";
 
-    private Set<String> jmlEnabledKeys = new TreeSet<>(Set.of("key"));
+    /** Default value for {@link #getJmlEnabledKeys()} */
+    public static final Set<String> JML_ENABLED_KEYS_DEFAULT = Set.of("key");
+
+    private Set<String> jmlEnabledKeys = new TreeSet<>(JML_ENABLED_KEYS_DEFAULT);
 
     /**
      * minimize interaction is on by default

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
@@ -34,14 +34,14 @@ public class GeneralSettings extends AbstractSettings {
 
     private static final String CATEGORY = "General";
 
-    private static final String TACLET_FILTER = "StupidMode";
-    private static final String DND_DIRECTION_SENSITIVE_KEY = "DnDDirectionSensitive";
-    private static final String USE_JML_KEY = "UseJML";
+    public static final String TACLET_FILTER = "StupidMode";
+    public static final String DND_DIRECTION_SENSITIVE_KEY = "DnDDirectionSensitive";
+    public static final String USE_JML_KEY = "UseJML";
 
-    private static final String KEY_JML_ENABLED_KEYS = "JML_ENABLED_KEYS";
+    public static final String KEY_JML_ENABLED_KEYS = "JML_ENABLED_KEYS";
 
-    private static final String RIGHT_CLICK_MACROS_KEY = "RightClickMacros";
-    private static final String AUTO_SAVE = "AutoSavePeriod";
+    public static final String RIGHT_CLICK_MACROS_KEY = "RightClickMacros";
+    public static final String AUTO_SAVE = "AutoSavePeriod";
 
     /**
      * The key for storing the ensureSourceConsistency flag in settings

--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -64,7 +64,7 @@ run {
     systemProperties["key.examples.dir"] = "$projectDir/examples"
     //systemProperties["slf4j.detectLoggerNameMismatch"] = true
     //systemProperties["KeyDebugFlag"] = "on"
-    args "--experimental"
+    //args "--experimental"
 
     // this can be used to solve a problem where the OS hangs during debugging of popup menus
     // (see https://docs.oracle.com/javase/10/troubleshoot/awt.htm#JSTGD425)

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
@@ -25,14 +25,21 @@ public class JmlEnabledKeysIndicator implements KeYGuiExtension, KeYGuiExtension
 
     public JmlEnabledKeysIndicator() {
         lblIndicator.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        lblIndicator.setToolTipText("Currently enabled keys for the JML condition evaluation");
+        lblIndicator.setToolTipText("Currently enabled keys for tool-specific JML annotations");
         settings.addPropertyChangeListener(GeneralSettings.KEY_JML_ENABLED_KEYS, it -> update());
         update();
     }
 
     private void update() {
-        var lbl = String.join(", ", settings.getJmlEnabledKeys());
-        lblIndicator.setText(lbl);
+        final var current = settings.getJmlEnabledKeys();
+        if (!GeneralSettings.JML_ENABLED_KEYS_DEFAULT.equals(current)) {
+            var lbl = String.join(", ", current);
+            lblIndicator.setText(lbl);
+            lblIndicator.setVisible(true);
+        } else {
+            lblIndicator.setText("");
+            lblIndicator.setVisible(false);
+        }
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
@@ -1,24 +1,31 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui;
+
+import java.util.List;
+import javax.swing.*;
 
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
 import de.uka.ilkd.key.settings.GeneralSettings;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
-import javax.swing.*;
-import java.util.List;
-
 /**
- * Provides a Label in the status line for the indication of the current enabled keys for the JML condition evaluation.
+ * Provides a Label in the status line for the indication of the current enabled keys for the JML
+ * condition evaluation.
+ *
  * @author weigl
  * @see GeneralSettings#getJmlEnabledKeys()
  */
 @KeYGuiExtension.Info(experimental = false, name = "JML Enabled Keys Indicator for the Status Line")
 public class JmlEnabledKeysIndicator implements KeYGuiExtension, KeYGuiExtension.StatusLine {
-    private final GeneralSettings settings = ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
+    private final GeneralSettings settings =
+        ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
     private final JLabel lblIndicator = new JLabel();
 
     public JmlEnabledKeysIndicator() {
-        lblIndicator.setToolTipText("Current enabled keys for the JML condition evaluation");
+        lblIndicator.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        lblIndicator.setToolTipText("Currently enabled keys for the JML condition evaluation");
         settings.addPropertyChangeListener(GeneralSettings.KEY_JML_ENABLED_KEYS, it -> update());
         update();
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/JmlEnabledKeysIndicator.java
@@ -1,0 +1,35 @@
+package de.uka.ilkd.key.gui;
+
+import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+import de.uka.ilkd.key.settings.GeneralSettings;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+
+import javax.swing.*;
+import java.util.List;
+
+/**
+ * Provides a Label in the status line for the indication of the current enabled keys for the JML condition evaluation.
+ * @author weigl
+ * @see GeneralSettings#getJmlEnabledKeys()
+ */
+@KeYGuiExtension.Info(experimental = false, name = "JML Enabled Keys Indicator for the Status Line")
+public class JmlEnabledKeysIndicator implements KeYGuiExtension, KeYGuiExtension.StatusLine {
+    private final GeneralSettings settings = ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
+    private final JLabel lblIndicator = new JLabel();
+
+    public JmlEnabledKeysIndicator() {
+        lblIndicator.setToolTipText("Current enabled keys for the JML condition evaluation");
+        settings.addPropertyChangeListener(GeneralSettings.KEY_JML_ENABLED_KEYS, it -> update());
+        update();
+    }
+
+    private void update() {
+        var lbl = String.join(", ", settings.getJmlEnabledKeys());
+        lblIndicator.setText(lbl);
+    }
+
+    @Override
+    public List<JComponent> getStatusLineComponents() {
+        return List.of(lblIndicator);
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainStatusLine.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainStatusLine.java
@@ -13,7 +13,7 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
 /**
  * Status line of the KeY MainWindow.
  * <p>
- * The status line hold a lblStatusText and a progress panel.
+ * The status line holds a lblStatusText and a progress panel.
  * <p>
  * You add additional components by using the extension points
  * {@link de.uka.ilkd.key.gui.extension.api.KeYGuiExtension.StatusLine}
@@ -28,7 +28,6 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
  * @see de.uka.ilkd.key.gui.extension.api.KeYGuiExtension.StatusLine
  */
 class MainStatusLine extends JPanel {
-    private static final long serialVersionUID = 2278249652314818379L;
     private final JLabel lblStatusText = new JLabel();
     private final JProgressBar progressBar = new JProgressBar();
 
@@ -120,3 +119,4 @@ class MainStatusLine extends JPanel {
         lblStatusText.setText(s);
     }
 }
+

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainStatusLine.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainStatusLine.java
@@ -119,4 +119,3 @@ class MainStatusLine extends JPanel {
         lblStatusText.setText(s);
     }
 }
-

--- a/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
+++ b/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
@@ -8,3 +8,4 @@ de.uka.ilkd.key.gui.LogView
 de.uka.ilkd.key.gui.plugins.javac.JavacExtension
 de.uka.ilkd.key.gui.plugins.caching.CachingExtension
 de.uka.ilkd.key.gui.utilities.HeapStatusExt
+de.uka.ilkd.key.gui.JmlEnabledKeysIndicator


### PR DESCRIPTION
Addition to #3373 which brings the following UI element: 

![image](https://github.com/KeYProject/key/assets/104259/0e5d2435-0813-4df9-b6d8-22bad3b21962)

A label which represents the current value of the enabled keys in `GeneralSettings`. 
