### PR TITLE
Nicer error message for parse errors

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -139,6 +139,7 @@ public final class ParsingFacade {
             LOGGER.warn("SLL was not enough");
             stream.seek(0);
             p = createParser(stream);
+            p.setErrorHandler(new BailErrorStrategy());
             ctx = p.file();
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -21,6 +21,7 @@ import de.uka.ilkd.key.util.parsing.BuildingException;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -131,7 +132,15 @@ public final class ParsingFacade {
         p.getInterpreter().setPredictionMode(PredictionMode.SLL);
         p.removeErrorListeners();
         p.setErrorHandler(new BailErrorStrategy());
-        KeYParser.FileContext ctx = p.file();
+        KeYParser.FileContext ctx;
+        try {
+            ctx = p.file();
+        } catch (ParseCancellationException ex) {
+            LOGGER.warn("SLL was not enough");
+            stream.seek(0);
+            p = createParser(stream);
+            ctx = p.file();
+        }
 
         p.getErrorReporter().throwException();
         return new KeyAst.File(ctx);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.util.parsing.BuildingException;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -130,17 +129,9 @@ public final class ParsingFacade {
         KeYParser p = createParser(stream);
 
         p.getInterpreter().setPredictionMode(PredictionMode.SLL);
-        // we don't want error messages or recovery during first try
         p.removeErrorListeners();
         p.setErrorHandler(new BailErrorStrategy());
-        KeYParser.FileContext ctx;
-        try {
-            ctx = p.file();
-        } catch (ParseCancellationException ex) {
-            LOGGER.warn("SLL was not enough");
-            p = createParser(stream);
-            ctx = p.file();
-        }
+        KeYParser.FileContext ctx = p.file();
 
         p.getErrorReporter().throwException();
         return new KeyAst.File(ctx);

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
@@ -129,7 +129,8 @@ public final class ExceptionTools {
 
         return token == null ? null
                 : new Location(
-                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName()).normalize().toUri(),
+                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName())
+                            .normalize().toUri(),
                     Position.fromToken(token));
     }
 
@@ -138,7 +139,8 @@ public final class ExceptionTools {
 
         return token == null ? null
                 : new Location(
-                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName()).normalize().toUri(),
+                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName())
+                            .normalize().toUri(),
                     Position.fromToken(token));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
@@ -129,7 +129,7 @@ public final class ExceptionTools {
 
         return token == null ? null
                 : new Location(
-                    Paths.get("/", exc.getInputStream().getSourceName()).normalize().toUri(),
+                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName()).normalize().toUri(),
                     Position.fromToken(token));
     }
 
@@ -138,7 +138,7 @@ public final class ExceptionTools {
 
         return token == null ? null
                 : new Location(
-                    Paths.get("/", exc.getInputStream().getSourceName()).normalize().toUri(),
+                    Paths.get(Paths.get("").toString(), exc.getInputStream().getSourceName()).normalize().toUri(),
                     Position.fromToken(token));
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
@@ -1,18 +1,22 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.util;
-
-import de.uka.ilkd.key.nparser.ParsingFacade;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
-import org.antlr.v4.runtime.InputMismatchException;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
-import org.junit.jupiter.api.Test;
-import org.key_project.util.helper.FindResources;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
+
+import de.uka.ilkd.key.nparser.ParsingFacade;
+import de.uka.ilkd.key.parser.Location;
+import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
+
+import org.key_project.util.helper.FindResources;
+
+import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
@@ -2,6 +2,7 @@ package de.uka.ilkd.key.util;
 
 import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.parser.Location;
+import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
 import org.antlr.v4.runtime.InputMismatchException;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,10 @@ class ExceptionToolsTest {
             assertEquals(6, loc.getPosition().line());
             assertEquals(1, loc.getPosition().column());
             assertEquals(fileToRead.toUri(), loc.fileUri());
+        } catch (SyntaxErrorReporter.ParserException exception) {
+            Location loc = ExceptionTools.getLocation(exception).get();
+            assertEquals(6, loc.getPosition().line());
+            assertEquals(1, loc.getPosition().column());
         }
     }
 }

--- a/key.core/src/test/resources/testcase/parserErrorTest/missing_semicolon.key
+++ b/key.core/src/test/resources/testcase/parserErrorTest/missing_semicolon.key
@@ -1,0 +1,10 @@
+\rules {
+   missingSemicolon {
+      \find(0=0)
+      \replacewith(1=1)
+  }
+}
+\problem {
+0=0
+}
+

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
@@ -41,6 +41,8 @@ import org.key_project.util.java.IOUtil;
 import org.key_project.util.java.StringUtil;
 import org.key_project.util.java.SwingUtil;
 
+import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -599,6 +601,14 @@ public final class IssueDialog extends JDialog {
             exception.printStackTrace(pw);
             String message = exception.getMessage();
             String info = sw.toString();
+
+            if (exception instanceof ParseCancellationException) {
+                exception = exception.getCause();
+            }
+
+            if (exception instanceof InputMismatchException ime) {
+                message = ExceptionTools.getNiceMessage(ime);
+            }
 
             // also add message of the cause to the string if available
             if (exception.getCause() != null) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
@@ -42,6 +42,7 @@ import org.key_project.util.java.StringUtil;
 import org.key_project.util.java.SwingUtil;
 
 import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -608,6 +609,9 @@ public final class IssueDialog extends JDialog {
 
             if (exception instanceof InputMismatchException ime) {
                 message = ExceptionTools.getNiceMessage(ime);
+            }
+            if (exception instanceof NoViableAltException nvae) {
+                message = ExceptionTools.getNiceMessage(nvae);
             }
 
             // also add message of the cause to the string if available


### PR DESCRIPTION
## Intended Change

#3406 leads to user-facing ParseCancellationExceptions, which are not debuggable. This PR enhances the user experience by actually showing the error in the context of the input file, and listing the found token and the expected token types. Previously, only the class name of the exception was displayed.

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [x] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: I tested the error reporting using the file below
- [ ] I have checked that runtime performance has not deteriorated.

`missing_semicolon.key`
```
\rules {
   missingSemicolon {
      \find(0=0)
      \replacewith(1=1)
  }
}

\problem { 0=0 }
```

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
