### PR TITLE
Fix for the LoopInvariantConfigurationDialog

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
@@ -136,7 +136,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     // -------------------------------------------------------------------------
 
     private Map /* Operator, Operator, Term -> Term */<Term, Term> getReplaceMap(Term selfTerm,
-            Map<LocationVariable, Term> atPres, Services services) {
+            Map<LocationVariable, Term> atPres) {
         final Map<Term, Term> result = new LinkedHashMap<>();
 
         // self
@@ -169,7 +169,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     private Map<Term, Term> getInverseReplaceMap(Term selfTerm, Map<LocationVariable, Term> atPres,
             Services services) {
         final Map<Term, Term> result = new LinkedHashMap<>();
-        final Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        final Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         for (Map.Entry<Term, Term> next : replaceMap.entrySet()) {
             result.put(next.getValue(), next.getKey());
         }
@@ -218,7 +218,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     public Term getInvariant(LocationVariable heap, Term selfTerm,
             Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replace(originalInvariants.get(heap));
     }
@@ -232,7 +232,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     public Term getFreeInvariant(LocationVariable heap, Term selfTerm,
             Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replace(originalFreeInvariants.get(heap));
     }
@@ -246,16 +246,17 @@ public final class LoopSpecImpl implements LoopSpecification {
     public Term getModifiable(LocationVariable heap, Term selfTerm,
             Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replace(originalModifiable.get(heap));
     }
 
     @Override
-    public Term getModifiable(Term selfTerm, Map<LocationVariable, Term> atPres, Services services) {
+    public Term getModifiable(Term selfTerm, Map<LocationVariable, Term> atPres,
+            Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
         LocationVariable baseHeap = services.getTypeConverter().getHeapLDT().getHeap();
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replace(originalModifiable.get(baseHeap));
     }
@@ -264,7 +265,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     public Term getFreeModifiable(LocationVariable heap, Term selfTerm,
             Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         final Term originalFreeModForHeap = originalFreeModifiable.get(heap);
         if (originalFreeModForHeap != null) {
@@ -278,7 +279,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     public ImmutableList<InfFlowSpec> getInfFlowSpecs(LocationVariable heap, Term selfTerm,
             Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replaceInfFlowSpec(originalInfFlowSpecs.get(heap));
     }
@@ -297,7 +298,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     @Override
     public Term getVariant(Term selfTerm, Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
+        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
         return or.replace(originalVariant);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
@@ -252,8 +252,7 @@ public final class LoopSpecImpl implements LoopSpecification {
     }
 
     @Override
-    public Term getModifiable(Term selfTerm, Map<LocationVariable, Term> atPres,
-            Services services) {
+    public Term getModifiable(Term selfTerm, Map<LocationVariable, Term> atPres, Services services) {
         assert (selfTerm == null) == (originalSelfTerm == null);
         LocationVariable baseHeap = services.getTypeConverter().getHeapLDT().getHeap();
         Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
@@ -267,17 +266,12 @@ public final class LoopSpecImpl implements LoopSpecification {
         assert (selfTerm == null) == (originalSelfTerm == null);
         Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
         OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
-        return or.replace(originalFreeModifiable.get(heap));
-    }
-
-    @Override
-    public Term getFreeModifiable(Term selfTerm, Map<LocationVariable, Term> atPres,
-            Services services) {
-        assert (selfTerm == null) == (originalSelfTerm == null);
-        LocationVariable baseHeap = services.getTypeConverter().getHeapLDT().getHeap();
-        Map<Term, Term> replaceMap = getReplaceMap(selfTerm, atPres, services);
-        OpReplacer or = new OpReplacer(replaceMap, services.getTermFactory(), services.getProof());
-        return or.replace(originalFreeModifiable.get(baseHeap));
+        final Term originalFreeModForHeap = originalFreeModifiable.get(heap);
+        if (originalFreeModForHeap != null) {
+            return or.replace(originalFreeModForHeap);
+        } else {
+            return services.getTermBuilder().strictlyNothing();
+        }
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecification.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecification.java
@@ -96,18 +96,6 @@ public interface LoopSpecification extends SpecificationElement {
             Services services);
 
     /**
-     * Returns the free modifiable clause.
-     *
-     * @param selfTerm the self term.
-     * @param atPres the operators used for the pre-heap.
-     * @param services the Services object.
-     * @return The modifiable clause as a term.
-     */
-    Term getFreeModifiable(Term selfTerm,
-            Map<LocationVariable, Term> atPres,
-            Services services);
-
-    /**
      * Returns the information flow specification clause.
      */
     ImmutableList<InfFlowSpec> getInfFlowSpecs(LocationVariable heap);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
@@ -102,8 +102,6 @@ public class InvariantConfigurator {
         index = 0;
 
         class InvariantDialog extends JDialog {
-            private final LocationVariable HEAP_LDT =
-                services.getTypeConverter().getHeapLDT().getHeap();
             private final Color COLOR_SUCCESS = Color.GREEN;
             private final Color COLOR_ERROR = Color.RED;
 
@@ -593,15 +591,17 @@ public class InvariantConfigurator {
                 JTabbedPane modPane = new JTabbedPane(JTabbedPane.BOTTOM);
                 for (LocationVariable heap : services.getTypeConverter().getHeapLDT()
                         .getAllHeaps()) {
+
+                    final LocationVariable baseHeap =
+                        services.getTypeConverter().getHeapLDT().getHeap();
                     final String k = heap.name().toString();
                     String title =
-                        format("Invariant%s - Status: ", heap == HEAP_LDT ? "" : "[" + k + "]");
+                        format("Invariant%s - Status: ", heap == baseHeap ? "" : "[" + k + "]");
                     String errorMessage = invMsgs == null ? "OK" : invMsgs.get(k);
                     Color invColor = invColors == null ? COLOR_SUCCESS : invColors.get(k);
                     JTextArea textArea = createErrorTextField(title, errorMessage, invColor);
                     invPane.add(k, textArea);
-                    title =
-                        format("Modifiable%s - Status: ", heap == HEAP_LDT ? "" : "[" + k + "]");
+                    title = format("Modifiable%s - Status: ", heap == baseHeap ? "" : "[" + k + "]");
                     String errorMessage2 = modMsgs == null ? "OK" : modMsgs.get(k);
                     Color modColor = modColors == null ? COLOR_SUCCESS : modColors.get(k);
                     textArea = createErrorTextField(title, errorMessage2, modColor);
@@ -852,7 +852,7 @@ public class InvariantConfigurator {
                         setError(modErrors, modCols, heap.toString(), e.getMessage());
                     }
                 }
-                LocationVariable baseHeap = HEAP_LDT;
+                LocationVariable baseHeap = services.getTypeConverter().getHeapLDT().getHeap();
                 // TODO: add post expressions and new objects
                 try {
                     infFlowSpecs.put(baseHeap, parseInfFlowSpec(baseHeap));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
@@ -18,7 +18,6 @@ import de.uka.ilkd.key.java.statement.LoopStatement;
 import de.uka.ilkd.key.ldt.HeapLDT;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.NamespaceSet;
-import de.uka.ilkd.key.logic.ProgramElementName;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.nparser.KeyIO;
@@ -185,11 +184,6 @@ public class InvariantConfigurator {
                 setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
                 final NamespaceSet nss = services.getNamespaces().copyWithParent();
-                Term self = loopInv.getInternalSelfTerm();
-                if (self != null) {
-                    nss.programVariables()
-                            .add(new LocationVariable(new ProgramElementName("self"), self.sort()));
-                }
                 parser = new KeyIO(services, nss);
                 parser.setAbbrevMap(getAbbrevMap());
 
@@ -601,7 +595,8 @@ public class InvariantConfigurator {
                     Color invColor = invColors == null ? COLOR_SUCCESS : invColors.get(k);
                     JTextArea textArea = createErrorTextField(title, errorMessage, invColor);
                     invPane.add(k, textArea);
-                    title = format("Modifiable%s - Status: ", heap == baseHeap ? "" : "[" + k + "]");
+                    title =
+                        format("Modifiable%s - Status: ", heap == baseHeap ? "" : "[" + k + "]");
                     String errorMessage2 = modMsgs == null ? "OK" : modMsgs.get(k);
                     Color modColor = modColors == null ? COLOR_SUCCESS : modColors.get(k);
                     textArea = createErrorTextField(title, errorMessage2, modColor);


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments may remain since they will be
invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->

This PR fixes a bug that prevented the interactive provision of a loop invariant.

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

It should be possible to enter loop invariants manually.

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: Applied a manually entered loop invariant
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->

The problem was if no "free modifies"/"free assignable" was available then creating the whole modifies set  "union(freeMod, mod)" led to a NullPointerException. The fix uses "strictly_nothing" as default for free assignables of loops, if non given.
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
