### PR TITLE
Fix copyright notice

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/util/KeYConstants.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/KeYConstants.java
@@ -10,6 +10,6 @@ public interface KeYConstants {
         KeYResourceManager.getManager().getVersion() + " (internal: " + INTERNAL_VERSION + ")";
 
     String COPYRIGHT = UnicodeHelper.COPYRIGHT + " Copyright 2001"
-        + UnicodeHelper.ENDASH + "2023 " + "Karlsruhe Institute of Technology, "
+        + UnicodeHelper.ENDASH + "2024 " + "Karlsruhe Institute of Technology, "
         + "Chalmers University of Technology, and Technische Universit\u00e4t Darmstadt";
 }


### PR DESCRIPTION
## Intended Change

Changes the copyright notice in the "about" dialog to read "2001 – 2024" instead of "2023"
