### PR TITLE
Activate the OverloadedOperatorHandler.java for Sequence datatype

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
@@ -100,7 +100,7 @@ public class OverloadedOperatorHandler {
 
         handlers.add(new BinaryBooleanHandler(services));
         handlers.add(new SequenceHandler(services));
-        // handlers.add(new LocSetHandler(services));
+        handlers.add(new LocSetHandler(services));
         handlers.add(this.integerHandler);
         handlers.add(new FloatHandler(services));
         handlers.add(new DoubleHandler(services));
@@ -180,10 +180,10 @@ public class OverloadedOperatorHandler {
                 case ADD, BITWISE_OR -> new SLExpression(tb.union(l, r));
                 case SUBTRACT -> new SLExpression(tb.setMinus(l, r));
                 case BITWISE_AND -> new SLExpression(tb.intersect(l, r));
-                case LT -> new SLExpression(tb.subset(l, r));
-                case LTE -> new SLExpression(tb.and(tb.subset(l, r), tb.equals(l, r)));
-                case GT -> new SLExpression(tb.subset(r, l));
-                case GTE -> new SLExpression(tb.and(tb.subset(r, l), tb.equals(l, r)));
+                case LT -> new SLExpression(tb.and(tb.subset(l, r), tb.not(tb.equals(l, r))));
+                case LTE -> new SLExpression(tb.subset(l, r));
+                case GT -> new SLExpression(tb.and(tb.subset(r, l), tb.not(tb.equals(l, r))));
+                case GTE -> new SLExpression(tb.subset(r, l));
                 default -> null;
                 };
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
@@ -99,7 +99,7 @@ public class OverloadedOperatorHandler {
         this.integerHandler = new IntegerHandler(services, specMathMode);
 
         handlers.add(new BinaryBooleanHandler(services));
-        // handlers.add(new SequenceHandler(services));
+        handlers.add(new SequenceHandler(services));
         // handlers.add(new LocSetHandler(services));
         handlers.add(this.integerHandler);
         handlers.add(new FloatHandler(services));

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
@@ -179,7 +179,7 @@ public class OverloadedOperatorHandler {
                 return switch (op) {
                 case ADD, BITWISE_OR -> new SLExpression(tb.union(l, r));
                 case SUBTRACT -> new SLExpression(tb.setMinus(l, r));
-                case BITWISE_AND -> new SLExpression(tb.intersect(l, r));
+                case MULT, BITWISE_AND -> new SLExpression(tb.intersect(l, r));
                 case LT -> new SLExpression(tb.and(tb.subset(l, r), tb.not(tb.equals(l, r))));
                 case LTE -> new SLExpression(tb.subset(l, r));
                 case GT -> new SLExpression(tb.and(tb.subset(r, l), tb.not(tb.equals(l, r))));

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/OverloadedOperatorHandler.java
@@ -150,6 +150,9 @@ public class OverloadedOperatorHandler {
         @Override
         public SLExpression build(JMLOperator op, SLExpression left, SLExpression right)
                 throws SLTranslationException {
+            if (right == null) {
+                return null;
+            }
             if (left.getTerm().sort() == ldtSequence.targetSort()
                     && right.getTerm().sort() == ldtSequence.targetSort()) {
                 if (op == JMLOperator.ADD) {
@@ -173,6 +176,9 @@ public class OverloadedOperatorHandler {
         @Override
         public SLExpression build(JMLOperator op, SLExpression left, SLExpression right)
                 throws SLTranslationException {
+            if (right == null) {
+                return null;
+            }
             final var l = left.getTerm();
             final var r = right.getTerm();
             if (l.sort() == ldt.targetSort() && r.sort() == ldt.targetSort()) {

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLTranslator.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLTranslator.java
@@ -25,6 +25,8 @@ import org.key_project.util.collection.ImmutableSLList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.*;
@@ -442,6 +444,38 @@ public class TestJMLTranslator {
         final boolean condition = result.equalsModRenaming(expected);
         assertTrue(condition, format("Expected:%s\n Was:%s",
             ProofSaver.printTerm(expected, services), ProofSaver.printTerm(result, services)));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "\\seq(1) + \\seq(2,3) : \\seq_concat(\\seq(1), \\seq(2,3))",
+        "\\locset(this.b) + \\locset(this.s) : \\set_union(\\locset(this.b), \\locset(this.s))",
+        "\\locset(this.b) | \\locset(this.s) : \\set_union(\\locset(this.b), \\locset(this.s))",
+        "\\locset(this.b) & \\locset(this.s) : \\intersect(\\locset(this.b), \\locset(this.s))",
+        "\\locset(this.b) * \\locset(this.s) : \\intersect(\\locset(this.b), \\locset(this.s))",
+        "\\locset(this.b) <= \\locset(this.s) : \\subset(\\locset(this.b), \\locset(this.s))",
+        "\\locset(this.b) < \\locset(this.s) : \\subset(\\locset(this.b), \\locset(this.s)) && \\locset(this.b) != \\locset(this.s)",
+        "\\locset(this.b) >= \\locset(this.s) : \\subset(\\locset(this.s), \\locset(this.b))",
+        "\\locset(this.b) > \\locset(this.s) : \\subset(\\locset(this.s), \\locset(this.b)) && \\locset(this.b) != \\locset(this.s)",
+    }, delimiter = ':')
+    public void testOperatorOverloading(String expression, String expected) {
+        Term tTrans = null, tExp = null;
+        try {
+            tTrans = jmlIO.parseExpression(expression);
+        } catch (Exception e) {
+            fail("Cannot parse " + expression, e);
+        }
+
+        try {
+            tExp = jmlIO.parseExpression(expected);
+        } catch (Exception e) {
+            fail("Cannot parse " + expected, e);
+        }
+
+        if (!tTrans.equalsModTermLabels(tExp)) {
+            // this gives nicer error
+            assertEquals(tExp, tTrans);
+        }
     }
 
 }


### PR DESCRIPTION
## Intended Change

Activate the operator overloading handler for the Sequence datatype. 

@mattulbrich The last change is from you on the particular line. 

![Screenshot from 2024-02-09 16-02-58](https://github.com/KeYProject/key/assets/104259/aa0fef7c-5fb4-49fc-8860-d0c03f4c44d5)


## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- **X** Bug fix (non-breaking change which fixes an issue)
- **not really** New feature (non-breaking change which adds functionality)
- **X** There are changes to the (Java) code

## Ensuring quality
   
- **X** I have tested the feature as follows: Test file
```
class SeqTest {
    /*@ ensures \seq(1,2,3) == \seq(1) + \seq(2,3);*/
    void foo() {}
}
```
