### PR TITLE
Fix for #3501: Decrease log level of duplicate sort warnings

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DeclarationBuilder.java
@@ -183,7 +183,7 @@ public class DeclarationBuilder extends DefaultBuilder {
                 // weigl: agreement on KaKeY meeting: this should be ignored until we finally have
                 // local namespaces for generic sorts
                 // addWarning(ctx, "Sort declaration is ignored, due to collision.");
-                LOGGER.info("Sort declaration of {} in {} is ignored due to collision (already "
+                LOGGER.debug("Sort declaration of {} in {} is ignored due to collision (already "
                     + "present in {}).", sortName, BuilderHelpers.getPosition(ctx),
                     existingSort.getOrigin());
             }


### PR DESCRIPTION
## Description

This pull request addresses #3501. Since this a warning (or better, lots of them) that potentially confuses the users, this very minor PR decreases the log level from INFO to DEBUG.

These duplicate sort declarations in the taclet base have been there for quite a long time and do not break anything. The purpose of the warning is to indicate that we should finally get rid of the duplicate declarations. However, at the moment this is difficult due to the lack of local namespaces for generic sorts.

See also the discussion here: #3302


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
