### PR TITLE
Add conversion rules for Float/Double negation

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/floatRulesAssumeStrictfp.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/floatRulesAssumeStrictfp.key
@@ -8,6 +8,11 @@
 }
 
 \rules(programRules:Java, floatRules:assumeStrictfp) {
+    translateJavaUnaryMinusFloat {
+        \find(javaUnaryMinusFloat(f1))
+        \replacewith(negFloat(f1))
+        \heuristics(javaFloatSemantics)
+    };
 
     translateJavaAddFloat {
         \find(javaAddFloat(f1, f2))
@@ -30,6 +35,12 @@
     translateJavaDivFloat {
         \find(javaDivFloat(f1, f2))
         \replacewith(divFloat(f1, f2))
+        \heuristics(javaFloatSemantics)
+    };
+
+    translateJavaUnaryMinusDouble {
+        \find(javaUnaryMinusDouble(d1))
+        \replacewith(negDouble(d1))
         \heuristics(javaFloatSemantics)
     };
 


### PR DESCRIPTION
It seems that there are two rules missing which convert from javaUnaryMinusFloat/Double to negFloat/negDouble. Without these rules, KeY (and also the SMT float conversion) can not prove very much when a negation occurs, since the function will just be left uninterpreted.
 
This PR just adds the two missing rules.

Caveat: Somebody with more knowledge about floating points should double-check this PR (I think it should be sound but am not 100% sure).

## Type of pull request

-[x] Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- There are changes to the (Java) code
-[x] There are changes to the taclet rule base
- There are changes to the deployment/CI infrastructure (gradle, github, ...)
- Other: 

## Ensuring quality
  
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: ...
- I have checked that runtime performance has not deteriorated.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
