### PR TITLE
PrettyPrinting: Show the availability by showing a comment. 

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/HTMLSyntaxHighlighter.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/HTMLSyntaxHighlighter.java
@@ -123,10 +123,16 @@ public class HTMLSyntaxHighlighter {
 
     private static final Pattern SINGLE_LINE_COMMENT_PATTERN = Pattern.compile("(//[^@].*?)<br>");
 
+    private static final Pattern MULTI_LINE_COMMENT_PATTERN = Pattern.compile("(/\\*.*?\\*/)",
+            Pattern.DOTALL | Pattern.MULTILINE);
+
     private static final Pattern SINGLE_LINE_JML_PATTERN = Pattern.compile("(//@.*?)<br>");
 
     private static final String SINGLE_LINE_COMMENT_REPLACEMENT =
-        "<span class=\"comment_highlight\">$1</span><br>";
+            "<span class=\"comment_highlight\">$1</span><br>";
+
+    private static final String MULTI_LINE_COMMENT_REPLACEMENT =
+            "<span class=\"comment_highlight\">$1</span>";
 
     private static final String SINGLE_LINE_JML_REPLACEMENT =
         "<span class=\"jml_highlight\">$1</span><br>";
@@ -232,6 +238,9 @@ public class HTMLSyntaxHighlighter {
 
             modality = SINGLE_LINE_COMMENT_PATTERN.matcher(modality)
                     .replaceAll(SINGLE_LINE_COMMENT_REPLACEMENT);
+
+            modality = MULTI_LINE_COMMENT_PATTERN.matcher(modality)
+                    .replaceAll(MULTI_LINE_COMMENT_REPLACEMENT);
 
             modality = SINGLE_LINE_JML_PATTERN.matcher(modality)
                     .replaceAll(SINGLE_LINE_JML_REPLACEMENT);


### PR DESCRIPTION
## Intended Change

In #3400, we extend the pretty printing of Java AST by a service object. This enables new pretty printing thingies like showing availability of specification for certain objects: loops and blocks. 

It uses a comment `/*C*/`: 
![image](https://github.com/KeYProject/key/assets/104259/37a5f1a6-6a42-4f87-addd-0f6fd6f6cfb6)


