### PR TITLE
Set the Java Release Version to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ subprojects {
     version = rootProject.version
 
     java {
-        sourceCompatibility = 17
-        targetCompatibility = 17
+        sourceCompatibility = 21
+        targetCompatibility = 21
     }
 
     repositories {
@@ -100,8 +100,8 @@ subprojects {
     tasks.withType(JavaCompile) {
         // Setting UTF-8 as the java source encoding.
         options.encoding = "UTF-8"
-        // Setting the release to Java 17
-        options.release = 17
+        // Setting the release to Java 21
+        options.release = 21
     }
 
     tasks.withType(Javadoc) {
@@ -109,9 +109,7 @@ subprojects {
         options.addBooleanOption 'Xdoclint:none', true
         //options.verbose()
         options.encoding = 'UTF-8'
-        if (JavaVersion.current().isJava9Compatible()) {
-            options.addBooleanOption('html5', true)
-        }
+        options.addBooleanOption('html5', true)
     }
 
     tasks.withType(Test) {//Configure all tests


### PR DESCRIPTION
I talked with @WolframPfeifer. For eons, we agreed to go with Java 21 after the next release. The release happened, so it is time for the new Java version. 

As a reminder: Java 21 was released in Sept 2023. It is the latest LTS release. [The feature differences are](https://mydeveloperplanet.com/2023/11/01/whats-new-between-java-17-and-java-21/) or [see here](https://bitbee.medium.com/new-features-from-java-17-to-21-a-detailed-overview-with-examples-87d7fbac2e71):

- JEP444: Virtual Threads: Threads are getting very cheap, also called greenlets, lightweight or heap-based threads.
- JEP431: Sequenced Collections: Refinement of the inheritance of Java collection API
- JEP440: Record Patterns 
- JEP441: Pattern Matching for Switch


Upcoming relevant Java features are [Primitive Types in Patterns, instanceof, and switch (Preview)](https://openjdk.org/jeps/455), [Statements before super(...) (Preview)](https://openjdk.org/jeps/447), [Markdown Documentation Comments](https://openjdk.org/jeps/467), [Stream Gatherers (Second Preview)](https://openjdk.org/jeps/473), [Structured Concurrency (Third Preview)](https://openjdk.org/jeps/480)


