### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,16 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "montly"
+      interval: "monthly"
     groups:
-      all:
+      gradle-deps:
         patterns:
           - "*"      
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "montly"
+      interval: "monthly"
     groups:
-      all:
+      github-actions-deps:
         patterns:
           - "*"


### PR DESCRIPTION
This PR reconfigures *dependenabot* in the following manner:

1. Group incoming updates into a single Pull Request
> Sometimes there are 3 or 4 PRs created by dependabot. Now they are bundled into one combined PR. 

2. Slow down the checking of new versions from weekly to monthly
> We are not very security-critical. This helps to prevent downloading new libs every week.
