### PR TITLE
RuleCommand can now deal with rules that have schema variables for logical variables

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
@@ -61,8 +61,18 @@ public class RuleCommand extends AbstractCommand<RuleCommand.Parameters> {
         RuleApp theApp = makeRuleApp(args, state);
         Goal g = state.getFirstOpenAutomaticGoal();
 
-        if (theApp instanceof TacletApp) {
-            RuleApp completeApp = ((TacletApp) theApp).tryToInstantiate(g.proof().getServices());
+        if (theApp instanceof TacletApp tacletApp) {
+
+            ImmutableList<TacletApp> ifSeqCandidates =
+                    tacletApp.findIfFormulaInstantiations(g.sequent(), g.proof().getServices());
+
+            if (ifSeqCandidates.size() == 1) {
+                theApp = ifSeqCandidates.head();
+                assert theApp != null;
+                tacletApp = (TacletApp) theApp;
+            }
+
+            RuleApp completeApp = tacletApp.tryToInstantiate(g.proof().getServices());
             theApp = completeApp == null ? theApp : completeApp;
         }
         assert theApp != null;

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
@@ -65,7 +65,7 @@ public class RuleCommand extends AbstractCommand<RuleCommand.Parameters> {
 
             if (!tacletApp.ifInstsComplete()) {
                 ImmutableList<TacletApp> ifSeqCandidates =
-                        tacletApp.findIfFormulaInstantiations(g.sequent(), g.proof().getServices());
+                    tacletApp.findIfFormulaInstantiations(g.sequent(), g.proof().getServices());
 
                 if (ifSeqCandidates.size() == 1) {
                     theApp = ifSeqCandidates.head();

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/scripts/RuleCommand.java
@@ -63,13 +63,15 @@ public class RuleCommand extends AbstractCommand<RuleCommand.Parameters> {
 
         if (theApp instanceof TacletApp tacletApp) {
 
-            ImmutableList<TacletApp> ifSeqCandidates =
-                    tacletApp.findIfFormulaInstantiations(g.sequent(), g.proof().getServices());
+            if (!tacletApp.ifInstsComplete()) {
+                ImmutableList<TacletApp> ifSeqCandidates =
+                        tacletApp.findIfFormulaInstantiations(g.sequent(), g.proof().getServices());
 
-            if (ifSeqCandidates.size() == 1) {
-                theApp = ifSeqCandidates.head();
-                assert theApp != null;
-                tacletApp = (TacletApp) theApp;
+                if (ifSeqCandidates.size() == 1) {
+                    theApp = ifSeqCandidates.head();
+                    assert theApp != null;
+                    tacletApp = (TacletApp) theApp;
+                }
             }
 
             RuleApp completeApp = tacletApp.tryToInstantiate(g.proof().getServices());


### PR DESCRIPTION
Rules in script could not be applied if there were free logical variable schema variables around.

This is the case for class invariant rules and others.

The commit fixes the issue by copying code from how it is done for interactive rule applications.

## Intended Change

More rules can be applied.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I have tested the feature as follows: FM case study

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
