### PR TITLE
Hackeython: ADTs in JML

### DIFF
--- a/key.core/src/main/antlr4/JmlLexer.g4
+++ b/key.core/src/main/antlr4/JmlLexer.g4
@@ -96,6 +96,7 @@ CAPTURES: 'captures' Pred -> pushMode(expr);
 CODE: 'code'; //?
 CONSTRAINT: 'constraint' Pred -> pushMode(expr);
 CONTINUES: 'continues' -> pushMode(expr);
+DATATYPE: 'datatype';
 DEBUG: 'debug'; //?
 DECREASING: ('decreasing' | 'decreases' | 'loop_variant') Pred -> pushMode(expr);
 DETERMINES: 'determines' -> pushMode(expr);
@@ -155,6 +156,7 @@ C_IDENT: '\\'? LETTER (LETTERORDIGIT)* -> type(IDENT);
 C_COLON: ':' -> type(COLON);
 C_DOT: '.' -> type(DOT);
 C_COMMA: ',' -> type(COMMA);
+C_INCLUSIVEOR: '|' -> type(INCLUSIVEOR);
 
 SL_COMMENT: {jmlMarkerDecision.isComment("//")}? ('//' ('\n'|'\r'|EOF) | '//' ~'@' ~('\n'|'\r')*) -> channel(HIDDEN);
 ML_COMMENT: {jmlMarkerDecision.isComment("/*")}? '/*' -> more, pushMode(mlComment);

--- a/key.core/src/main/antlr4/JmlParser.g4
+++ b/key.core/src/main/antlr4/JmlParser.g4
@@ -22,6 +22,7 @@ classlevel_element
   | monitors_for_clause | readable_if_clause | writable_if_clause
   | datagroup_clause    | set_statement      | nowarn_pragma
   | accessible_clause   | assert_statement   | assume_statement
+  | datatype_declaration
   ;
 
 methodlevel_comment: (modifiers? methodlevel_element modifiers?)* EOF;
@@ -41,7 +42,28 @@ modifier
   | CODE_JAVA_MATH | CODE_SAFE_MATH | CODE_BIGINT_MATH)
  ;
 
+datatype_declaration:
+    DATATYPE
+    dt_name=IDENT
+    LBRACE
+    datatype_constructor (INCLUSIVEOR datatype_constructor)*
+    SEMI_TOPLEVEL
+    (datatype_function)*
+    RBRACE
+    ;
 
+datatype_constructor:
+  con_name=IDENT
+  (
+    LPAREN
+    (argType+=type argName+=IDENT
+     (COMMA argType+=type argName+=IDENT)*
+    )?
+    RPAREN
+  )?
+;
+
+datatype_function: type IDENT param_list method_body;
 
 class_axiom: AXIOM expression SEMI_TOPLEVEL;
 initially_clause: INITIALLY expression SEMI_TOPLEVEL;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/Namespace.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/Namespace.java
@@ -184,7 +184,7 @@ public class Namespace<E extends Named> implements java.io.Serializable {
     }
 
     /** Convenience method to look up. */
-    public E lookup(String name) {
+    public @Nullable E lookup(String name) {
         return lookup(new Name(name));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/AdtHelper.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/AdtHelper.java
@@ -1,0 +1,225 @@
+package de.uka.ilkd.key.nparser;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.logic.*;
+import de.uka.ilkd.key.logic.op.*;
+import de.uka.ilkd.key.logic.sort.ProgramSVSort;
+import de.uka.ilkd.key.logic.sort.Sort;
+import de.uka.ilkd.key.logic.sort.SortImpl;
+import de.uka.ilkd.key.parser.SchemaVariableModifierSet;
+import de.uka.ilkd.key.rule.RewriteTaclet;
+import de.uka.ilkd.key.rule.tacletbuilder.RewriteTacletBuilder;
+import de.uka.ilkd.key.rule.tacletbuilder.TacletGoalTemplate;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.key_project.util.collection.ImmutableArray;
+import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableSet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Alexander Weigl
+ * @version 1 (27.02.25)
+ */
+@NullMarked
+public record AdtHelper(Services services, Namespace<SchemaVariable> schemaVariables) {
+    public AdtHelper(Services services) {
+        this(services, new Namespace<>());
+    }
+
+    public record Adt(String name, Sort sort, List<AdtConstructor> constructors) {
+    }
+
+    public record AdtConstructor(String name, List<Sort> args, List<String> argNames) {
+    }
+
+    public Sort createSorts(String name, @Nullable String comment, @Nullable String origin) {
+        var s = new SortImpl(new Name(name), ImmutableSet.empty(), false, comment, origin);
+        sorts().addSafely(s);
+        return s;
+    }
+
+    public void createConstructor(Sort sort, AdtConstructor c) {
+        var dtNamespace = new Namespace<Function>();
+        for (int i = 0; i < c.args.size(); i++) {
+            var argSort = c.args.get(i);
+            var argName = c.argNames.get(i);
+            var alreadyDefinedFn = dtNamespace.lookup(argName);
+            if (alreadyDefinedFn != null
+                    && (!alreadyDefinedFn.sort().equals(argSort)
+                    || !alreadyDefinedFn.argSort(0).equals(sort))) {
+                throw new RuntimeException("Name already in namespace: " + argName);
+            }
+            Function fn = new Function(new Name(argName), argSort, new Sort[]{sort}, null,
+                    false, false);
+            dtNamespace.add(fn);
+        }
+        final ImmutableArray<Sort> s = new ImmutableArray<>(c.args);
+        Function function = new Function(new Name(c.name), sort, s);
+        functions().addSafely(function);
+        functions().addSafely(dtNamespace.allElements());
+    }
+
+    public void createTaclets(Adt adt) {
+        createAxiomTaclet(adt);
+        createConstructorSplit(adt);
+    }
+
+
+    private RewriteTacletBuilder<RewriteTaclet> createAxiomTaclet(Adt adt) {
+        var tacletBuilder = new RewriteTacletBuilder<>();
+        tacletBuilder.setName(new Name(String.format("%s_Axiom", adt.name)));
+        var tb = services.getTermBuilder();
+        var phi = declareSchemaVariable("phi", Sort.FORMULA, true,
+                new SchemaVariableModifierSet.FormulaSV());
+        var qvar = (VariableSV) declareSchemaVariable("x", adt.sort,
+                true,
+                new SchemaVariableModifierSet.VariableSV());
+
+        var find = tb.all(qvar, tb.var(phi)); // \forall #x #phi
+        tacletBuilder.setFind(find);
+        tacletBuilder.addVarsNotFreeIn(qvar, phi);
+
+        var cases = adt.constructors.stream()
+                .map(it -> createQuantifiedFormula(it, qvar, tb.var(phi), adt.sort))
+                .toList();
+
+        var axiom = tb.equals(find, tb.and(cases));
+
+        var goal = new TacletGoalTemplate(
+                Sequent.createAnteSequent(new Semisequent(new SequentFormula(axiom))),
+                ImmutableSLList.nil());
+        tacletBuilder.addTacletGoalTemplate(goal);
+
+        tacletBuilder.setDisplayName("Axiom_for_" + adt.name);
+        return tacletBuilder;
+    }
+
+    private Term createQuantifiedFormula(AdtConstructor c,
+                                         QuantifiableVariable qvX, Term phi, Sort dt) {
+        var tb = services.getTermBuilder();
+        var fn = functions().lookup(c.name);
+        var argSort = fn.argSorts();
+
+        if (argSort.isEmpty()) {
+            return tb.subst(qvX, tb.func(fn), phi);
+        }
+
+        var args = new Term[argSort.size()];
+        var qvs = new ArrayList<QuantifiableVariable>(args.length);
+        var ind = new ArrayList<Term>(args.length);
+
+        for (int i = 0; i < argSort.size(); i++) {
+            final var qv = new LogicVariable(new Name(c.argNames.get(i)), argSort.get(i));
+            qvs.add(qv);
+            args[i] = services.getTermFactory().createTerm(qvs.get(i));
+
+            if (argSort.get(i).equals(dt)) {
+                ind.add(tb.subst(qvX, args[i], phi));
+            }
+        }
+
+        if (ind.isEmpty()) {
+            return tb.all(qvs, tb.func(fn, args));
+        } else {
+            var base = tb.and(ind);
+            return tb.all(qvs, tb.imp(base, tb.subst(qvX, tb.func(fn, args), phi)));
+        }
+    }
+
+    private RewriteTacletBuilder<RewriteTaclet> createConstructorSplit(Adt adt) {
+        final var tb = services.getTermBuilder();
+
+        final String prefix = adt.name + "_";
+
+        Map<String, Term> variables = new HashMap<>();
+        for (AdtConstructor c : adt.constructors) {
+            for (int i = 0; i < c.argNames.size(); i++) {
+                var name = c.argNames.get(i);
+                var sort = c.args.get(i);
+                var sv = declareSchemaVariable(name, sort, true, new SchemaVariableModifierSet.TermSV());
+                variables.put(name, tb.var(sv));
+            }
+        }
+
+        final var b = new RewriteTacletBuilder<>();
+        b.setApplicationRestriction(RewriteTaclet.SAME_UPDATE_LEVEL);
+        final var sort = adt.sort;
+
+        b.setName(new Name(sort.name() + "_ctor_split"));
+        b.setDisplayName("case distinction of " + sort.name());
+
+        var phi = declareSchemaVariable("var", sort,
+                false,
+                new SchemaVariableModifierSet.TermSV());
+        b.setFind(tb.var(phi));
+
+        for (AdtConstructor c : adt.constructors) {
+            var func = functions().lookup(adt.name);
+            Term[] args = new Term[c.argNames.size()];
+            for (int i = 0; i < args.length; i++) {
+                args[i] = variables.get(c.argNames.get(i));
+            }
+            Semisequent antec =
+                    new Semisequent(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args))));
+            Sequent addedSeq = Sequent.createAnteSequent(antec);
+            TacletGoalTemplate goal = new TacletGoalTemplate(addedSeq, ImmutableSLList.nil());
+            goal.setName("#var = " + c.name);
+            b.addTacletGoalTemplate(goal);
+        }
+        return b;
+    }
+
+
+    private Namespace<Sort> sorts() {
+        return services.getNamespaces().sorts();
+    }
+
+    private Namespace<Function> functions() {
+        return services.getNamespaces().functions();
+    }
+
+
+    private SchemaVariable declareSchemaVariable(String name, Sort s,
+                                                 boolean makeSkolemTermSV,
+                                                 SchemaVariableModifierSet mods) {
+        SchemaVariable v;
+        if (s == Sort.FORMULA && !makeSkolemTermSV) {
+            v = SchemaVariableFactory.createFormulaSV(new Name(name), mods.rigid());
+        } else if (s == Sort.UPDATE) {
+            v = SchemaVariableFactory.createUpdateSV(new Name(name));
+        } else if (s instanceof ProgramSVSort) {
+            v = SchemaVariableFactory.createProgramSV(new ProgramElementName(name),
+                    (ProgramSVSort) s, mods.list());
+        } else {
+            if (false) {
+                v = SchemaVariableFactory.createVariableSV(new Name(name), s);
+            } else if (makeSkolemTermSV) {
+                v = SchemaVariableFactory.createSkolemTermSV(new Name(name), s);
+            } else if (false) {
+                v = SchemaVariableFactory.createTermLabelSV(new Name(name));
+            } else {
+                v = SchemaVariableFactory.createTermSV(new Name(name), s, mods.rigid(),
+                        mods.strict());
+            }
+        }
+
+        if (services.getNamespaces().variables().lookup(v.name()) != null) {
+            throw new RuntimeException("Schema variables shadows previous declared variable: " + v.name());
+        }
+
+        if (schemaVariables.lookup(v.name()) != null) {
+            SchemaVariable old = schemaVariables().lookup(v.name());
+            if (!old.sort().equals(v.sort())) {
+                throw new RuntimeException("Schema variables clashes with previous declared schema variable: " + v.name());
+            }
+        }
+        schemaVariables().add(v);
+        return v;
+    }
+
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
@@ -16,12 +16,10 @@ import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.logic.op.ProgramVariable;
 import de.uka.ilkd.key.logic.sort.*;
 import de.uka.ilkd.key.nparser.AdtHelper;
-import de.uka.ilkd.key.nparser.AdtHelper;
 import de.uka.ilkd.key.nparser.KeYParser;
 import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.rule.RuleSet;
 
-import org.jspecify.annotations.Nullable;
 import org.key_project.logic.Name;
 import org.key_project.logic.Named;
 import org.key_project.logic.sort.Sort;
@@ -66,9 +64,9 @@ public class DeclarationBuilder extends DefaultBuilder {
 
     @Override
     public Object visitDatatype_decl(KeYParser.Datatype_declContext ctx) {
-        new AdtHelper(services).createSorts(ctx.getText(),
-                ctx.doc != null ? ctx.doc.getText() : null,
-                BuilderHelpers.getPosition(ctx));
+        new AdtHelper(services).createSort(ctx.getText(),
+            ctx.doc != null ? ctx.doc.getText() : null,
+            BuilderHelpers.getPosition(ctx));
         return null;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
@@ -15,10 +15,13 @@ import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.logic.op.ProgramVariable;
 import de.uka.ilkd.key.logic.sort.*;
+import de.uka.ilkd.key.nparser.AdtHelper;
+import de.uka.ilkd.key.nparser.AdtHelper;
 import de.uka.ilkd.key.nparser.KeYParser;
 import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.rule.RuleSet;
 
+import org.jspecify.annotations.Nullable;
 import org.key_project.logic.Name;
 import org.key_project.logic.Named;
 import org.key_project.logic.sort.Sort;
@@ -63,14 +66,9 @@ public class DeclarationBuilder extends DefaultBuilder {
 
     @Override
     public Object visitDatatype_decl(KeYParser.Datatype_declContext ctx) {
-        // boolean freeAdt = ctx.FREE() != null;
-        var name = ctx.name.getText();
-        var doc = ctx.DOC_COMMENT() != null
-                ? ctx.DOC_COMMENT().getText()
-                : null;
-        var origin = BuilderHelpers.getPosition(ctx);
-        var s = new SortImpl(new Name(name), ImmutableSet.empty(), false, doc, origin);
-        sorts().addSafely(s);
+        new AdtHelper(services).createSorts(ctx.getText(),
+                ctx.doc != null ? ctx.doc.getText() : null,
+                BuilderHelpers.getPosition(ctx));
         return null;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -8,13 +8,11 @@ import java.util.Objects;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
-import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.NamespaceSet;
 import de.uka.ilkd.key.logic.op.JFunction;
 import de.uka.ilkd.key.logic.op.SortDependingFunction;
 import de.uka.ilkd.key.logic.op.Transformer;
 import de.uka.ilkd.key.logic.sort.GenericSort;
-import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.nparser.AdtHelper;
 import de.uka.ilkd.key.nparser.KeYParser;
 
@@ -58,44 +56,44 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
         var sort = Objects.requireNonNull(sorts().lookup(ctx.name.getText()));
         for (KeYParser.Datatype_constructorContext constructorContext : ctx
                 .datatype_constructor()) {
-            Name name = new Name(constructorContext.name.getText());
+            var name = constructorContext.name.getText();
             List<Sort> args = mapOf(constructorContext.sortId());
             List<String> argNames = mapOf(constructorContext.argName);
 
-            adtHelper.createConstructor(sort, name, args, argNames);
+            adtHelper.createConstructor(sort, new AdtHelper.AdtConstructor(name));
         }
         return null;
 
         /*
-        // weigl: all datatypes are free ==> functions are unique!
-        // boolean freeAdt = ctx.FREE() != null;
-        var sort = sorts().lookup(ctx.name.getText());
-        var dtNamespace = new Namespace<JFunction>();
-        for (KeYParser.Datatype_constructorContext constructorContext : ctx
-                .datatype_constructor()) {
-            Name name = new Name(constructorContext.name.getText());
-            Sort[] args = new Sort[constructorContext.sortId().size()];
-            var argNames = constructorContext.argName;
-            for (int i = 0; i < args.length; i++) {
-                Sort argSort = accept(constructorContext.sortId(i));
-                args[i] = argSort;
-                var argName = argNames.get(i).getText();
-                var alreadyDefinedFn = dtNamespace.lookup(argName);
-                if (alreadyDefinedFn != null
-                        && (!alreadyDefinedFn.sort().equals(argSort)
-                                || !alreadyDefinedFn.argSort(0).equals(sort))) {
-                    throw new RuntimeException("Name already in namespace: " + argName);
-                }
-                JFunction fn = new JFunction(new Name(argName), argSort, new Sort[] { sort }, null,
-                    false, false);
-                dtNamespace.add(fn);
-            }
-            JFunction function = new JFunction(name, sort, args, null, true, false);
-            namespaces().functions().addSafely(function);
-        }
-        namespaces().functions().addSafely(dtNamespace.allElements());
-        return null;
-        */
+         * // weigl: all datatypes are free ==> functions are unique!
+         * // boolean freeAdt = ctx.FREE() != null;
+         * var sort = sorts().lookup(ctx.name.getText());
+         * var dtNamespace = new Namespace<JFunction>();
+         * for (KeYParser.Datatype_constructorContext constructorContext : ctx
+         * .datatype_constructor()) {
+         * Name name = new Name(constructorContext.name.getText());
+         * Sort[] args = new Sort[constructorContext.sortId().size()];
+         * var argNames = constructorContext.argName;
+         * for (int i = 0; i < args.length; i++) {
+         * Sort argSort = accept(constructorContext.sortId(i));
+         * args[i] = argSort;
+         * var argName = argNames.get(i).getText();
+         * var alreadyDefinedFn = dtNamespace.lookup(argName);
+         * if (alreadyDefinedFn != null
+         * && (!alreadyDefinedFn.sort().equals(argSort)
+         * || !alreadyDefinedFn.argSort(0).equals(sort))) {
+         * throw new RuntimeException("Name already in namespace: " + argName);
+         * }
+         * JFunction fn = new JFunction(new Name(argName), argSort, new Sort[] { sort }, null,
+         * false, false);
+         * dtNamespace.add(fn);
+         * }
+         * JFunction function = new JFunction(name, sort, args, null, true, false);
+         * namespaces().functions().addSafely(function);
+         * }
+         * namespaces().functions().addSafely(dtNamespace.allElements());
+         * return null;
+         */
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.nparser.builder;
 
 import java.util.List;
+import java.util.Objects;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
@@ -13,6 +14,8 @@ import de.uka.ilkd.key.logic.op.JFunction;
 import de.uka.ilkd.key.logic.op.SortDependingFunction;
 import de.uka.ilkd.key.logic.op.Transformer;
 import de.uka.ilkd.key.logic.sort.GenericSort;
+import de.uka.ilkd.key.logic.sort.Sort;
+import de.uka.ilkd.key.nparser.AdtHelper;
 import de.uka.ilkd.key.nparser.KeYParser;
 
 import org.key_project.logic.Name;
@@ -51,6 +54,19 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
 
     @Override
     public Object visitDatatype_decl(KeYParser.Datatype_declContext ctx) {
+        var adtHelper = new AdtHelper(services);
+        var sort = Objects.requireNonNull(sorts().lookup(ctx.name.getText()));
+        for (KeYParser.Datatype_constructorContext constructorContext : ctx
+                .datatype_constructor()) {
+            Name name = new Name(constructorContext.name.getText());
+            List<Sort> args = mapOf(constructorContext.sortId());
+            List<String> argNames = mapOf(constructorContext.argName);
+
+            adtHelper.createConstructor(sort, name, args, argNames);
+        }
+        return null;
+
+        /*
         // weigl: all datatypes are free ==> functions are unique!
         // boolean freeAdt = ctx.FREE() != null;
         var sort = sorts().lookup(ctx.name.getText());
@@ -79,6 +95,7 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
         }
         namespaces().functions().addSafely(dtNamespace.allElements());
         return null;
+        */
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -377,11 +377,11 @@ public class TacletPBuilder extends ExpressionBuilder {
         tacletBuilder.setName(new Name(String.format("%s_Axiom", ctx.name.getText())));
         final var sort = sorts().lookup(ctx.name.getText());
         var phi = declareSchemaVariable(ctx, "phi", JavaDLTheory.FORMULA, true,
-                false, false, new SchemaVariableModifierSet.FormulaSV());
+            false, false, new SchemaVariableModifierSet.FormulaSV());
         var tb = services.getTermBuilder();
         var qvar = (VariableSV) declareSchemaVariable(ctx, "x", sort,
-                true, false, false,
-                new SchemaVariableModifierSet.VariableSV());
+            true, false, false,
+            new SchemaVariableModifierSet.VariableSV());
         var find = tb.all(qvar, tb.var(phi)); // \forall #x #phi
 
         var cases = ctx.datatype_constructor().stream()
@@ -391,8 +391,8 @@ public class TacletPBuilder extends ExpressionBuilder {
         var axiom = tb.equals(find, tb.and(cases));
 
         var goal = new TacletGoalTemplate(
-                Sequent.createAnteSequent(new Semisequent(new SequentFormula(axiom))),
-                ImmutableSLList.nil());
+            Sequent.createAnteSequent(new Semisequent(new SequentFormula(axiom))),
+            ImmutableSLList.nil());
         tacletBuilder.addTacletGoalTemplate(goal);
 
         tacletBuilder.setDisplayName("Axiom_for_" + sort.name());
@@ -400,7 +400,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private Term createQuantifiedFormula(KeYParser.Datatype_constructorContext context,
-                                         QuantifiableVariable qvX, Term phi, Sort dt) {
+            QuantifiableVariable qvX, Term phi, Sort dt) {
         var tb = services.getTermBuilder();
         var fn = functions().lookup(context.name.getText());
         if (context.argName.isEmpty())
@@ -409,13 +409,13 @@ public class TacletPBuilder extends ExpressionBuilder {
         var args = new Term[context.argName.size()];
 
         var argSort =
-                context.argSort.stream()
-                        .map(it -> sorts().lookup(it.getText()))
-                        .toList();
+            context.argSort.stream()
+                    .map(it -> sorts().lookup(it.getText()))
+                    .toList();
         var argNames =
-                context.argName.stream()
-                        .map(RuleContext::getText)
-                        .toList();
+            context.argName.stream()
+                    .map(RuleContext::getText)
+                    .toList();
         var qvs = new ArrayList<QuantifiableVariable>(args.length);
         var ind = new ArrayList<Term>(args.length);
 
@@ -449,8 +449,8 @@ public class TacletPBuilder extends ExpressionBuilder {
                 var name = context.argName.get(i).getText();
                 var sort = sorts().lookup(context.argSort.get(i).getText());
                 var sv = declareSchemaVariable(ctx, prefix + name, sort,
-                        false, true, false,
-                        new SchemaVariableModifierSet.TermSV());
+                    false, true, false,
+                    new SchemaVariableModifierSet.TermSV());
                 variables.put(name, tb.var(sv));
             }
         }
@@ -463,8 +463,8 @@ public class TacletPBuilder extends ExpressionBuilder {
         b.setDisplayName("case distinction of " + sort.name());
 
         var phi = declareSchemaVariable(ctx, "var", sort,
-                false, false, false,
-                new SchemaVariableModifierSet.TermSV());
+            false, false, false,
+            new SchemaVariableModifierSet.TermSV());
         b.setFind(tb.var(phi));
         for (KeYParser.Datatype_constructorContext context : ctx.datatype_constructor()) {
             var func = functions().lookup(context.name.getText());
@@ -473,7 +473,7 @@ public class TacletPBuilder extends ExpressionBuilder {
                 args[i] = variables.get(context.argName.get(i).getText());
             }
             Semisequent antec =
-                    new Semisequent(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args))));
+                new Semisequent(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args))));
             Sequent addedSeq = Sequent.createAnteSequent(antec);
             TacletGoalTemplate goal = new TacletGoalTemplate(addedSeq, ImmutableSLList.nil());
             goal.setName("#var = " + context.name.getText());

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -377,11 +377,11 @@ public class TacletPBuilder extends ExpressionBuilder {
         tacletBuilder.setName(new Name(String.format("%s_Axiom", ctx.name.getText())));
         final var sort = sorts().lookup(ctx.name.getText());
         var phi = declareSchemaVariable(ctx, "phi", JavaDLTheory.FORMULA, true,
-            false, false, new SchemaVariableModifierSet.FormulaSV());
+                false, false, new SchemaVariableModifierSet.FormulaSV());
         var tb = services.getTermBuilder();
         var qvar = (VariableSV) declareSchemaVariable(ctx, "x", sort,
-            true, false, false,
-            new SchemaVariableModifierSet.VariableSV());
+                true, false, false,
+                new SchemaVariableModifierSet.VariableSV());
         var find = tb.all(qvar, tb.var(phi)); // \forall #x #phi
 
         var cases = ctx.datatype_constructor().stream()
@@ -391,8 +391,8 @@ public class TacletPBuilder extends ExpressionBuilder {
         var axiom = tb.equals(find, tb.and(cases));
 
         var goal = new TacletGoalTemplate(
-            Sequent.createAnteSequent(new Semisequent(new SequentFormula(axiom))),
-            ImmutableSLList.nil());
+                Sequent.createAnteSequent(new Semisequent(new SequentFormula(axiom))),
+                ImmutableSLList.nil());
         tacletBuilder.addTacletGoalTemplate(goal);
 
         tacletBuilder.setDisplayName("Axiom_for_" + sort.name());
@@ -400,7 +400,7 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private Term createQuantifiedFormula(KeYParser.Datatype_constructorContext context,
-            QuantifiableVariable qvX, Term phi, Sort dt) {
+                                         QuantifiableVariable qvX, Term phi, Sort dt) {
         var tb = services.getTermBuilder();
         var fn = functions().lookup(context.name.getText());
         if (context.argName.isEmpty())
@@ -409,13 +409,13 @@ public class TacletPBuilder extends ExpressionBuilder {
         var args = new Term[context.argName.size()];
 
         var argSort =
-            context.argSort.stream()
-                    .map(it -> sorts().lookup(it.getText()))
-                    .toList();
+                context.argSort.stream()
+                        .map(it -> sorts().lookup(it.getText()))
+                        .toList();
         var argNames =
-            context.argName.stream()
-                    .map(RuleContext::getText)
-                    .toList();
+                context.argName.stream()
+                        .map(RuleContext::getText)
+                        .toList();
         var qvs = new ArrayList<QuantifiableVariable>(args.length);
         var ind = new ArrayList<Term>(args.length);
 
@@ -449,8 +449,8 @@ public class TacletPBuilder extends ExpressionBuilder {
                 var name = context.argName.get(i).getText();
                 var sort = sorts().lookup(context.argSort.get(i).getText());
                 var sv = declareSchemaVariable(ctx, prefix + name, sort,
-                    false, true, false,
-                    new SchemaVariableModifierSet.TermSV());
+                        false, true, false,
+                        new SchemaVariableModifierSet.TermSV());
                 variables.put(name, tb.var(sv));
             }
         }
@@ -463,8 +463,8 @@ public class TacletPBuilder extends ExpressionBuilder {
         b.setDisplayName("case distinction of " + sort.name());
 
         var phi = declareSchemaVariable(ctx, "var", sort,
-            false, false, false,
-            new SchemaVariableModifierSet.TermSV());
+                false, false, false,
+                new SchemaVariableModifierSet.TermSV());
         b.setFind(tb.var(phi));
         for (KeYParser.Datatype_constructorContext context : ctx.datatype_constructor()) {
             var func = functions().lookup(context.name.getText());
@@ -473,7 +473,7 @@ public class TacletPBuilder extends ExpressionBuilder {
                 args[i] = variables.get(context.argName.get(i).getText());
             }
             Semisequent antec =
-                new Semisequent(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args))));
+                    new Semisequent(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args))));
             Sequent addedSeq = Sequent.createAnteSequent(antec);
             TacletGoalTemplate goal = new TacletGoalTemplate(addedSeq, ImmutableSLList.nil());
             goal.setName("#var = " + context.name.getText());

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
@@ -21,6 +21,9 @@ import de.uka.ilkd.key.java.statement.MergePointStatement;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.proof.OpReplacer;
+import de.uka.ilkd.key.logic.sort.SortImpl;
+import de.uka.ilkd.key.nparser.AdtHelper;
+import de.uka.ilkd.key.nparser.builder.BuilderHelpers;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.ContractPO;
 import de.uka.ilkd.key.proof.init.ProofOblInput;
@@ -31,6 +34,9 @@ import de.uka.ilkd.key.rule.tacletbuilder.RewriteTacletBuilder;
 import de.uka.ilkd.key.rule.tacletbuilder.RewriteTacletGoalTemplate;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.speclang.jml.JMLInfoExtractor;
+import de.uka.ilkd.key.speclang.jml.JmlAdt;
+import de.uka.ilkd.key.speclang.jml.translation.ProgramVariableCollection;
+import de.uka.ilkd.key.speclang.jml.JmlAdt;
 import de.uka.ilkd.key.speclang.jml.translation.ProgramVariableCollection;
 import de.uka.ilkd.key.speclang.translation.SLTranslationException;
 import de.uka.ilkd.key.util.MiscTools;
@@ -1639,6 +1645,16 @@ public final class SpecificationRepository {
     }
 
     /**
+     *
+     */
+    public void addAdt(JmlAdt adt) {
+        AdtHelper adtHelper = new AdtHelper(services);
+        adtHelper.createSorts();
+
+
+    }
+
+    /**
      * Adds a new {@code LoopContract} and a new {@link FunctionalLoopContract} to the repository.
      *
      * @param contract the {@code LoopContract} to add.
@@ -1740,11 +1756,14 @@ public final class SpecificationRepository {
                 addLoopContract((LoopContract) spec);
             } else if (spec instanceof MergeContract) {
                 addMergeContract((MergeContract) spec);
+            } else if (spec instanceof JmlAdt adt) {
+                addAdt(adt);
             } else {
                 assert false : "unexpected spec: " + spec + "\n(" + spec.getClass() + ")";
             }
         }
     }
+
 
     public Pair<IObserverFunction, ImmutableSet<Taclet>> limitObs(IObserverFunction obs) {
         assert limitedToUnlimited.get(obs) == null : " observer is already limited: " + obs;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
@@ -20,10 +20,8 @@ import de.uka.ilkd.key.java.statement.LoopStatement;
 import de.uka.ilkd.key.java.statement.MergePointStatement;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.*;
-import de.uka.ilkd.key.proof.OpReplacer;
-import de.uka.ilkd.key.logic.sort.SortImpl;
 import de.uka.ilkd.key.nparser.AdtHelper;
-import de.uka.ilkd.key.nparser.builder.BuilderHelpers;
+import de.uka.ilkd.key.proof.OpReplacer;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.ContractPO;
 import de.uka.ilkd.key.proof.init.ProofOblInput;
@@ -34,8 +32,6 @@ import de.uka.ilkd.key.rule.tacletbuilder.RewriteTacletBuilder;
 import de.uka.ilkd.key.rule.tacletbuilder.RewriteTacletGoalTemplate;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.speclang.jml.JMLInfoExtractor;
-import de.uka.ilkd.key.speclang.jml.JmlAdt;
-import de.uka.ilkd.key.speclang.jml.translation.ProgramVariableCollection;
 import de.uka.ilkd.key.speclang.jml.JmlAdt;
 import de.uka.ilkd.key.speclang.jml.translation.ProgramVariableCollection;
 import de.uka.ilkd.key.speclang.translation.SLTranslationException;
@@ -1644,14 +1640,24 @@ public final class SpecificationRepository {
         blockContracts.compute(b, (k, set) -> set.remove(contract));
     }
 
+    private boolean isJmlAdtsActivated = false;
+    private List<AdtHelper.Adt> adts = new ArrayList<>(16);
+
     /**
      *
      */
     public void addAdt(JmlAdt adt) {
+        var a = new AdtHelper.Adt(adt.getKJT().createPackagePrefix().toString(),
+                adt.getName());
+        adts.add(a);
+    }
+
+    public void activateAdts() {
+        if(isJmlAdtsActivated) {return;}
+        isJmlAdtsActivated=true;
+
         AdtHelper adtHelper = new AdtHelper(services);
-        adtHelper.createSorts();
-
-
+        adtHelper.process(adts);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
@@ -339,6 +339,9 @@ public final class JMLSpecExtractor implements SpecExtractor {
                     } else if (c instanceof TextualJMLClassAxiom) {
                         ClassAxiom ax = jsf.createJMLClassAxiom(kjt, (TextualJMLClassAxiom) c);
                         result = result.add(ax);
+                    } else if (c instanceof TextualJMLDatatype a) {
+                        JmlAdt adt = jsf.createJMLAdt(a);
+                        result = result.add(adt);
                     } else {
                         // DO NOTHING
                         // There may be other kinds of JML constructs which are

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JmlAdt.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JmlAdt.java
@@ -1,13 +1,17 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.jml;
+
+import java.util.function.UnaryOperator;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.abstraction.KeYJavaType;
 import de.uka.ilkd.key.java.declaration.modifier.VisibilityModifier;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.speclang.SpecificationElement;
-import org.jspecify.annotations.Nullable;
 
-import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Alexander Weigl

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JmlAdt.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JmlAdt.java
@@ -1,0 +1,41 @@
+package de.uka.ilkd.key.speclang.jml;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.java.abstraction.KeYJavaType;
+import de.uka.ilkd.key.java.declaration.modifier.VisibilityModifier;
+import de.uka.ilkd.key.logic.Term;
+import de.uka.ilkd.key.speclang.SpecificationElement;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * @author Alexander Weigl
+ * @version 1 (27.02.25)
+ */
+public class JmlAdt implements SpecificationElement {
+    @Override
+    public String getName() {
+        return "";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public @Nullable VisibilityModifier getVisibility() {
+        return null;
+    }
+
+    @Override
+    public KeYJavaType getKJT() {
+        return null;
+    }
+
+    @Override
+    public SpecificationElement map(UnaryOperator<Term> op, Services services) {
+        return null;
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDatatype.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDatatype.java
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.jml.pretranslation;
 
+import java.util.Objects;
+
 import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
-import org.jspecify.annotations.NullMarked;
-import org.key_project.util.collection.ImmutableList;
+
 import org.key_project.util.collection.ImmutableSLList;
 
-import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
 
 
 /**
@@ -39,18 +40,17 @@ public final class TextualJMLDatatype extends TextualJMLConstruct {
         return adt.toString();
     }
 
-
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TextualJMLDatatype ci)) {
+        if (o == null || getClass() != o.getClass())
             return false;
-        }
-        return mods.equals(ci.mods) && adt.equals(ci.adt);
-    }
 
+        TextualJMLDatatype that = (TextualJMLDatatype) o;
+        return adt.equals(that.adt);
+    }
 
     @Override
     public int hashCode() {
-        return mods.hashCode() + adt.hashCode();
+        return adt.hashCode();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDatatype.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDatatype.java
@@ -1,0 +1,56 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.speclang.jml.pretranslation;
+
+import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
+import org.jspecify.annotations.NullMarked;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSLList;
+
+import java.util.Objects;
+
+
+/**
+ * A JML adt declaration in textual form.
+ */
+@NullMarked
+public final class TextualJMLDatatype extends TextualJMLConstruct {
+    private final LabeledParserRuleContext adt;
+
+    /**
+     * new textual representation.
+     *
+     * @param adt the expression in this clause
+     */
+    public TextualJMLDatatype(LabeledParserRuleContext adt) {
+        super(ImmutableSLList.nil());
+        this.adt = Objects.requireNonNull(adt);
+        setPosition(adt);
+    }
+
+    public LabeledParserRuleContext getAdt() {
+        return adt;
+    }
+
+
+    @Override
+    public String toString() {
+        return adt.toString();
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TextualJMLDatatype ci)) {
+            return false;
+        }
+        return mods.equals(ci.mods) && adt.equals(ci.adt);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return mods.hashCode() + adt.hashCode();
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
@@ -40,6 +40,7 @@ import de.uka.ilkd.key.rule.merge.procedures.UnparametricMergeProcedure;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.speclang.jml.JMLInfoExtractor;
 import de.uka.ilkd.key.speclang.jml.JMLSpecExtractor;
+import de.uka.ilkd.key.speclang.jml.JmlAdt;
 import de.uka.ilkd.key.speclang.jml.pretranslation.*;
 import de.uka.ilkd.key.speclang.njml.*;
 import de.uka.ilkd.key.speclang.translation.SLTranslationException;
@@ -244,6 +245,10 @@ public class JMLSpecFactory {
                 Map.of(heap, false), // has free mod
                 progVarCollection);
         }
+    }
+
+    public JmlAdt createJMLAdt(TextualJMLDatatype a) {
+        throw new RuntimeException("TODO");
     }
 
     // -------------------------------------------------------------------------

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
@@ -450,6 +450,12 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         return null;
     }
 
+    @Override
+    public Object visitDatatype_declaration(JmlParser.Datatype_declarationContext ctx) {
+        TextualJMLDatatype adt = new TextualJMLDatatype(new LabeledParserRuleContext(ctx));
+        constructs = constructs.append(adt);
+        return null;
+    }
 
     @Override
     public Object visitField_declaration(JmlParser.Field_declarationContext ctx) {


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments may remain since they will be
invisible when showing the PR.
-->

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

Based on #3420. Changes the JML pareser to accept definitions of ADTs. Datatypes have a list of _constructors_ separated by `|`, and a body of functions.

```java
class Test {
	/*@ datatype List {
	  @ 	Nil()
	  @	| Cons(\any head, List tail);
	  @
	  @ 	int size() {
	  @		return 0;
	  @ 	}
	  @ }
	  @*/
}
```

Currently, ADTs can only be defined on class-level, not inside methods or outside of classes.

There also is no semantics for these ADTs. KeY simply ignores them. Ideally, we want to use the defined types and functions in specification and translate them to KeY ADTs.

We also want to use the new Java switch expressions to allow pattern matching on ADTs, i.e,:
```java
switch (list) {
  case Nil -> 0;
  case Cons(_, xs) -> 1 + xs.size();
}
```

Open questions are:
- How are JML ADTs translated to KeY?
- How are switch expressions with pattern matching translated?
- Can we define a shorthand infix notation for ADT function, e.g., `l1 + l2` for `l1.append(l2)`?
- How do we resolve ADT function calls in specification?
- What happens if we already have a `List` class/interface?

OpenJML has a similar concept of ADTs and pattern matching. For demonstration, [there is a list example](https://github.com/OpenJML/OpenJML/blob/master-21/OpenJMLTest/test/datatype/Test.java).

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [x] Other: Changes to ANLTR grammars

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [ ] I have tested the feature as follows: ...
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
