### PR TITLE
Always sort extension actions in context submenus (+bugfix to allow disabling extensions)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
@@ -77,6 +77,9 @@ public class ProofIndependentSettings {
             if (lastReadedProperties != null) {
                 settings.readSettings(lastReadedProperties);
             }
+            if (lastReadedConfiguration != null) {
+                settings.readSettings(lastReadedConfiguration);
+            }
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/ExtensionSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/ExtensionSettings.java
@@ -10,12 +10,16 @@ import java.util.TreeSet;
 import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
 
 public class ExtensionSettings extends AbstractPropertiesSettings {
-    public final static String KEY_DISABLED = "disabled";
+    private static final String NAME = "Extensions";
+    public static final String KEY_DISABLED = "disabled";
+    /**
+     * Class names of disabled extensions.
+     */
     private final PropertyEntry<Set<String>> forbiddenClasses =
         createStringSetProperty(KEY_DISABLED, "");
 
     public ExtensionSettings() {
-        super("Extensions");
+        super(NAME);
     }
 
     public Collection<String> getForbiddenClasses() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/KeYGuiExtensionFacade.java
@@ -223,17 +223,29 @@ public final class KeYGuiExtensionFacade {
         return getExtensionInstances(KeYGuiExtension.ContextMenu.class);
     }
 
+    /**
+     * Create a context menu with extension-provided actions for the specified kind and underlying
+     * object.
+     * <p>
+     * If the underlying object is a proof, this will also include the usual actions.
+     * </p>
+     *
+     * @param kind what kind of object the context menu is built on
+     * @param underlyingObject the object the context menu is built on
+     * @param mediator the KeY mediator
+     * @return populated context menu
+     */
     public static JPopupMenu createContextMenu(ContextMenuKind kind, Object underlyingObject,
             KeYMediator mediator) {
         JPopupMenu menu = new JPopupMenu();
-        if (underlyingObject instanceof Proof) {
-            for (Component comp : MainWindow.getInstance().createProofMenu((Proof) underlyingObject)
+        if (underlyingObject instanceof Proof proof) {
+            for (Component comp : MainWindow.getInstance().createProofMenu(proof)
                     .getMenuComponents()) {
                 menu.add(comp);
             }
         }
         List<Action> content = getContextMenuItems(kind, underlyingObject, mediator);
-        content.forEach(menu::add);
+        content.forEach(it -> sortActionIntoMenu(it, menu));
         return menu;
     }
 


### PR DESCRIPTION
## Intended Change

This changes the display of extension-provided context menu actions. If they set a menu path, it will now be respected when constructing the popup menu.

The second commit fixes a bug where it was no longer possible to disable extensions (they would always re-enable on next KeY launch).

## Type of pull request

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: it works as expected for a new context menu action I added in another PR
- [x] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
