### PR TITLE
Fix for visual bug with overlapping/unreadable text in color settings

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
@@ -75,7 +75,10 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
             }
 
             private Icon drawRect(Color c, int size) {
-                BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+                /* Not sure if the alpha channel is used. Highlights seem to be blended correctly
+                 * even if the color is not transparent at all. However, make sure to use ARGB to
+                 * avoid black icons here ... */
+                BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
                 Graphics g = bi.getGraphics();
                 g.setColor(c);
                 g.fillRect(0, 0, size, size);
@@ -167,6 +170,10 @@ class HexColorCellEditor extends DefaultCellEditor {
 
     HexColorCellEditor(JTextField textField) {
         super(textField);
+
+        // this is somehow important to avoid visual artifacts such as overlapping text:
+        textField.setOpaque(false);
+
         textField.addActionListener(e -> stopCellEditing());
         textField.getDocument().addDocumentListener(new DocumentListener() {
             @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
@@ -75,9 +75,11 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
             }
 
             private Icon drawRect(Color c, int size) {
-                /* Not sure if the alpha channel is used. Highlights seem to be blended correctly
+                /*
+                 * Not sure if the alpha channel is used. Highlights seem to be blended correctly
                  * even if the color is not transparent at all. However, make sure to use ARGB to
-                 * avoid black icons here ... */
+                 * avoid black icons here ...
+                 */
                 BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
                 Graphics g = bi.getGraphics();
                 g.setColor(c);


### PR DESCRIPTION
This PR fixes a visual bug in the Options dialog when changing the colors.
The bug was originally discovered by @BookWood7th (on Windows, but I think that is irrelevant), who also provided this screenshot that shows the problem:

![Screenshot 2024-08-23 142549](https://github.com/user-attachments/assets/2a9d9653-f178-4201-a9f3-d3750dfdb804)


## Intended Change
* Fix of the visual bug where during editing of a color text field, the text gets unreadable and weirdly overlaps. The fix was to set the field to transparent. I do not know why it works, but somehow opaque components do not work correctly with background colors that also contain alpha.
* Fix: For the preview icons besides the color (in non-edited cells), the alpha channel was not correctly interpreted: It seems that it was interpreted as if the background was black. When merged with the non-alpha part, it resulted in colors that are usually not shown in the GUI (since the background color is not black there). Now, background is interpreted as white, which is much better in my opinion (compare for instance the first two colors between the screenshots: they represent the same color code!).

New screenshot with the fix:
![image](https://github.com/user-attachments/assets/75c524c2-6079-418a-8be6-487be87ca23a)


## Type of pull request

- [x] Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- There are changes to the taclet rule base
- There are changes to the deployment/CI infrastructure (gradle, github, ...)
- Other: 

## Ensuring quality
    
- [x] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: Manual inspection in GUI.
- I have checked that runtime performance has not deteriorated.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
