### PR TITLE
fix smt solver downloader script

### DIFF
--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -56,7 +56,7 @@ echo "::endgroup::"
 #################################################
 echo "::group::{install cvc5}"
 if -f cvc5-Linux-static/bin/cvc5; then
-  echo "::notice::{Z3 found. Caching works! Skip installation}"
+  echo "::notice::{CVC5 found. Caching works! Skip installation}"
 else 
   echo "Install CVC5"
   # does not work anymore

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -55,7 +55,7 @@ echo "::endgroup::"
 
 #################################################
 echo "::group::{install cvc5}"
-if -f cvc5-Linux; then 
+if -f cvc5-Linux-static/bin/cvc5; then
   echo "::notice::{Z3 found. Caching works! Skip installation}"
 else 
   echo "Install CVC5"

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -1,6 +1,6 @@
 # No shebang!
 
-## Weigl's little helper to download SMT-solvers. 
+## Weigl's little helper to download SMT-solvers.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script is meant to be executed inside an Github Action to download the SMT-solver. 
@@ -27,6 +27,7 @@
 mkdir smt-solvers
 cd smt-solvers
 
+set -x # exit on error
 
 #################################################
 echo "::group::{install z3}"

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -39,7 +39,7 @@ else
   rm z3-*.zip
   # gh release download --skip-existing -p 'z3-*-x64-glibc-2.35.zip' -R Z3Prover/z3
   ## pin to a release
-  wget https://github.com/Z3Prover/z3/releases/download/z3-4.13.0/z3-4.13.0-x64-glibc-2.35.zip
+  wget -q https://github.com/Z3Prover/z3/releases/download/z3-4.13.0/z3-4.13.0-x64-glibc-2.35.zip
   unzip -n z3*.zip
   rm z3-*-x64-glibc-*.zip  
 fi
@@ -58,10 +58,15 @@ if -f cvc5-Linux; then
   echo "::notice::{Z3 found. Caching works! Skip installation}"
 else 
   echo "Install CVC5"
-  gh release download --skip-existing -p 'cvc5-Linux' -R cvc5/cvc5  
+  # does not work anymore
+  # gh release download --skip-existing -p 'cvc5-Linux' -R cvc5/cvc5
+
+  wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-1.1.2/cvc5-Linux-static.zip
+  unzip cvc5-Linux-static.zip
+  rm cvc5-Linux-static.zip
 fi 
 
-CVC5=$(readlink -f cvc5-Linux)
+CVC5=$(readlink -f cvc5-Linux-static/bin/cvc5)
 echo "CVC5 installed and added to path: CVC5"
 chmod u+x $CVC5
 echo $(dirname $CVC5) >> $GITHUB_PATH

--- a/.github/dlsmt.sh
+++ b/.github/dlsmt.sh
@@ -36,7 +36,10 @@ if readlink -f */bin/z3; then
   echo "::notice::{Z3 found. Caching works! Skip installation}"
 else 
   echo "Download Z3"
-  gh release download --skip-existing -p 'z3-*-x64-glibc-*.zip' -R Z3Prover/z3
+  rm z3-*.zip
+  # gh release download --skip-existing -p 'z3-*-x64-glibc-2.35.zip' -R Z3Prover/z3
+  ## pin to a release
+  wget https://github.com/Z3Prover/z3/releases/download/z3-4.13.0/z3-4.13.0-x64-glibc-2.35.zip
   unzip -n z3*.zip
   rm z3-*-x64-glibc-*.zip  
 fi


### PR DESCRIPTION
Fix the downloading of SMT solver in the CI pipeline. 

Version of z3 and CVC5 are now pinned. 