### PR TITLE
Allow "\seq()" and "\locset()" in JML

### DIFF
--- a/key.core/src/main/antlr4/JmlParser.g4
+++ b/key.core/src/main/antlr4/JmlParser.g4
@@ -347,7 +347,7 @@ jmlprimary
   | VALUES                                                                            #primaryValues
   | STRING_EQUAL LPAREN expression COMMA expression RPAREN                            #primaryStringEq
   | EMPTYSET                                                                          #primaryEmptySet
-  | (LOCSET|STOREREF) LPAREN storeRefUnion RPAREN                                     #primaryStoreRef
+  | (LOCSET|STOREREF) LPAREN storeRefUnion? RPAREN                                    #primaryStoreRef
   | SINGLETON LPAREN expression RPAREN                                                #primaryCreateLocsetSingleton
   | UNION LPAREN storeRefUnion RPAREN                                                 #primaryUnion
   | INTERSECT LPAREN storeRefIntersect RPAREN                                         #primaryIntersect

--- a/key.core/src/main/antlr4/JmlParser.g4
+++ b/key.core/src/main/antlr4/JmlParser.g4
@@ -217,7 +217,7 @@ storeRefUnion: list = storeRefList;
 storeRefList: storeref (COMMA storeref)*;
 storeRefIntersect: storeRefList;
 storeref: (NOTHING | EVERYTHING | NOT_SPECIFIED |  STRICTLY_NOTHING | storeRefExpr);
-createLocset: (LOCSET | SINGLETON) LPAREN exprList RPAREN;
+createLocset: (LOCSET | SINGLETON) LPAREN exprList? RPAREN;
 exprList: expression (COMMA expression)*;
 storeRefExpr: expression;
 predornot: (predicate |NOT_SPECIFIED | SAME);
@@ -365,7 +365,7 @@ jmlprimary
 sequence
   : SEQEMPTY                                                              #sequenceEmpty
   | seqdefterm                                                            #sequenceIgnore1
-  | (SEQSINGLETON | SEQ) LPAREN exprList RPAREN                           #sequenceCreate
+  | (SEQSINGLETON | SEQ) LPAREN exprList? RPAREN                          #sequenceCreate
   | SEQSUB LPAREN expression COMMA expression COMMA expression RPAREN     #sequenceSub
   | SEQREVERSE LPAREN expression RPAREN                                   #sequenceReverse
   | SEQREPLACE LPAREN expression COMMA expression COMMA expression RPAREN #sequenceReplace

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -352,7 +352,12 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public Object visitCreateLocset(JmlParser.CreateLocsetContext ctx) {
-        return termFactory.createLocSet(requireNonNull(accept(ctx.exprList())));
+        JmlParser.ExprListContext exprList = ctx.exprList();
+        if (exprList == null) {
+            return termFactory.createLocSet(ImmutableSLList.nil());
+        } else {
+            return termFactory.createLocSet(requireNonNull(accept(exprList)));
+        }
     }
 
 
@@ -1619,8 +1624,11 @@ class Translator extends JmlParserBaseVisitor<Object> {
     @Override
     public SLExpression visitSequenceCreate(JmlParser.SequenceCreateContext ctx) {
         ImmutableList<SLExpression> list = accept(ctx.exprList());
-        assert list != null;
-        return termFactory.seqConst(list);
+        if (list == null) {
+            return new SLExpression(tb.seqEmpty());
+        } else {
+            return termFactory.seqConst(list);
+        }
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -1516,8 +1516,10 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public Object visitPrimaryStoreRef(JmlParser.PrimaryStoreRefContext ctx) {
+        if (ctx.storeRefUnion() == null) {
+            return new SLExpression(termFactory.createLocSet(ImmutableSLList.nil()));
+        }
         Term t = accept(ctx.storeRefUnion());
-        assert t != null;
         return new SLExpression(t, javaInfo.getPrimitiveKeYJavaType(PrimitiveType.JAVA_LOCSET));
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/ExpressionTranslatorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/ExpressionTranslatorTest.java
@@ -52,7 +52,7 @@ public class ExpressionTranslatorTest {
         JmlLexer lexer = JmlFacade.createLexer(expr);
         lexer._mode = JmlLexer.expr;
         JmlParser parser = new JmlParser(new CommonTokenStream(lexer));
-        JmlParser.ExpressionContext ctx = parser.expression();
+        JmlParser.ExpressionContext ctx = parser.expressionEOF().expression();
         Assertions.assertEquals(0, parser.getNumberOfSyntaxErrors());
         Translator et = new Translator(services, kjt, self, SpecMathMode.defaultMode(),
             ImmutableSLList.nil(), result, exc, new HashMap<>(), new HashMap<>());

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
@@ -12,3 +12,5 @@ this
 1.f + 2.f
 1. + 2
 1f + 2d
+\seq()
+\locset()

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
@@ -11,6 +11,6 @@ this
 1.f < 2.f < 3.f
 1.f + 2.f
 1. + 2
-1f + 2d
+1.f + 2.d
 \seq()
 \locset()


### PR DESCRIPTION
## Intended Change

Currently, \seq() and \locset() are syntactically illegal, but should represent the empty set and empty sequence resp.

## Type of pull request

- New feature (non-breaking change which adds functionality)

## Ensuring quality
   
- I added new test case(s) for new functionality.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
