### PR TITLE
Fix error handling for unknown sorts

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
@@ -167,6 +167,8 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
 
             SortDependingFunction firstInstance =
                 SortDependingFunction.getFirstInstance(new Name(varfuncName), getServices());
+            if(sort == null)
+                semanticError(ctx,"Could not find sort: %s", sortName);
             if (firstInstance != null) {
                 SortDependingFunction v = firstInstance.getInstanceFor(sort, getServices());
                 if (v != null) {

--- a/key.core/src/test/resources/de/uka/ilkd/key/nparser/exceptional/unknownsort2.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/nparser/exceptional/unknownsort2.key
@@ -1,7 +1,7 @@
 // verbose: true
 // msgMatch: Could not find sort: seq
-// exceptionClass: BuildingException
-// position: 9/10
+// exceptionClass: ProblemLoaderException
+// position: 9/11
 
 
 \rules {


### PR DESCRIPTION



## Intended Change
<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

This change handle properly the error of unknown sort, for example `seq` in `seq::seqGet(seqEmpty, 0)`. 
Previously this would throw a `NullPointerException` (Message: `Given sort is null`) after creating the function name `null::seqGet` and after trying to create `AbstractSortedOperator` with null sort.

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: ParserExceptionTest, cases: unknownsort.key,unknownsort2.key
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
