### PR TITLE
Using semantic version (SemVer) scheme for KeY

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,10 @@ static def getDate() {
 }
 
 // The $BUILD_NUMBER is an environment variable set by Jenkins.
-def build = System.env.BUILD_NUMBER == null ? "" : "-${System.env.BUILD_NUMBER}"
+def build = System.env.BUILD_NUMBER == null ? "-dev" : "-${System.env.BUILD_NUMBER}"
 
 group = "org.key-project"
-version = "2.13.0$build"
+version = "2.12.4$build"
 
 subprojects {
     apply plugin: "java"


### PR DESCRIPTION
In the KaKeY meeting (2024-10-25), we discussed a change of the version scheme. To be more precise, we want to drop the old Linux kernel/odd-even version numbering. 

*Currently,* the development version of KeY is 2.13.0. The release created from this development will be `2.14.0`. After this release, the development version will become `2.15.0`. Odd numbers for development, even numbers for releases.

**New,** we keep in line with our release versioning. The current released version is `2.12.3`, so our development version would be `2.12.4-dev`. If the version steps through the releasing stages, it becomes `2.12.4-alpha`, `2.12.4-beta`, and `2.12.4-rc`. Finally, it will result in the release `2.12.4`. If the release is larger, it can also be lifted from PATCH to MINOR and become the release `2.13.0`.

This versioning scheme conforms to SemVer, particularly [§9](https://semver.org/#spec-item-9).

This pull request changes the versioning of artifacts accordingly in the `build.gradle`.

Please comment @mattulbrich, @unp1.