### PR TITLE
Repairing the NonNull checker framework exception

### DIFF
--- a/key.util/build.gradle
+++ b/key.util/build.gradle
@@ -12,7 +12,7 @@ checkerFramework {
         extraJavacArgs = [
                 "-AonlyDefs=^org\\.key_project\\.util",
                 "-Xmaxerrs", "10000",
-                "-Astubs=$projectDir/src/main/checkerframework:permit-nullness-assertion-exception.astub",
+                "-Astubs=$projectDir/src/main/checkerframework:permit-nullness-assertion-exception.astub:checker.jar/junit-assertions.astub",
                 "-AstubNoWarnIfNotFound",
                 "-Werror",
                 "-Aversion",

--- a/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableMap.java
+++ b/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableMap.java
@@ -4,33 +4,38 @@
 package org.key_project.util.collection;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.key_project.util.Strings;
+
+import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class implements {@code ImmutableMap<S,T>} and provides a persistent map.
  * It is a simple implementation like lists
  */
-@SuppressWarnings("nullness")
-public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
+public final class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
 
     /** the empty map */
+    private static final DefaultImmutableMap<?, ?> EMPTY_MAP = new DefaultImmutableMap<>();
 
     @SuppressWarnings("unchecked")
     public static <S, T> DefaultImmutableMap<S, T> nilMap() {
-        return (DefaultImmutableMap<S, T>) NILMap.EMPTY_MAP;
+        return (DefaultImmutableMap<S, T>) EMPTY_MAP;
     }
 
     /**
      * The map this map builds on. Lookups will also consider entries in this map if the key
      * does not match {@link #entry}.
      */
-    private final DefaultImmutableMap<S, T> parent;
+    private final @Nullable DefaultImmutableMap<S, T> parent;
 
     /**
      * The (key, value) mapping last inserted into this map.
      */
-    private final ImmutableMapEntry<S, T> entry;
+    private final @Nullable ImmutableMapEntry<S, T> entry;
 
     /**
      * Number of entries in the map. Equal to <code>1 + parent.size</code> if entry is not null,
@@ -39,33 +44,18 @@ public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
     private final int size;
 
     /** only for use by NILMap */
-    protected DefaultImmutableMap() {
-        entry = null;
+    private DefaultImmutableMap() {
+        this.entry = null;
         this.parent = null;
         this.size = 0;
     }
 
-
-    /** creates new map with mapping entry */
-    protected DefaultImmutableMap(ImmutableMapEntry<S, T> entry) {
-        if (entry == null) {
-            throw new RuntimeException("'null' is not allowed as entry");
-        }
-        this.entry = entry;
-        this.parent = DefaultImmutableMap.nilMap();
-        this.size = 1;
-    }
-
     /** creates new map with mapping entry and parent map */
-    protected DefaultImmutableMap(ImmutableMapEntry<S, T> entry, DefaultImmutableMap<S, T> parent) {
-        if (entry == null) {
-            throw new IllegalArgumentException("'null' is not allowed as entry");
-        }
-        this.entry = entry;
+    private DefaultImmutableMap(ImmutableMapEntry<S, T> entry, DefaultImmutableMap<S, T> parent) {
+        this.entry = Objects.requireNonNull(entry);
         this.parent = parent;
         this.size = parent.size + 1;
     }
-
 
     /**
      * inserts mapping {@code <key,val>} into the map (old map is not modified) if key exists old
@@ -82,10 +72,13 @@ public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
         return new DefaultImmutableMap<>(new MapEntry<>(key, value), this.remove(key));
     }
 
-
-
-    /** @return value of type T that is mapped by key of type S */
-    public T get(S key) {
+    /**
+     * Retrieves the value mapped to key in this map.
+     *
+     * @param key key to look up
+     * @return value of type T that is mapped by key of type S, null if key is not in the map
+     */
+    public @Nullable T get(S key) {
         DefaultImmutableMap<S, T> queue = this;
         while (!queue.isEmpty()) {
             final ImmutableMapEntry<S, T> e = queue.entry;
@@ -106,8 +99,15 @@ public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
     }
 
     /** returns true if the map is empty */
+    @EnsuresNonNullIf(result = false, expression = { "entry", "parent" })
     public boolean isEmpty() {
-        return false;
+        if (parent == null) {
+            return true;
+        } else {
+            assert entry != null
+                    : "@AssumeAssertion(nullness): entry and parent are both nonnull ...";
+            return false;
+        }
     }
 
     /** @return true iff the map includes key */
@@ -225,25 +225,27 @@ public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
         return Strings.formatAsList(this, "[", ",", "]");
     }
 
+    /**
+     * The equality checks if the argument is another immutable map with the same
+     * entries.
+     *
+     * @return true iff the other object is an immutable map with the same entries
+     */
     @SuppressWarnings("unchecked")
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof ImmutableMap)) {
             return false;
         }
+
         if (o == this) {
             return true;
         }
 
-        ImmutableMap<S, T> o1 = null;
-        try {
-            o1 = (ImmutableMap<S, T>) o;
-            if (o1.size() != size()) {
-                return false;
-            }
-        } catch (ClassCastException cce) {
+        // TODO: This unchecked cast is a bit blunt but seems safe in the current implementations
+        ImmutableMap<S, T> o1 = (ImmutableMap<S, T>) o;
+        if (o1.size() != size()) {
             return false;
         }
-
 
         for (ImmutableMapEntry<S, T> e : this) {
             if (!e.value().equals(o1.get(e.key()))) {
@@ -262,206 +264,114 @@ public class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
         return hashCode;
     }
 
-    /** the empty map */
-    private static class NILMap<S, T> extends DefaultImmutableMap<S, T> {
+    /** iterator for the values */
+    private static abstract class MapIterator<S, T> {
+        // stores the entry iterator
+        private DefaultImmutableMap<S, T> map;
 
-        @SuppressWarnings("rawtypes")
-        static final NILMap<?, ?> EMPTY_MAP = new NILMap();
+        // creates the iterator
+        MapIterator(DefaultImmutableMap<S, T> map) {
+            this.map = map;
+        }
+
+        /** @return true iff there are more elements */
+        public boolean hasNext() {
+            return !map.isEmpty();
+        }
+
+        /** @return next value in list */
+        protected final ImmutableMapEntry<S, T> nextEntry() {
+            if (map.isEmpty()) {
+                throw new IllegalStateException("No more elements in iterator");
+            }
+            final @NonNull ImmutableMapEntry<S, T> entry = map.entry;
+            map = map.parent;
+            return entry;
+        }
 
         /**
-         * generated serial
+         * throws an unsupported operation exception as removing elements is not allowed on
+         * immutable maps
          */
-        private static final long serialVersionUID = 412820308341055305L;
+        public void remove() {
+            throw new UnsupportedOperationException(
+                "Removing elements via an iterator" + " is not supported for immutable maps.");
+        }
+    }
 
-        private NILMap() {
+
+    /** iterator for the values */
+    private static final class MapEntryIterator<S, T> extends MapIterator<S, T>
+            implements Iterator<ImmutableMapEntry<S, T>> {
+
+        MapEntryIterator(DefaultImmutableMap<S, T> map) {
+            super(map);
         }
 
-        public ImmutableMap<S, T> put(S key, T value) {
-            return new DefaultImmutableMap<>(new MapEntry<>(key, value));
+        /** @return next value in list */
+        public ImmutableMapEntry<S, T> next() {
+            return nextEntry();
+        }
+    }
+
+
+    private static final class MapValueIterator<S, T> extends MapIterator<S, T>
+            implements Iterator<T> {
+
+        MapValueIterator(DefaultImmutableMap<S, T> map) {
+            super(map);
         }
 
-        public T get(S key) {
-            return null;
+        /** @return next value in list */
+        public T next() {
+            return nextEntry().value();
+        }
+    }
+
+
+    private static final class MapKeyIterator<S, T> extends MapIterator<S, T>
+            implements Iterator<S> {
+
+        MapKeyIterator(DefaultImmutableMap<S, T> map) {
+            super(map);
         }
 
-        public boolean isEmpty() {
-            return true;
-        }
-
-        public boolean containsKey(S key) {
-            return false;
-        }
-
-        public boolean containsValue(T val) {
-            return false;
-        }
-
-        public DefaultImmutableMap<S, T> remove(S key) {
-            return this;
-        }
-
-        public ImmutableMap<S, T> removeAll(T value) {
-            return this;
-        }
-
-        /** @return iterator for keys */
-        public Iterator<S> keyIterator() {
-            return ImmutableSLList.<S>nil().iterator();
-        }
-
-        /** @return iterator for values */
-        public Iterator<T> valueIterator() {
-            return ImmutableSLList.<T>nil().iterator();
-        }
-
-        /** @return iterator for entries */
-        public Iterator<ImmutableMapEntry<S, T>> iterator() {
-            return ImmutableSLList.<ImmutableMapEntry<S, T>>nil().iterator();
-        }
-
-        public int size() {
-            return 0;
-        }
-
-        public String toString() {
-            return "[(,)]";
+        /** @return next value in list */
+        public S next() {
+            return nextEntry().key();
         }
     }
 
     /**
-     * inner class for the entries
+     * class for the map entries
      *
      * @param key   the key
      * @param value the value
      */
-        private record MapEntry<S,T>(
-    S key, T value)implements ImmutableMapEntry<S,T>
-    {
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6785625761293313622L;
+    // @formatter:off Spotless cannot deal with inner records yet or so it seems :(
+    private record MapEntry<S,T>(S key, T value) implements ImmutableMapEntry<S,T> {
 
-    /**
-     * creates a new map entry that contains key and value
-     */
-    private MapEntry
-    {
-    }
-
-    /**
-     * @return the key stored in this entry
-     */
-    @Override
-    public S key() {
-        return key;
-    }
-
-    /**
-     * @return the value stored in this entry
-     */
-    @Override
-    public T value() {
-        return value;
-    }
-
-    /**
-     * @return true iff both objects have equal pairs of key and value
-     */
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
+        /**
+         * @return true iff both objects have equal pairs of key and value
+         */
+        public boolean equals(@Nullable Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (!(obj instanceof ImmutableMapEntry)) {
+                return false;
+            }
+            @SuppressWarnings("unchecked")
+            final ImmutableMapEntry<S, T> cmp = (ImmutableMapEntry<S, T>) obj;
+            final S cmpKey = cmp.key();
+            final T cmpVal = cmp.value();
+            return (key == cmpKey && value == cmpVal)
+                    || (key.equals(cmpKey) && value.equals(cmpVal));
         }
-        if (!(obj instanceof ImmutableMapEntry)) {
-            return false;
+
+        public String toString() {
+            return key + "->" + value;
         }
-        @SuppressWarnings("unchecked")
-        final ImmutableMapEntry<S, T> cmp = (ImmutableMapEntry<S, T>) obj;
-        final S cmpKey = cmp.key();
-        final T cmpVal = cmp.value();
-        return (key == cmpKey && value == cmpVal)
-                || (key.equals(cmpKey) && value.equals(cmpVal));
     }
-
-    public String toString() {
-        return key + "->" + value;
-    }
-}
-
-
-/** iterator for the values */
-private static abstract class MapIterator<S, T> {
-    // stores the entry iterator
-    private DefaultImmutableMap<S, T> map;
-
-    // creates the iterator
-    MapIterator(DefaultImmutableMap<S, T> map) {
-        this.map = map;
-    }
-
-    /** @return true iff there are more elements */
-    public boolean hasNext() {
-        return !map.isEmpty();
-    }
-
-    /** @return next value in list */
-    protected final ImmutableMapEntry<S, T> nextEntry() {
-        final ImmutableMapEntry<S, T> entry = map.entry;
-        map = map.parent;
-        return entry;
-    }
-
-    /**
-     * throws an unsupported operation exception as removing elements is not allowed on
-     * immutable maps
-     */
-    public void remove() {
-        throw new UnsupportedOperationException(
-            "Removing elements via an iterator" + " is not supported for immutable maps.");
-    }
-}
-
-
-/** iterator for the values */
-private static final class MapEntryIterator<S, T> extends MapIterator<S, T>
-        implements Iterator<ImmutableMapEntry<S, T>> {
-
-    MapEntryIterator(DefaultImmutableMap<S, T> map) {
-        super(map);
-    }
-
-    /** @return next value in list */
-    public ImmutableMapEntry<S, T> next() {
-        return nextEntry();
-    }
-}
-
-
-private static final class MapValueIterator<S, T> extends MapIterator<S, T>
-        implements Iterator<T> {
-
-    MapValueIterator(DefaultImmutableMap<S, T> map) {
-        super(map);
-    }
-
-    /** @return next value in list */
-    public T next() {
-        return nextEntry().value();
-    }
-}
-
-
-private static final class MapKeyIterator<S, T> extends MapIterator<S, T>
-        implements Iterator<S> {
-
-    MapKeyIterator(DefaultImmutableMap<S, T> map) {
-        super(map);
-    }
-
-    /** @return next value in list */
-    public S next() {
-        return nextEntry().key();
-    }
-}
 
 }

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
@@ -8,12 +8,13 @@ import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.jspecify.annotations.Nullable;
 import org.key_project.util.Strings;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
-public class ImmutableArray<S extends @Nullable Object> implements java.lang.Iterable<S>, java.io.Serializable {
+public class ImmutableArray<S extends @Nullable Object>
+        implements java.lang.Iterable<S>, java.io.Serializable {
 
     private static final long serialVersionUID = -9041545065066866250L;
 

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
@@ -4,24 +4,17 @@
 package org.key_project.util.collection;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.jspecify.annotations.Nullable;
 import org.key_project.util.Strings;
 
 import org.jspecify.annotations.NonNull;
 
-@SuppressWarnings("nullness")
-public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Serializable {
+public class ImmutableArray<S extends @Nullable Object> implements java.lang.Iterable<S>, java.io.Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -9041545065066866250L;
 
     private final S[] content;
@@ -41,13 +34,14 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
      */
     @SuppressWarnings("unchecked")
     public ImmutableArray(S... arr) {
-        content = (S[]) Array.newInstance(arr.getClass().getComponentType(), arr.length);
-        System.arraycopy(arr, 0, content, 0, arr.length);
+        this(arr, 0, arr.length);
     }
 
     @SuppressWarnings("unchecked")
     public ImmutableArray(S[] arr, int lower, int upper) {
-        content = (S[]) Array.newInstance(arr.getClass().getComponentType(), upper - lower);
+        Class<? extends Object[]> arrayClass = arr.getClass();
+        assert arrayClass.isArray() : "@AssumeAssertion(nullness): arrayClass is an array";
+        content = (S[]) Array.newInstance(arrayClass.getComponentType(), upper - lower);
         System.arraycopy(arr, lower, content, 0, upper - lower);
     }
 
@@ -101,7 +95,7 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
 
     public boolean contains(S op) {
         for (S el : content) {
-            if (el.equals(op)) {
+            if (Objects.equals(el, op)) {
                 return true;
             }
         }
@@ -117,7 +111,9 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
     public <T> T[] toArray(T[] array) {
         T[] result;
         if (array.length < size()) {
-            result = (T[]) Array.newInstance(array.getClass().getComponentType(), content.length);
+            Class<? extends Object[]> arrayClass = array.getClass();
+            assert arrayClass.isArray() : "@AssumeAssertion(nullness): arrayClass is an array";
+            result = (T[]) Array.newInstance(arrayClass.getComponentType(), content.length);
         } else {
             result = array;
         }
@@ -131,15 +127,14 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (o == this) {
             return true;
         }
 
-        final S[] cmp;
+        final @Nullable Object @Nullable [] cmp;
         if (o instanceof ImmutableArray) {
-            cmp = ((ImmutableArray<S>) o).content;
+            cmp = ((ImmutableArray<?>) o).content;
         } else {
             return false;
         }
@@ -149,7 +144,7 @@ public class ImmutableArray<S> implements java.lang.Iterable<S>, java.io.Seriali
         }
 
         for (int i = 0; i < content.length; i++) {
-            if (!content[i].equals(cmp[i])) {
+            if (!Objects.equals(content[i], cmp[i])) {
                 return false;
             }
         }

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
@@ -5,59 +5,113 @@ package org.key_project.util.collection;
 
 import java.util.Iterator;
 
+import org.jspecify.annotations.Nullable;
 
 /**
- * This interface has to be implemented by a Class providing a persistent Map.
+ * An immutable data structure mapping keys to values. The map is not modified by any operation
+ * after creation.
+ *
+ * @param <S> the type of keys for this map
+ * @param <T> the type of contained mapped values
  */
-public interface ImmutableMap<S, T>
+public interface ImmutableMap<S, T extends @Nullable Object>
         extends Iterable<ImmutableMapEntry<S, T>> {
 
     /**
-     * adds a mapping {@code <key,val>} to the Map (old map is not modified) if key exists old entry
-     * has to
-     * be removed
+     * Adds a mapping {@code <key, value>} to the map (old map is not modified)
      *
+     * If the key exists, the old entry will be overwritten.
+     *
+     * @param key the key with which the specified value is to be associated
+     * @param value the value to be associated with the specified key
      * @return the new mapping
      */
     ImmutableMap<S, T> put(S key, T value);
 
-    /** @return value of type <T> that is mapped by key of type<S> */
-    T get(S key);
+    /**
+     * Retrieves the value mapped to the specified key in this map.
+     *
+     * @param key the key whose associated value is to be returned
+     * @return the value to which the specified key is mapped, or {@code null} if this map contains
+     *         no mapping for the key
+     */
+    @Nullable T get(S key);
 
-    /** @return number of entries as int */
+    /**
+     * Returns the number of entries in this map.
+     *
+     * @return the number of entries in this map
+     */
     int size();
 
-    /** @return true iff the map is empty */
+    /**
+     * Returns {@code true} if this map contains no entries.
+     *
+     * @return {@code true} if this map contains no entries
+     */
     boolean isEmpty();
 
-    /** @return true iff the map includes key */
+    /**
+     * Returns {@code true} if this map contains a mapping for the specified key.
+     *
+     * @param key the key whose presence in this map is to be tested
+     * @return {@code true} if this map contains a mapping for the specified key
+     */
     boolean containsKey(S key);
 
-    /** @return true iff the map includes value */
+    /**
+     * Returns {@code true} if this map maps one or more keys to the specified value.
+     *
+     * Comparison is modulo {@link Object#equals(Object)}.
+     *
+     * @param value the value whose presence in this map is to be tested
+     * @return {@code true} if this map maps one or more keys to the specified value
+     */
     boolean containsValue(T value);
 
     /**
-     * removes mapping (key,...) from map
+     * Removes the mapping for a key from this map if it is present.
      *
-     * @return the new map (the same if key is not in the map)
+     * @param key the key whose mapping is to be removed from the map
+     * @return the new map (the same if the key is not in the map)
      */
     ImmutableMap<S, T> remove(S key);
 
     /**
-     * removes all mappings (...,value) from map
+     * Removes all mappings for the specified value from this map.
      *
-     * @return the new map (the same if value is not mapped)
+     * Comparison is modulo {@link Object#equals(Object)}.
+     *
+     * @param value the value whose mappings are to be removed from the map
+     * @return the new map (the same if the value is not mapped)
      */
     ImmutableMap<S, T> removeAll(T value);
 
-    /** @return iterator about all keys */
+    /**
+     * Returns an iterator over the keys in this map.
+     *
+     * The order is most recent first.
+     *
+     * @return an iterator over the keys in this map
+     */
     Iterator<S> keyIterator();
 
-    /** @return iterator about all values */
+    /**
+     * Returns an iterator over the values in this map.
+     *
+     * If a value is contained multiple times, it will be returned multiple times.
+     * The order is most recent first.
+     *
+     * @return an iterator over the values in this map
+     */
     Iterator<T> valueIterator();
 
-    /** @return iterator for entries */
+
+    /**
+     * Returns an iterator over the entries in this map.
+     * The order is most recent first.
+     *
+     * @return an iterator over the entries in this map
+     */
     Iterator<ImmutableMapEntry<S, T>> iterator();
-
-
 }

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
@@ -5,6 +5,7 @@ package org.key_project.util.collection;
 
 import java.util.Iterator;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -14,7 +15,7 @@ import org.jspecify.annotations.Nullable;
  * @param <S> the type of keys for this map
  * @param <T> the type of contained mapped values
  */
-public interface ImmutableMap<S, T extends @Nullable Object>
+public interface ImmutableMap<S extends @NonNull Object, T extends @Nullable Object>
         extends Iterable<ImmutableMapEntry<S, T>> {
 
     /**

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableMap.java
@@ -36,7 +36,8 @@ public interface ImmutableMap<S extends @NonNull Object, T extends @Nullable Obj
      * @return the value to which the specified key is mapped, or {@code null} if this map contains
      *         no mapping for the key
      */
-    @Nullable T get(S key);
+    @Nullable
+    T get(S key);
 
     /**
      * Returns the number of entries in this map.

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableMapEntry.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableMapEntry.java
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.collection;
 
+import org.checkerframework.checker.nullness.qual.KeyForBottom;
+import org.jspecify.annotations.Nullable;
+
 /**
  * This interface declares a tupel of two values. The first one is of type <S> and named key, the
  * second one is of type <T> and named value
+ *
+ * For type annotations see Florian Lanzinger or Werner Dietl. :)
+ * https://eisop.github.io/cf/manual/manual.html#map-key-defaults-lowerbound
  */
 
-public interface ImmutableMapEntry<S, T> {
+public interface ImmutableMapEntry<@KeyForBottom S, @KeyForBottom T extends @Nullable Object> {
 
     /** @return the first part of the tupel */
     S key();

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
@@ -97,7 +97,8 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
         for (int i = 0, sz = size(); i < sz; i++) {
             // @ assert !rest.isEmpty();
             T head = rest.head();
-            result[i] = type.cast(head);
+            // Somehow the nullness checker needs this cast to be explicit.
+            result[i] = (S)type.cast(head);
             rest = rest.tail();
         }
         return result;

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
@@ -98,7 +98,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
             // @ assert !rest.isEmpty();
             T head = rest.head();
             // Somehow the nullness checker needs this cast to be explicit.
-            result[i] = (S)type.cast(head);
+            result[i] = (S) type.cast(head);
             rest = rest.tail();
         }
         return result;

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
@@ -91,14 +91,13 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
      * Convert the list to a Java array (O(n))
      */
     @Override
-    @SuppressWarnings("nullness")
     public <S extends @Nullable Object> S[] toArray(Class<S> type) {
         S[] result = (S[]) Array.newInstance(type, size());
         ImmutableList<T> rest = this;
         for (int i = 0, sz = size(); i < sz; i++) {
             // @ assert !rest.isEmpty();
             T head = rest.head();
-            result[i] = (S) type.cast(head);
+            result[i] = type.cast(head);
             rest = rest.tail();
         }
         return result;

--- a/key.util/src/main/java/org/key_project/util/collection/Immutables.java
+++ b/key.util/src/main/java/org/key_project/util/collection/Immutables.java
@@ -210,7 +210,7 @@ public final class Immutables {
     public static <T extends @Nullable Object, R extends @Nullable Object> ImmutableList<R> map(
             ImmutableList<T> ts, Function<? super T, R> function) {
         // This must be a loop. A tail recursive implementation is not optimised
-        // by the compiler and quickly leads to a stack overlow.
+        // by the compiler and quickly leads to a stack overflow.
         ImmutableList<R> acc = ImmutableSLList.nil();
         while (!ts.isEmpty()) {
             T hd = ts.head();

--- a/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
@@ -1,0 +1,124 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DefaultImmutableMapTest {
+
+    private ImmutableMap<String, Integer> map;
+
+    @BeforeEach
+    public void setUp() {
+        map = DefaultImmutableMap.nilMap();
+    }
+
+    @Test
+    public void testPutAndGet() {
+        map = map.put("one", 1);
+        assertEquals(1, map.get("one"));
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(0, map.size());
+        map = map.put("one", 1);
+        assertEquals(1, map.size());
+        map = map.put("two", 1);
+        assertEquals(2, map.size());
+        map = map.put("two", 2);
+        assertEquals(2, map.size());
+        map = map.put("one", 3);
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(map.isEmpty());
+        map = map.put("one", 1);
+        assertFalse(map.isEmpty());
+    }
+
+    @Test
+    public void testContainsKey() {
+        map = map.put("one", 1);
+        assertTrue(map.containsKey("one"));
+        assertFalse(map.containsKey("two"));
+    }
+
+    @Test
+    public void testContainsValue() {
+        map = map.put("one", 1);
+        assertTrue(map.containsValue(1));
+        assertFalse(map.containsValue(2));
+    }
+
+    @Test
+    public void testRemove() {
+        map = map.put("one", 1);
+        map = map.remove("one");
+        assertFalse(map.containsKey("one"));
+        assertEquals(0, map.size());
+
+        map = DefaultImmutableMap.nilMap();
+        map = map.put("one", 1);
+        map = map.remove("two");
+        assertTrue(map.containsKey("one"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testRemoveAll() {
+        map = map.put("one", 1);
+        map = map.put("two", 1);
+        map = map.removeAll(1);
+        assertFalse(map.containsValue(1));
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testKeyIterator() {
+        map = map.put("one", 1);
+        map = map.put("two", 2);
+        Iterator<String> iterator = map.keyIterator();
+        assertTrue(iterator.hasNext());
+        assertEquals("two", iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals("one", iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testValueIterator() {
+        map = map.put("one", 1);
+        map = map.put("two", 2);
+        Iterator<Integer> iterator = map.valueIterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(2, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(1, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator() {
+        map = map.put("one", 1);
+        map = map.put("two", 2);
+        Iterator<ImmutableMapEntry<String, Integer>> iterator = map.iterator();
+        assertTrue(iterator.hasNext());
+        ImmutableMapEntry<String, Integer> entry = iterator.next();
+        assertEquals("two", entry.key());
+        assertEquals(2, entry.value());
+        assertTrue(iterator.hasNext());
+        entry = iterator.next();
+        assertEquals("one", entry.key());
+        assertEquals(1, entry.value());
+        assertFalse(iterator.hasNext());
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
@@ -5,6 +5,8 @@ package org.key_project.util.collection;
 
 import java.util.Iterator;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class DefaultImmutableMapTest {
 
-    private ImmutableMap<String, Integer> map;
+    private @MonotonicNonNull ImmutableMap<String, Integer> map;
 
     @BeforeEach
     public void setUp() {
@@ -21,12 +23,16 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testPutAndGet() {
+        assertNotNull(map);
         map = map.put("one", 1);
-        assertEquals(1, map.get("one"));
+        Integer one = map.get("one");
+        assertNotNull(one);
+        assertEquals(1, one);
     }
 
     @Test
     public void testSize() {
+        assertNotNull(map);
         assertEquals(0, map.size());
         map = map.put("one", 1);
         assertEquals(1, map.size());
@@ -40,6 +46,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testIsEmpty() {
+        assertNotNull(map);
         assertTrue(map.isEmpty());
         map = map.put("one", 1);
         assertFalse(map.isEmpty());
@@ -47,6 +54,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testContainsKey() {
+        assertNotNull(map);
         map = map.put("one", 1);
         assertTrue(map.containsKey("one"));
         assertFalse(map.containsKey("two"));
@@ -54,6 +62,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testContainsValue() {
+        assertNotNull(map);
         map = map.put("one", 1);
         assertTrue(map.containsValue(1));
         assertFalse(map.containsValue(2));
@@ -61,6 +70,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testRemove() {
+        assertNotNull(map);
         map = map.put("one", 1);
         map = map.remove("one");
         assertFalse(map.containsKey("one"));
@@ -75,6 +85,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testRemoveAll() {
+        assertNotNull(map);
         map = map.put("one", 1);
         map = map.put("two", 1);
         map = map.removeAll(1);
@@ -84,6 +95,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testKeyIterator() {
+        assertNotNull(map);
         map = map.put("one", 1);
         map = map.put("two", 2);
         Iterator<String> iterator = map.keyIterator();
@@ -96,6 +108,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testValueIterator() {
+        assertNotNull(map);
         map = map.put("one", 1);
         map = map.put("two", 2);
         Iterator<Integer> iterator = map.valueIterator();
@@ -108,6 +121,7 @@ public class DefaultImmutableMapTest {
 
     @Test
     public void testIterator() {
+        assertNotNull(map);
         map = map.put("one", 1);
         map = map.put("two", 2);
         Iterator<ImmutableMapEntry<String, Integer>> iterator = map.iterator();

--- a/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/DefaultImmutableMapTest.java
@@ -6,7 +6,6 @@ package org.key_project.util.collection;
 import java.util.Iterator;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/key.util/src/test/java/org/key_project/util/testcase/collection/TestMapAsListFromIntegerToString.java
+++ b/key.util/src/test/java/org/key_project/util/testcase/collection/TestMapAsListFromIntegerToString.java
@@ -86,9 +86,13 @@ public class TestMapAsListFromIntegerToString {
         // another key before
         Integer hundred = 100;
         map = map.put(hundred, entryStr[1]);
-        assertSame(map.get(hundred), entryStr[1],
+        String valHundred = map.get(hundred);
+        assertNotNull(valHundred);
+        assertSame(valHundred, entryStr[1],
             entryStr[1] + " is not mapped to the newer key 100");
-        assertSame(map.get(entryInt[1]), entryStr[1],
+        String val1 = map.get(entryInt[1]);
+        assertNotNull(val1);
+        assertSame(val1, entryStr[1],
             entryStr[1] + " is not mapped to the older key " + entryInt[1]);
     }
 


### PR DESCRIPTION
## Related Issue

For a while the checker framework raised an exception during CI. This adds type annotations to remove the errors-

## Intended Change

No more failing CI.

I refactored the util classes a bit, but there should be no different behaviour.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change change)

## Ensuring quality
   
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality / existing functionality

## Additional information and contact(s)

See https://eisop.github.io/cf/manual/manual.html#map-key-defaults-lowerbound for details on the fix.

Thanks to @wmdietl  and @flo2702 for fixing this with me.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
