### PR TITLE
added checkbox to disable example loader directly in dialog

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ExampleChooser.java
@@ -21,6 +21,8 @@ import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
 import de.uka.ilkd.key.gui.utilities.GuiUtilities;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
 
 import org.key_project.util.java.IOUtil;
 
@@ -277,6 +279,15 @@ public final class ExampleChooser extends JDialog {
                 .setMaximumSize(new Dimension(Integer.MAX_VALUE, (int) buttonDim.getHeight() + 10));
         getContentPane().add(buttonPanel);
 
+        // create the checkbox to hide example load on next startup
+        ViewSettings vs = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
+        JCheckBox showAgainCheckbox =
+            new JCheckBox("Show this dialog on startup", vs.getShowLoadExamplesDialog());
+        buttonPanel.add(showAgainCheckbox);
+        showAgainCheckbox.addActionListener(e -> {
+            vs.setShowLoadExamplesDialog(showAgainCheckbox.isSelected());
+        });
+
         // create "load" button
         loadButton = new JButton("Load Example");
         loadButton.addActionListener(e -> {
@@ -311,6 +322,7 @@ public final class ExampleChooser extends JDialog {
         });
         buttonPanel.add(cancelButton);
         GuiUtilities.attachClickOnEscListener(cancelButton);
+
 
         // select first example
         DefaultMutableTreeNode firstLeaf =


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments may remain since they will be
invisible when showing the PR.
-->

## Intended Change
Added a checkbox to the example loader dialog that allows to hide it on subsequent startups. I consider this a reasonable change as this functionality is already supported by KeY but hidden in the preferences which most user might never open. Additionally i think this is standard behavior for similar IDEs or programs. No default behavior is changed.
<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [x] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [x] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: Multiple startups with all possible configurations. 
- [x] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
