### PR TITLE
Fix loading of taclet proof obligations (issue #3477)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/EmptyEnvInput.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/EmptyEnvInput.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.proof.init.ProofInputException;
 import de.uka.ilkd.key.proof.io.AbstractEnvInput;
 import de.uka.ilkd.key.speclang.PositionedString;
 
+import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableSet;
 
 public class EmptyEnvInput extends AbstractEnvInput {
@@ -21,8 +22,7 @@ public class EmptyEnvInput extends AbstractEnvInput {
 
     @Override
     public ImmutableSet<PositionedString> read() throws ProofInputException {
-        // nothing to to do
-        return null;
+        return DefaultImmutableSet.nil();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationAction.java
@@ -233,6 +233,8 @@ public abstract class LemmaGenerationAction extends MainWindowAction {
                     getMediator().startInterface(true);
                     if (p != null) {
                         mainWindow.getUserInterface().registerProofAggregate(p);
+                        mainWindow.getMediator().getSelectionModel()
+                                .setSelectedProof(p.getFirstProof());
                     }
                 }
 


### PR DESCRIPTION
* This commit fixes an NPE when loading
* This commit fixes missing or inconsistent selection of loaded proof
  obligation

<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->
This pull request addresses #3477.

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->
Fix the NullPointerException when loading a taclet proof obligation.
In addition the PO selection was inconsistent, which is fixed as well.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: Loaded Taclet POs (both a single one as well as several at once)

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
