### PR TITLE
Remove Ctrl+C handling, see #3456

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
@@ -18,7 +18,6 @@ import de.uka.ilkd.key.control.TermLabelVisibilityManager;
 import de.uka.ilkd.key.control.UserInterfaceControl;
 import de.uka.ilkd.key.control.instantiation_model.TacletInstantiationModel;
 import de.uka.ilkd.key.core.KeYMediator;
-import de.uka.ilkd.key.gui.actions.ExitMainAction;
 import de.uka.ilkd.key.gui.mergerule.MergeRuleCompletion;
 import de.uka.ilkd.key.gui.notification.events.GeneralFailureEvent;
 import de.uka.ilkd.key.gui.notification.events.NotificationEvent;
@@ -55,7 +54,6 @@ import org.key_project.util.java.SwingUtil;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.Signal;
 
 /**
  * Implementation of {@link UserInterfaceControl} which controls the {@link MainWindow} with the
@@ -79,19 +77,6 @@ public class WindowUserInterfaceControl extends AbstractMediatorUserInterfaceCon
         completions.add(new BlockContractInternalCompletion(mainWindow));
         completions.add(new BlockContractExternalCompletion(mainWindow));
         completions.add(MergeRuleCompletion.INSTANCE);
-        try {
-            Signal.handle(new Signal("INT"), sig -> {
-                if (getMediator().isInAutoMode()) {
-                    LOGGER.warn("Caught SIGINT, stopping automode...");
-                    getMediator().getUI().getProofControl().stopAutoMode();
-                } else {
-                    LOGGER.warn("Caught SIGINT, exiting...");
-                    new ExitMainAction(mainWindow).exitMainWithoutInteraction();
-                }
-            });
-        } catch (Exception e) {
-            // the above is optional functionality and may not work on every OS
-        }
     }
 
     @Override


### PR DESCRIPTION
Removes the explicit ctrl+c handling in `WindowsUserInterfaceControl`

See bug report: #3456.
