### PR TITLE
saving proofs for sequent problems

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
@@ -209,7 +209,7 @@ public class OutputStreamProofSaver {
                 }
                 final Sequent problemSeq = proof.root().sequent();
                 ps.println("\\problem {");
-                if(problemSeq.antecedent().isEmpty() && problemSeq.succedent().size() == 1) {
+                if (problemSeq.antecedent().isEmpty() && problemSeq.succedent().size() == 1) {
                     // Problem statement is a single formula ...
                     printer.printSemisequent(problemSeq.succedent());
                 } else {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/OutputStreamProofSaver.java
@@ -209,7 +209,13 @@ public class OutputStreamProofSaver {
                 }
                 final Sequent problemSeq = proof.root().sequent();
                 ps.println("\\problem {");
-                printer.printSemisequent(problemSeq.succedent());
+                if(problemSeq.antecedent().isEmpty() && problemSeq.succedent().size() == 1) {
+                    // Problem statement is a single formula ...
+                    printer.printSemisequent(problemSeq.succedent());
+                } else {
+                    // Problem statement is a proper sequent ...
+                    printer.printSequent(problemSeq);
+                }
                 ps.println(printer.result());
                 ps.println("}\n");
             }

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/io/ProofSaverTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/io/ProofSaverTest.java
@@ -1,4 +1,10 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof.io;
+
+import java.io.File;
+import java.io.IOException;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Sequent;
@@ -7,12 +13,8 @@ import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.AbstractProfile;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.rule.TacletForTests;
-import de.uka.ilkd.key.util.KeYConstants;
-import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,7 +26,7 @@ class ProofSaverTest {
         KeyIO.Loader loader = io.load(content);
         Sequent seq = loader.parseFile().loadProblem().getProblem();
         final InitConfig initConfig =
-                new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
+            new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
         Proof proof = new Proof("test", seq, "", initConfig, null);
         File file = File.createTempFile("proofSaveTest", ".key");
         file.deleteOnExit();

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/io/ProofSaverTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/io/ProofSaverTest.java
@@ -1,0 +1,52 @@
+package de.uka.ilkd.key.proof.io;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.logic.Sequent;
+import de.uka.ilkd.key.nparser.KeyIO;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.init.AbstractProfile;
+import de.uka.ilkd.key.proof.init.InitConfig;
+import de.uka.ilkd.key.rule.TacletForTests;
+import de.uka.ilkd.key.util.KeYConstants;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProofSaverTest {
+
+    void testSaveProblemToFile(String content) throws IOException {
+        Services services = TacletForTests.services();
+        KeyIO io = new KeyIO(services);
+        KeyIO.Loader loader = io.load(content);
+        Sequent seq = loader.parseFile().loadProblem().getProblem();
+        final InitConfig initConfig =
+                new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
+        Proof proof = new Proof("test", seq, "", initConfig, null);
+        File file = File.createTempFile("proofSaveTest", ".key");
+        file.deleteOnExit();
+        String status = new ProofSaver(proof, file).save();
+        assertNull(status);
+
+        KeyIO io2 = new KeyIO(services);
+        KeyIO.Loader loader2 = io2.load(content);
+        Sequent seq2 = loader2.parseFile().loadProblem().getProblem();
+
+        assertEquals(seq, seq2);
+    }
+
+    @Test
+    void saveTermProblemToFile() throws IOException {
+        String content = "\\problem { true }";
+        testSaveProblemToFile(content);
+    }
+
+    @Test
+    void saveSequentProblemToFile() throws IOException {
+        String content = "\\problem { true, false ==> false, false }";
+        testSaveProblemToFile(content);
+    }
+}


### PR DESCRIPTION
Parsing sequents in \problem{...} has been supported for a while now. This commit adapts the saving routine accordingly.

## Related Issue

This is unintentionally reported in #3483.
There the actual problem here is shadowed by this problem here.

## Intended Change

Currently sequents can be formulated in the `\problem` section, but cannot be stored.

This fix changes that.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality
 
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
