### PR TITLE
Fixing the broken automode

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
@@ -148,35 +148,40 @@ public class ConsoleUserInterfaceControl extends AbstractMediatorUserInterfaceCo
                 printResults(openGoals, info, result2);
             }
         } else if (info.getSource() instanceof ProblemLoader) {
-            LOGGER.debug("{}", result2);
-            System.exit(-1);
-        }
-        if (loadOnly || openGoals == 0) {
-            LOGGER.info("Number of open goals after loading: {}", openGoals);
-            System.exit(0);
-        }
-        ProblemLoader problemLoader = (ProblemLoader) info.getSource();
-        if (problemLoader.hasProofScript()) {
-            try {
-                ProofScriptEntry script = problemLoader.getProofScript();
-                if (script != null) {
-                    ProofScriptEngine pse =
-                        new ProofScriptEngine(script.script(), script.location());
-                    this.taskStarted(
-                        new DefaultTaskStartedInfo(TaskKind.Macro, "Script started", 0));
-                    pse.execute(this, proof);
-                    // The start and end messages are fake to persuade the system ...
-                    // All this here should refactored anyway ...
-                    this.taskFinished(new ProofMacroFinishedInfo(new SkipMacro(), proof));
+            if (result2 != null) {
+                LOGGER.debug("{}", result2);
+                if (result2 instanceof Throwable) {
+                    LOGGER.debug("Exception: ", (Throwable) result2);
                 }
-            } catch (Exception e) {
-                LOGGER.debug("", e);
                 System.exit(-1);
             }
-        } else if (macroChosen()) {
-            applyMacro();
-        } else {
-            finish(proof);
+            if (loadOnly || openGoals == 0) {
+                LOGGER.info("Number of open goals after loading: {}", openGoals);
+                System.exit(0);
+            }
+            ProblemLoader problemLoader = (ProblemLoader) info.getSource();
+            if (problemLoader.hasProofScript()) {
+                try {
+                    ProofScriptEntry script = problemLoader.getProofScript();
+                    if (script != null) {
+                        ProofScriptEngine pse =
+                            new ProofScriptEngine(script.script(), script.location());
+                        this.taskStarted(
+                            new DefaultTaskStartedInfo(TaskKind.Macro, "Script started", 0));
+                        pse.execute(this, proof);
+                        // The start and end messages are fake to persuade the system ...
+                        // All this here should refactored anyway ...
+                        this.taskFinished(new ProofMacroFinishedInfo(new SkipMacro(), proof));
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug("", e);
+                    System.exit(-1);
+                }
+            } else if (macroChosen()) {
+                applyMacro();
+            } else {
+                finish(proof);
+            }
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
@@ -131,27 +131,26 @@ public class ConsoleUserInterfaceControl extends AbstractMediatorUserInterfaceCo
         super.taskFinished(info);
         progressMax = 0; // reset progress bar marker
         final Proof proof = info.getProof();
+        final Object result = info.getResult();
         if (proof == null) {
-            final Object error = info.getResult();
             LOGGER.info("Proof loading failed");
-            if (error instanceof Throwable) {
-                LOGGER.info("Proof loading failed", (Throwable) error);
+            if (result instanceof Throwable thrown) {
+                LOGGER.info("Proof loading failed", thrown);
             } else {
                 LOGGER.info("Proof loading failed");
             }
             System.exit(1);
         }
         final int openGoals = proof.openGoals().size();
-        final Object result2 = info.getResult();
         if (info.getSource() instanceof ProverCore || info.getSource() instanceof ProofMacro) {
             if (!isAtLeastOneMacroRunning()) {
-                printResults(openGoals, info, result2);
+                printResults(openGoals, info, result);
             }
         } else if (info.getSource() instanceof ProblemLoader) {
-            if (result2 != null) {
-                LOGGER.debug("{}", result2);
-                if (result2 instanceof Throwable) {
-                    LOGGER.debug("Exception: ", (Throwable) result2);
+            if (result != null) {
+                LOGGER.debug("{}", result);
+                if (result instanceof Throwable thrown) {
+                    LOGGER.debug("Exception: ", thrown);
                 }
                 System.exit(-1);
             }


### PR DESCRIPTION
## Intended Change

The auto-mode in KeY does no longer work: It merely loads a file but does not try to prove it.
This PR partially reverts changes introduced in 8b6df72e14ac9ed620961d93db0a779fc65b7a6a.

## Plan

* [x] Fix `ConsoleUserInterfaceControl`

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: Run it on the CLI

## Additional information and contact(s)

It re-establishes CLI behaviour that we used to have in KeY.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
