### PR TITLE
Fix position info for equality expr errors

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -573,6 +573,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
             if (floatResult != null) {
                 return floatResult;
             }
+            exc.updatePosition(ctx.getStart());
             if (tok.getText().equals("==")) {
                 result = termFactory.eq(result, expr.get(i));
             } else {

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exceptional/TypeError.java
@@ -1,8 +1,7 @@
 // exceptionClass: RuntimeException
 // msgContains: Error in equality-expression
-// position: 12/17
+// position: 11/19
 // verbose: true
-// broken: true
 
 // It's not the best of error messages ...
 // and there is no file location information


### PR DESCRIPTION
## Intended Change

This PR fixes the position info of the error for incorrect equality expressions.

## Type of pull request

<!--- What types of changes does your code introduce? Put an `x` in the box(es) that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [x] I added new test case(s) for new functionality: I re-enabled the test case by no longer marking it as broken
- [x] I have tested the feature as follows: automated test
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
