### PR TITLE
Option to disable ProofTree tooltips, render them lazily

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -112,6 +112,9 @@ public class ViewSettings extends AbstractPropertiesSettings {
     /** this setting enables/disables tool tips in the source view */
     private static final String SOURCE_VIEW_TOOLTIP = "SourceViewTooltips";
 
+    /** this setting enables/disables tool tips in the proof tree */
+    private static final String PROOF_TREE_TOOLTIP = "ProofTreeTooltips";
+
     private static final String HIGHLIGHT_ORIGIN = "HighlightOrigin";
     /**
      *
@@ -202,6 +205,8 @@ public class ViewSettings extends AbstractPropertiesSettings {
         createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showSourceViewTooltips =
         createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
+    private final PropertyEntry<Boolean> showProofTreeTooltips =
+        createBooleanProperty(PROOF_TREE_TOOLTIP, true);
     private final PropertyEntry<Boolean> highlightOrigin =
         createBooleanProperty(HIGHLIGHT_ORIGIN, true);
     private final PropertyEntry<Set<String>> clutterRules =
@@ -537,6 +542,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
 
     public void setShowSourceViewTooltips(boolean showSourceViewTooltips) {
         this.showSourceViewTooltips.set(showSourceViewTooltips);
+    }
+
+    public boolean isShowProofTreeTooltips() {
+        return showProofTreeTooltips.get();
+    }
+
+    public void setShowProofTreeTooltips(boolean showProofTreeTooltips) {
+        this.showProofTreeTooltips.set(showProofTreeTooltips);
     }
 
     public double getUIFontSizeFactor() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -1461,7 +1461,8 @@ public final class MainWindow extends JFrame {
     }
 
     public void setShowProofTreeTooltip(Object source) {
-        toogleProofTreeTooltipAction.actionPerformed(new ActionEvent(proofTreeView, ActionEvent.ACTION_PERFORMED, ""));
+        toogleProofTreeTooltipAction
+                .actionPerformed(new ActionEvent(proofTreeView, ActionEvent.ACTION_PERFORMED, ""));
     }
 
     public AutoModeAction getAutoModeAction() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -164,6 +164,8 @@ public final class MainWindow extends JFrame {
         new ToggleSequentViewTooltipAction(this);
     private final ToggleSourceViewTooltipAction toggleSourceViewTooltipAction =
         new ToggleSourceViewTooltipAction(this);
+    private final ToggleProofTreeTooltipAction toogleProofTreeTooltipAction =
+        new ToggleProofTreeTooltipAction(this);
     private final TermLabelMenu termLabelMenu;
     private boolean frozen = false;
     /**
@@ -930,6 +932,7 @@ public final class MainWindow extends JFrame {
         view.add(new JCheckBoxMenuItem(hidePackagePrefixToggleAction));
         view.add(new JCheckBoxMenuItem(toggleSequentViewTooltipAction));
         view.add(new JCheckBoxMenuItem(toggleSourceViewTooltipAction));
+        view.add(new JCheckBoxMenuItem(toogleProofTreeTooltipAction));
 
         view.addSeparator();
         {
@@ -1455,6 +1458,10 @@ public final class MainWindow extends JFrame {
 
     public boolean isShowTacletInfo() {
         return mainFrame.isShowTacletInfo();
+    }
+
+    public void setShowProofTreeTooltip(Object source) {
+        toogleProofTreeTooltipAction.actionPerformed(new ActionEvent(proofTreeView, ActionEvent.ACTION_PERFORMED, ""));
     }
 
     public AutoModeAction getAutoModeAction() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleProofTreeTooltipAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleProofTreeTooltipAction.java
@@ -1,0 +1,58 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.actions;
+
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Toggles the tooltips of the proof tree.
+ *
+ * @author Wolfram Pfeifer
+ */
+public class ToggleProofTreeTooltipAction extends MainWindowAction {
+    /** This action's name. */
+    public static final String NAME = "Show Tooltips in Proof Tree";
+
+    /** This action's tooltip. */
+    public static final String TOOL_TIP = "If ticked, moving the mouse over a node in the proof"
+        + " tree will show a tooltip with additional information.";
+
+    /**
+     * Create a new action.
+     *
+     * @param mainWindow the main window.
+     */
+    public ToggleProofTreeTooltipAction(MainWindow mainWindow) {
+        super(mainWindow);
+        setName(NAME);
+        setTooltip(TOOL_TIP);
+        // Listens to changes to the view settings to call {@link #updateSelectedState()}.
+        PropertyChangeListener viewSettingsListener = e -> updateSelectedState();
+        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                .addPropertyChangeListener(viewSettingsListener);
+        updateSelectedState();
+    }
+
+    /**
+     * Updates the state of this action according to {@link ViewSettings#isShowProofTreeTooltips()}
+     */
+    protected void updateSelectedState() {
+        final boolean setting =
+            ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isShowProofTreeTooltips();
+        setSelected(setting);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        boolean selected = ((JCheckBoxMenuItem) e.getSource()).isSelected();
+        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                .setShowProofTreeTooltips(selected);
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleProofTreeTooltipAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleProofTreeTooltipAction.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions;
 
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.*;
+
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ViewSettings;
-
-import javax.swing.*;
-import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeListener;
 
 /**
  * Toggles the tooltips of the proof tree.

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
@@ -10,12 +10,12 @@ import de.uka.ilkd.key.gui.docking.DynamicCMenu;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 import bibliothek.gui.dock.common.action.CAction;
 import bibliothek.gui.dock.common.action.CButton;
 import bibliothek.gui.dock.common.action.CCheckBox;
 import bibliothek.gui.dock.common.action.CMenu;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 import static de.uka.ilkd.key.gui.prooftree.ProofTreePopupFactory.ICON_SIZE;
 
@@ -140,11 +140,13 @@ public class ProofTreeSettingsMenuFactory {
         CCheckBox check = new CCheckBox() {
             @Override
             protected void changed() {
-                /* The ToogleProofTreeTooltipAction (in the View menu) is updated via
-                 * PropertyChangeListener, no manual update needed! */
+                /*
+                 * The ToogleProofTreeTooltipAction (in the View menu) is updated via
+                 * PropertyChangeListener, no manual update needed!
+                 */
                 final boolean selected = isSelected();
                 ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                    .setShowProofTreeTooltips(selected);
+                        .setShowProofTreeTooltips(selected);
             }
         };
         check.setText("Show Tooltips");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSettingsMenuFactory.java
@@ -15,6 +15,7 @@ import bibliothek.gui.dock.common.action.CAction;
 import bibliothek.gui.dock.common.action.CButton;
 import bibliothek.gui.dock.common.action.CCheckBox;
 import bibliothek.gui.dock.common.action.CMenu;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 import static de.uka.ilkd.key.gui.prooftree.ProofTreePopupFactory.ICON_SIZE;
 
@@ -39,6 +40,7 @@ public class ProofTreeSettingsMenuFactory {
             menu.addSeparator();
 
             menu.add(createExpandOSSToggle(view));
+            menu.add(createTooltipToggle());
             menu.add(createTacletInfoToggle());
             return menu;
         };
@@ -131,6 +133,25 @@ public class ProofTreeSettingsMenuFactory {
         };
         check.setText("Show taclet info (inner nodes only)");
         check.setSelected(MainWindow.getInstance().isShowTacletInfo());
+        return check;
+    }
+
+    private static CCheckBox createTooltipToggle() {
+        CCheckBox check = new CCheckBox() {
+            @Override
+            protected void changed() {
+                /* The ToogleProofTreeTooltipAction (in the View menu) is updated via
+                 * PropertyChangeListener, no manual update needed! */
+                final boolean selected = isSelected();
+                ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                    .setShowProofTreeTooltips(selected);
+            }
+        };
+        check.setText("Show Tooltips");
+        // No PropertyChangeListener needed, since the menu is always freshly generated.
+        final boolean setting =
+            ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isShowProofTreeTooltips();
+        check.setSelected(setting);
         return check;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -177,6 +177,33 @@ public class ProofTreeView extends JPanel implements TabPanel {
             private static final long serialVersionUID = 6555955929759162324L;
 
             @Override
+            public String getToolTipText(MouseEvent mouseEvent) {
+                /* For performance reasons, we want to make sure that the tooltips are only rendered
+                 * when they are really needed. Therefore, they are now lazily generated and can
+                 * also be disabled completely. */
+                if (!ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                    .isShowProofTreeTooltips()) {
+                    return null;
+                }
+                TreePath path = delegateView.getPathForLocation(mouseEvent.getX(),
+                    mouseEvent.getY());
+                if (path == null) {
+                    return null;
+                }
+                var last = path.getLastPathComponent();
+
+                if (last instanceof GUIAbstractTreeNode node) {
+
+                    Style style = renderer.initStyleForNode(node);
+                    if (style.tooltip != null) {
+                        return renderTooltip(style.tooltip);
+                    }
+                }
+
+                return super.getToolTipText(mouseEvent);
+            }
+
+            @Override
             public void setFont(Font font) {
                 iconHeight = font.getSize();
                 super.setFont(font);
@@ -1243,16 +1270,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
 
-            Style style = new Style();
-            style.foreground = getForeground();
-            style.background = getBackground();
-            // Normalize whitespace
-            style.text = value.toString().replaceAll("\\s+", " ");
-            style.border = null;
-            style.tooltip = new Style.Tooltip();
-            style.icon = null;
-
-            stylers.forEach(it -> it.style(style, node));
+            Style style = initStyleForNode(node);
 
             setForeground(style.foreground);
             setBackground(style.background);
@@ -1265,12 +1283,32 @@ public class ProofTreeView extends JPanel implements TabPanel {
             }
 
             setFont(getFont().deriveFont(Font.PLAIN));
-            String tooltip = renderTooltip(style.tooltip);
-            setToolTipText(tooltip);
+            // For performance reasons, we render the tooltips now lazily ...
+            // String tooltip = renderTooltip(style.tooltip);
+            // setToolTipText(tooltip);
             setText(style.text);
             setIcon(style.icon);
 
             return this;
+        }
+
+        /**
+         * Creates a new Style object and fills it for the given node.
+         * @param node the tree node
+         * @return the created Style with all the info about the node
+         */
+        public Style initStyleForNode(GUIAbstractTreeNode node) {
+            Style style = new Style();
+            style.foreground = getForeground();
+            style.background = getBackground();
+            // Normalize whitespace
+            style.text = node.toString().replaceAll("\\s+", " ");
+            style.border = null;
+            style.tooltip = new Style.Tooltip();
+            style.icon = null;
+
+            stylers.forEach(it -> it.style(style, node));
+            return style;
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -178,11 +178,13 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
             @Override
             public String getToolTipText(MouseEvent mouseEvent) {
-                /* For performance reasons, we want to make sure that the tooltips are only rendered
+                /*
+                 * For performance reasons, we want to make sure that the tooltips are only rendered
                  * when they are really needed. Therefore, they are now lazily generated and can
-                 * also be disabled completely. */
+                 * also be disabled completely.
+                 */
                 if (!ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                    .isShowProofTreeTooltips()) {
+                        .isShowProofTreeTooltips()) {
                     return null;
                 }
                 TreePath path = delegateView.getPathForLocation(mouseEvent.getX(),
@@ -1294,6 +1296,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
         /**
          * Creates a new Style object and fills it for the given node.
+         *
          * @param node the tree node
          * @return the created Style with all the info about the node
          */


### PR DESCRIPTION
Trying to solve #3500, this PR does two things:
* It adds an option to disable the ProofTree tooltips, as requested for example by @unp1 and @mattulbrich. This option can be set in the options of the proof tree (gear icon) as well as in the global menu via "View" -> "Show ProofTree Tooltips" (where the SequentView and SourceView tooltips also can be toggled).
* A tooltip is now lazily rendered directly when it is needed, not already during creation of the GUITreeNode.

## Related Issue

This pull request addresses #3500.

## Type of pull request

- [x] Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- [x] There are changes to the (Java) code
- There are changes to the taclet rule base
- There are changes to the deployment/CI infrastructure (gradle, github, ...)
- Other: 

## Ensuring quality
   
- [x] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- I added new test case(s) for new functionality.
- [x] I have tested the feature as follows: manual inspection and testing in the GUI
- [x] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
