### PR TITLE
Adding groups in proof collection which were lost in translation

### DIFF
--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
@@ -237,10 +237,13 @@ public class ProofCollections {
 
 
         // Other tests:
+        g = c.group("other");
         g.provable("heap/coincidence_count/project.key");
         g.provable("heap/verifyThis11_1_Maximum/project.key");
         g.provable("heap/fm12_01_LRS/lcp.key");
         g.provable("heap/SemanticSlicing/project.key");
+
+        g = c.group("simple_SIF");
         g.provable("heap/information_flow/ArrayList_contains.key");
         g.provable("heap/information_flow/ArrayList_get.key");
         g.provable("heap/information_flow/ArrayList_size.key");


### PR DESCRIPTION
## Intended Change

In runAllProofs, some groups got mixed up and ended having files that should be in groups of their own. This PR fixes this.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

minor structural reorganisation of test cases    

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
