### PR TITLE
Solved an issue with row/column numbers in JML Parser

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/JMLTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/JMLTransformer.java
@@ -92,13 +92,32 @@ public final class JMLTransformer extends RecoderModelTransformer {
         StringBuilder sb = new StringBuilder(comments[0].getText());
 
         for (int i = 1; i < comments.length; i++) {
-            Position relativePos = comments[i].getRelativePosition();
-            for (int j = 0; j < relativePos.getLine(); j++) {
-                sb.append("\n");
-            }
-            for (int j = 0; j < relativePos.getColumn(); j++) {
-                sb.append(" ");
-            }
+            Position previousStart = comments[i - 1].getStartPosition();
+
+            // this also includes // or /* ... */
+            String previousText = comments[i - 1].getText();
+
+            int previousEndLine = previousStart.getLine() +
+                    (int) previousText.chars().filter(x -> x == '\n').count();
+
+            // /*ab*/  => length: 6, lastIndex: -1, so we get 6
+            // /*\nb*/ => length: 6, lastIndex:  2, so we get 3
+            int previousEndColumn = previousStart.getColumn() - 1 +
+                    previousText.length() - (previousText.lastIndexOf('\n') + 1);
+
+            Position currentStart = comments[i].getStartPosition();
+
+            int insertRows = currentStart.getLine() - previousEndLine;
+
+            // the columns are starting at 1 and not at 0
+            int insertColumns = insertRows > 0 ? // line break between the comments
+                    currentStart.getColumn() - 1 :
+                    (currentStart.getColumn() - 1) - previousEndColumn;
+
+            assert insertRows >= 0 && insertColumns >= 0;
+
+            sb.append("\n".repeat(insertRows));
+            sb.append(" ".repeat(insertColumns));
             sb.append(comments[i].getText());
         }
 

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/IllegalInv.java
@@ -1,4 +1,4 @@
-// exceptionClass: ConvertException
+// exceptionClass: PosConvertException
 // msgContains: mismatched input ';'
 // position: 17/19
 // verbose: true


### PR DESCRIPTION
Solved an issue with row/column numbers caused by the comment concatenation. The issue occurred when there was code (class declaration) between two comments parented to the class.