### PR TITLE
Missing project description for two sub-modules

### DIFF
--- a/keyext.caching/build.gradle
+++ b/keyext.caching/build.gradle
@@ -1,3 +1,5 @@
+description "Caching of provable nodes to make proving with KeY faster."
+
 dependencies {
     implementation project(":key.core")
     implementation project(":key.ui")

--- a/keyext.slicing/build.gradle
+++ b/keyext.slicing/build.gradle
@@ -1,3 +1,6 @@
+description "Proof slicing (removing of unnecessary nodes) for the KeY system."
+
+
 dependencies {
     implementation project(":key.core")
     implementation project(":key.ui")


### PR DESCRIPTION
Small backport of missing metadata inside two Gradle modules. Uploading to ossrh shows that the project description are required for Maven central. 