### PR TITLE
Fix startup crash if ~/.key/colors.json is not present

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ParsingFacade.java
@@ -208,7 +208,7 @@ public final class ParsingFacade {
 
     // region configuration
     /**
-     * Parses a the configuration determined by the given {@code file}.
+     * Parses the configuration determined by the given {@code file}.
      * A configuration corresponds to the grammar rule {@code cfile} in the {@code KeYParser.g4}.
      *
      * @param file non-null {@link Path} object
@@ -221,19 +221,20 @@ public final class ParsingFacade {
     }
 
     /**
+     * @param file non-null file to read as configuration
      * @see #parseConfigurationFile(Path)
+     * @throws IOException if the file is not found or not readable.
      */
     public static KeyAst.ConfigurationFile parseConfigurationFile(File file) throws IOException {
         return parseConfigurationFile(file.toPath());
     }
 
     /**
-     * Parses a the configuration determined by the given {@code stream}.
+     * Parses the configuration determined by the given {@code stream}.
      * A configuration corresponds to the grammar rule {@code cfile} in the {@code KeYParser.g4}.
      *
-     * @param file non-null {@link CharStream} object
+     * @param stream non-null {@link CharStream} object
      * @return monad that encapsluate the ParserRuleContext
-     * @throws IOException if the file is not found or not readable.
      * @throws BuildingException if the file is syntactical broken.
      */
     public static KeyAst.ConfigurationFile parseConfigurationFile(CharStream stream) {
@@ -244,20 +245,20 @@ public final class ParsingFacade {
     }
 
     /**
-     * Parses a the configuration determined by the given {@code stream}.
+     * Parses the configuration determined by the given {@code stream}.
      * A configuration corresponds to the grammar rule {@code cfile} in the {@code KeYParser.g4}.
      *
-     * @param file non-null {@link CharStream} object
-     * @return a configration object with the data deserialize from the given file
-     * @throws IOException if the file is not found or not readable.
+     * @param input non-null {@link CharStream} object
+     * @return a configuration object with the data deserialize from the given file
      * @throws BuildingException if the file is syntactical broken.
      */
-    public static Configuration readConfigurationFile(CharStream input) throws IOException {
+    public static Configuration readConfigurationFile(CharStream input) {
         return parseConfigurationFile(input).asConfiguration();
     }
 
     /**
      * @see #readConfigurationFile(CharStream)
+     * @throws IOException if the file is not found or not readable.
      */
     public static Configuration readConfigurationFile(Path file) throws IOException {
         return readConfigurationFile(CharStreams.fromPath(file));
@@ -265,6 +266,7 @@ public final class ParsingFacade {
 
     /**
      * @see #readConfigurationFile(CharStream)
+     * @throws IOException if the file is not found or not readable.
      */
     public static Configuration readConfigurationFile(File file) throws IOException {
         return readConfigurationFile(file.toPath());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
@@ -32,7 +32,7 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
         super();
         setHeaderText(getDescription());
         setSubHeaderText(
-            "Color settings are stored in: " + ColorSettings.SETTINGS_FILE.getAbsolutePath());
+            "Color settings are stored in: " + ColorSettings.SETTINGS_FILE_NEW.getAbsolutePath());
         add(new JScrollPane(tblColors));
     }
 


### PR DESCRIPTION
## Related Issue

This pull request fixes #3416.

## Intended Change

This PR removes the fallback to the old `.properties` file in ColorSettings.
Due to an issue in static initialization order, it is not possible to use the SettingsManager to (attempt to) read the old configuration file.

## Type of pull request

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (behaviour should not change or only minimally change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- [ ] There are changes to the taclet rule base
- [ ] There are changes to the deployment/CI infrastructure (gradle, github, ...)
- [ ] Other: 

## Ensuring quality
    
- [x] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: attempted to reproduce again as described in https://github.com/KeYProject/key/issues/3416#issuecomment-1985366875, issue did not occur
- [x] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.