### PR TITLE
Make the proof tree (or the KeY GUI in general) responsive during automatic proof search

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/pp/SequentPrintFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/SequentPrintFilter.java
@@ -82,6 +82,10 @@ public abstract class SequentPrintFilter {
      * entries.
      */
     protected void filterIdentity() {
+        if(originalSequent==null) {
+            return;
+        }
+
         antec = ImmutableSLList.nil();
         Iterator<SequentFormula> it = originalSequent.antecedent().iterator();
         while (it.hasNext()) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
@@ -720,7 +720,7 @@ public class KeYMediator {
         addKeYSelectionListener(new KeYSelectionListener() {
             @Override
             public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                a.setEnabled(e.getSource().getSelectedProof() != null);
+                a.setEnabled(e.source().getSelectedProof() != null);
             }
         });
     }
@@ -736,7 +736,7 @@ public class KeYMediator {
 
             @Override
             public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                a.setEnabled(e.getSource().getSelectedProof() != null);
+                a.setEnabled(e.source().getSelectedProof() != null);
             }
         });
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYMediator.java
@@ -16,6 +16,7 @@ import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.control.ProofControl;
 import de.uka.ilkd.key.gui.GUIListener;
 import de.uka.ilkd.key.gui.UserActionListener;
+import de.uka.ilkd.key.gui.actions.MainWindowAction;
 import de.uka.ilkd.key.gui.actions.useractions.UserAction;
 import de.uka.ilkd.key.gui.notification.events.NotificationEvent;
 import de.uka.ilkd.key.gui.notification.events.ProofClosedNotificationEvent;
@@ -704,13 +705,19 @@ public class KeYMediator {
         }
     }
 
-    /*
-     * Disable certain actions until a proof is loaded.
-     */
+    /// Disable certain actions until a proof is loaded.
+    ///
+    /// ### DEPRECATION
+    /// You should rather use the [MainWindowAction] class
+    /// with the [MainWindowAction#updateEnablednessOnSelectionChange()] method.
+    ///
+    /// This provides more flexibility, as the enabledness can define in cases of a
+    /// combination of predicates.
+    ///
+    @Deprecated(forRemoval = true)
     public void enableWhenProofLoaded(final Action a) {
         a.setEnabled(getSelectedProof() != null);
         addKeYSelectionListener(new KeYSelectionListener() {
-
             @Override
             public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
                 a.setEnabled(e.getSource().getSelectedProof() != null);
@@ -722,7 +729,7 @@ public class KeYMediator {
      * Disable certain actions until a proof is loaded. This is a workaround for a broken proof
      * macro menu in the GUI. Remove this method as soon as another solution can be found.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public void enableWhenProofLoaded(final javax.swing.AbstractButton a) {
         a.setEnabled(getSelectedProof() != null);
         addKeYSelectionListener(new KeYSelectionListener() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionEvent.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionEvent.java
@@ -6,52 +6,20 @@ package de.uka.ilkd.key.core;
 
 /**
  * An event that indicates that the users focused node or proof has changed
+ *
+ * @param source            the source of this event
+ * @param previousSelection the previously selected item
+ * @param currentSelection  the previously selected item
  */
-
-public class KeYSelectionEvent<Sel> {
-
-    /** the source of this event */
-    private final KeYSelectionModel source;
-
-    /** the previously selected item */
-    private final Sel previousSelection;
-
-    /**
-     * creates a new SelectedNodeEvent
-     *
-     * @param source the SelectedNodeModel where the event had its origin
-     * @param previousSelection the previous selected item
-     */
-    public KeYSelectionEvent(KeYSelectionModel source, Sel previousSelection) {
-        this.source = source;
-        this.previousSelection = previousSelection;
-    }
-
-    /**
-     * creates a new SelectedNodeEvent
-     *
-     * @param source the SelectedNodeModel where the event had its origin
-     */
-    public KeYSelectionEvent(KeYSelectionModel source) {
-        this(source, null);
-    }
-
-
+public record KeYSelectionEvent<Sel>(
+        KeYSelectionModel source, Sel previousSelection, Sel currentSelection) {
     /**
      * returns the KeYSelectionModel that caused this event
      *
      * @return the KeYSelectionModel that caused this event
      */
-    public KeYSelectionModel getSource() {
+    @Override
+    public KeYSelectionModel source() {
         return source;
-    }
-
-    /**
-     * returns the previous selected item
-     *
-     * @return the previous selected item
-     */
-    public Sel getPreviousSelection() {
-        return previousSelection;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/KeYSelectionModel.java
@@ -360,7 +360,7 @@ public class KeYSelectionModel {
     public synchronized void fireSelectedNodeChanged(Node previousNode) {
         synchronized (listenerList) {
             final KeYSelectionEvent<Node> selectionEvent =
-                new KeYSelectionEvent<>(this, previousNode);
+                new KeYSelectionEvent<>(this, previousNode, selectedNode);
             for (final KeYSelectionListener listener : listenerList) {
                 listener.selectedNodeChanged(selectionEvent);
             }
@@ -371,7 +371,7 @@ public class KeYSelectionModel {
         synchronized (listenerList) {
             LOGGER.debug("Selected Proof changed, firing...");
             final KeYSelectionEvent<Proof> selectionEvent =
-                new KeYSelectionEvent<>(this, previousProof);
+                new KeYSelectionEvent<>(this, previousProof, proof);
             for (final KeYSelectionListener listener : listenerList) {
                 listener.selectedProofChanged(selectionEvent);
             }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
@@ -568,7 +568,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
          */
         public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
             LOGGER.debug("GoalList: initialize with new proof");
-            selectingListModel.setProof(e.getSource().getSelectedProof());
+            selectingListModel.setProof(e.source().getSelectedProof());
             validate();
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/InfoView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/InfoView.java
@@ -214,7 +214,7 @@ public class InfoView extends JSplitPane implements TabPanel {
          */
         @Override
         public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-            final KeYSelectionModel selectionModel = e.getSource();
+            final KeYSelectionModel selectionModel = e.source();
             Runnable action = () -> {
                 if (isVisible()) {
                     if (selectionModel.getSelectedProof() == null) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -8,6 +8,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -1650,7 +1651,7 @@ public final class MainWindow extends JFrame {
             if (proof != null && !proof.isDisposed()) {
                 proof.getSettings().getStrategySettings().removePropertyChangeListener(this);
             }
-            proof = e.getSource().getSelectedProof();
+            proof = e.source().getSelectedProof();
             if (proof != null) {
                 proof.getSettings().getStrategySettings().removePropertyChangeListener(this);
             }
@@ -1697,7 +1698,7 @@ public final class MainWindow extends JFrame {
 
         @Override
         public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-            handleProof(e.getSource().getSelectedProof());
+            handleProof(e.source().getSelectedProof());
         }
 
         private void handleProof(Proof p) {
@@ -1710,7 +1711,7 @@ public final class MainWindow extends JFrame {
 
         @Override
         public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-            handleProof(e.getSource().getSelectedProof());
+            handleProof(e.source().getSelectedProof());
         }
 
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/SelectionHistory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/SelectionHistory.java
@@ -151,12 +151,12 @@ public class SelectionHistory implements KeYSelectionListener, ProofDisposedList
     @Override
     public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
         if (selectedNodes.isEmpty()) {
-            selectedNodes.add(new WeakReference<>(e.getSource().getSelectedNode()));
+            selectedNodes.add(new WeakReference<>(e.source().getSelectedNode()));
             fireChangeEvent();
             return;
         }
         Node last = selectedNodes.peekLast().get();
-        Node now = e.getSource().getSelectedNode();
+        Node now = e.source().getSelectedNode();
         if (last != now) {
             selectedNodes.add(new WeakReference<>(now));
             fireChangeEvent();
@@ -165,7 +165,7 @@ public class SelectionHistory implements KeYSelectionListener, ProofDisposedList
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        Proof p = e.getSource().getSelectedProof();
+        Proof p = e.source().getSelectedProof();
         if (p == null || monitoredProofs.contains(p)) {
             return;
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/StrategySelectionView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/StrategySelectionView.java
@@ -98,7 +98,7 @@ public final class StrategySelectionView extends JPanel implements TabPanel {
     private final KeYSelectionListener mediatorListener = new KeYSelectionListener() {
 
         public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-            refresh(e.getSource().getSelectedProof());
+            refresh(e.source().getSelectedProof());
         }
     };
     private JButton btnGo;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -403,10 +403,10 @@ public class TaskTree extends JPanel {
          * the selected proof has changed (e.g. a new proof has been loaded)
          */
         public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-            if (e.getSource().getSelectedProof() == null) {
+            if (e.source().getSelectedProof() == null) {
                 return;
             }
-            TaskTreeNode ttn = model.getTaskForProof(e.getSource().getSelectedProof());
+            TaskTreeNode ttn = model.getTaskForProof(e.source().getSelectedProof());
             delegateView.setSelectionPath(new TreePath(ttn.getPath()));
             validate();
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
@@ -24,7 +24,7 @@ public final class AbandonTaskAction extends MainWindowAction {
         setIcon(IconFactory.abandon(16));
         setTooltip("Drop current proof.");
 
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.proof = proof;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AbandonTaskAction.java
@@ -10,12 +10,6 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.proof.Proof;
 
 public final class AbandonTaskAction extends MainWindowAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 915588190956945751L;
-
     private final Proof proof;
 
     public AbandonTaskAction(MainWindow mainWindow, Proof proof) {
@@ -25,6 +19,7 @@ public final class AbandonTaskAction extends MainWindowAction {
         setTooltip("Drop current proof.");
 
         enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
 
         this.proof = proof;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoModeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoModeAction.java
@@ -21,16 +21,12 @@ import de.uka.ilkd.key.proof.*;
 import org.key_project.util.collection.ImmutableList;
 
 public final class AutoModeAction extends MainWindowAction {
-
-    private static final KeyStroke START_KEY =
+    public static final KeyStroke START_KEY =
         KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, InputEvent.CTRL_DOWN_MASK);
-    private static final KeyStroke STOP_KEY = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7702898691162947994L;
-    final Icon startLogo = IconFactory.autoModeStartLogo(MainWindow.TOOLBAR_ICON_SIZE);
-    final Icon stopLogo = IconFactory.autoModeStopLogo(MainWindow.TOOLBAR_ICON_SIZE);
+    public static final KeyStroke STOP_KEY = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+    public static final Icon startLogo =
+        IconFactory.autoModeStartLogo(MainWindow.TOOLBAR_ICON_SIZE);
+    public static final Icon stopLogo = IconFactory.autoModeStopLogo(MainWindow.TOOLBAR_ICON_SIZE);
 
     private Proof associatedProof;
 
@@ -91,7 +87,7 @@ public final class AutoModeAction extends MainWindowAction {
                     associatedProof.removeProofTreeListener(ptl);
                 }
 
-                associatedProof = e.getSource().getSelectedProof();
+                associatedProof = e.source().getSelectedProof();
                 enable();
 
                 if (associatedProof != null) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoSave.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/AutoSave.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import org.key_project.util.java.IOUtil;
 
 public class AutoSave extends MainWindowAction {
-    private static final long serialVersionUID = -2598146925208531491L;
     public static final int DEFAULT_PERIOD = 2000;
 
     public AutoSave(MainWindow mainWindow) {
@@ -21,6 +20,9 @@ public class AutoSave extends MainWindowAction {
         setName("Auto Save Proofs");
         setSelected(
             ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings().autoSavePeriod() > 0);
+
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/GoalSelectAboveAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/GoalSelectAboveAction.java
@@ -26,6 +26,8 @@ public final class GoalSelectAboveAction extends MainWindowAction {
         setIcon(IconFactory.selectGoalAbove(MainWindow.TOOLBAR_ICON_SIZE));
         setTooltip(
             "Changes selected goal in the proof-tree to the next item above the current one");
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HeatmapSettingsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/HeatmapSettingsAction.java
@@ -5,13 +5,9 @@ package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
 
-import de.uka.ilkd.key.core.KeYSelectionEvent;
-import de.uka.ilkd.key.core.KeYSelectionListener;
 import de.uka.ilkd.key.gui.HeatmapOptionsDialog;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
-import de.uka.ilkd.key.proof.Node;
-import de.uka.ilkd.key.proof.Proof;
 
 /**
  * Action for invoking the heatmap options dialog.
@@ -19,8 +15,6 @@ import de.uka.ilkd.key.proof.Proof;
  * @author jschiffl
  */
 public class HeatmapSettingsAction extends MainWindowAction {
-    private static final long serialVersionUID = -6165100588113899099L;
-
     private HeatmapOptionsDialog dialog;
 
     /**
@@ -34,20 +28,7 @@ public class HeatmapSettingsAction extends MainWindowAction {
         setMenuPath("View.Heatmap");
         setEnabled(getMediator().getSelectedProof() != null);
         setIcon(IconFactory.selectDecProcArrow(MainWindow.TOOLBAR_ICON_SIZE));
-
-        final KeYSelectionListener selListener = new KeYSelectionListener() {
-            @Override
-            public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-                final Proof proof = getMediator().getSelectedProof();
-                setEnabled(proof != null);
-            }
-
-            @Override
-            public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                selectedNodeChanged(null);
-            }
-        };
-        getMediator().addKeYSelectionListener(selListener);
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeYProjectHomepageAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeYProjectHomepageAction.java
@@ -23,7 +23,6 @@ import org.key_project.util.java.SwingUtil;
  *
  */
 public class KeYProjectHomepageAction extends MainWindowAction {
-    private static final long serialVersionUID = 8657661861116034536L;
     private final static String url = "https://www.key-project.org/";
 
     public KeYProjectHomepageAction(MainWindow mainWindow) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
@@ -9,8 +9,6 @@ import javax.swing.KeyStroke;
 
 import de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager;
 
-import java.util.function.Supplier;
-
 import static de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager.SHORTCUT_KEY_MASK;
 
 /// Common class for all "actions" (menu entries / toolbar buttons) the user can trigger.
@@ -23,7 +21,7 @@ import static de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager.SHORTCUT_KEY_MAS
 /// [#enabledWhen]. This predicate is ask whether the action is enabled in the current state inside
 /// the method [#updateEnabledness()]. This machinary requires, that the enabledness of an action
 /// is defined as follows in a sub-class:
-/// 1. You need to set this variable using [#setEnabledWhen(Supplier<Boolean>)].
+/// 1. You need to set this variable using [#setEnabledWhen(Pred)].
 /// 2. You also need to add the method [#updateEnabledness()] in the listener,
 /// e.g., {@link java.beans.PropertyChangeListener}, s.t. the action is notified on a state change.
 ///
@@ -89,6 +87,13 @@ public abstract class KeyAction extends AbstractAction {
     /// @see [#setEnabledWhen(Pred)]
     public Pred getEnabledWhen() {
         return enabledWhen;
+    }
+
+    /// Appends conjunctively a predicate to the enabledness predicated of this action
+    /// @see #setEnabledWhen(Pred)
+    /// @see #getEnabledWhen()
+    public void addConjunctivelyEnabledWhen(Pred enabledWhen) {
+        setEnabledWhen(getEnabledWhen().and(enabledWhen));
     }
 
     /**
@@ -197,9 +202,10 @@ public abstract class KeyAction extends AbstractAction {
     }
 
     /// A stupid interface which is like [#java.util.function.Predicate] but without an argument.
-    /// The JDK alternative [#java.util.function.BooleanSupplier] does not provide combinatorial functions.
+    /// The JDK alternative [#java.util.function.BooleanSupplier] does not provide combinatorial
+    /// functions.
     /// @author weigl
-    interface Pred {
+    public interface Pred {
         boolean test();
 
         default Pred not() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationAction.java
@@ -48,7 +48,7 @@ public abstract class LemmaGenerationAction extends MainWindowAction {
         putValue(NAME, getTitle());
         putValue(SHORT_DESCRIPTION, getDescription());
         if (proofIsRequired()) {
-            getMediator().enableWhenProofLoaded(this);
+            enabledOnAnActiveProof();
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationBatchModeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/LemmaGenerationBatchModeAction.java
@@ -35,13 +35,13 @@ public class LemmaGenerationBatchModeAction extends MainWindowAction {
                 runProver --help
                 in the batch mode.""";
 
-    private static final long serialVersionUID = 1L;
-
     public LemmaGenerationBatchModeAction(MainWindow mainWindow) {
         super(mainWindow);
         setTooltip("Show information about proving taclets by using the batch mode.");
         putValue(NAME, "Taclets Using the Batch Mode...");
         putValue(SHORT_DESCRIPTION, "A short description for using the batch mode.");
+
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MainWindowAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MainWindowAction.java
@@ -53,7 +53,7 @@ public abstract class MainWindowAction extends KeyAction {
     /// Useful as a predicate for [#setEnabledWhen].
     /// ```java
     /// setEnabledWhen(this::isProofSelected);
-    ///```
+    /// ```
     protected final boolean isProofSelected() {
         return getMediator().getSelectionModel().getSelectedProof() != null;
     }
@@ -62,7 +62,7 @@ public abstract class MainWindowAction extends KeyAction {
     /// Useful as a predicate for [#setEnabledWhen].
     /// ```java
     /// setEnabledWhen(not(this::isMainWindowAutoMode));
-    ///```
+    /// ```
     protected final boolean isMainWindowAutoMode() {
         return mainWindow.isInAutoMode();
     }
@@ -86,10 +86,11 @@ public abstract class MainWindowAction extends KeyAction {
     }
 
     /// This methods places a {@link #java.beans.PropertyChangeListener}, s.t.,
-    /// the enabledness is updated when the auto-mode/macro is executed or finished in side the [#mainWindow].
+    /// the enabledness is updated when the auto-mode/macro is executed or finished in side the
+    /// [#mainWindow].
     protected final void updateEnablednessOnAutoModeChange() {
         mainWindow.addPropertyChangeListener(MainWindow.PROPERTY_IN_AUTO_MODE,
-                p -> updateEnabledness());
+            p -> updateEnabledness());
     }
 
     @Override
@@ -108,19 +109,5 @@ public abstract class MainWindowAction extends KeyAction {
 
     protected KeYMediator getMediator() {
         return mainWindow.getMediator();
-    }
-}
-
-        @Override
-        public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-            var enable = e.getSource().getSelectedProof() != null;
-            actions.forEach(a -> a.setEnabled(enable));
-        }
-
-        @Override
-        public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-            var enable = e.getSource().getSelectedProof() != null;
-            actions.forEach(a -> a.setEnabled(enable));
-        }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/OpenFileAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/OpenFileAction.java
@@ -14,18 +14,14 @@ import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 public class OpenFileAction extends MainWindowAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8548805965130100236L;
-
     public OpenFileAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("Load...");
         setIcon(IconFactory.openKeYFile(MainWindow.TOOLBAR_ICON_SIZE));
         setTooltip("Browse and load problem or proof files.");
+        enabledWhenNotInAutoMode();
     }
+
 
     public void actionPerformed(ActionEvent e) {
         KeYFileChooser fc = KeYFileChooser.getFileChooser("Select file to load proof or problem");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ProofManagementAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ProofManagementAction.java
@@ -5,14 +5,10 @@ package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
 
-import de.uka.ilkd.key.core.KeYSelectionEvent;
-import de.uka.ilkd.key.core.KeYSelectionListener;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.ProofManagementDialog;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.notification.events.GeneralFailureEvent;
-import de.uka.ilkd.key.proof.Node;
-import de.uka.ilkd.key.proof.Proof;
 
 /**
  * Shows the proof management dialog
@@ -30,28 +26,7 @@ public final class ProofManagementAction extends MainWindowAction {
         setTooltip("Browse contracts and possible proof targets");
         setIcon(IconFactory.proofMgt(16));
 
-        setEnabled(enabled());
-
-        getMediator().addKeYSelectionListener(new KeYSelectionListener() {
-            /** focused node has changed */
-            public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-            }
-
-            /**
-             * the selected proof has changed. Enable or disable action depending on whether a proof
-             * is
-             * available or not
-             */
-            public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                setEnabled(enabled());
-            }
-        });
-    }
-
-    private boolean enabled() {
-        return getMediator().getSelectedProof() != null
-                && getMediator().getSelectedProof().getServices().getJavaModel() != null
-                && !getMediator().getSelectedProof().getServices().getJavaModel().isEmpty();
+        enabledOnAnActiveProof();
     }
 
     public void actionPerformed(ActionEvent e) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickLoadAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickLoadAction.java
@@ -16,8 +16,6 @@ import de.uka.ilkd.key.gui.MainWindow;
  *
  */
 public class QuickLoadAction extends MainWindowAction {
-    private static final long serialVersionUID = -7149996409297248408L;
-
     /**
      * Create a new action.
      *

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickSaveAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickSaveAction.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class QuickSaveAction extends MainWindowAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(QuickSaveAction.class);
-    private static final long serialVersionUID = -7084304175671744403L;
 
     /** The OS's tmp directory. */
     private static final File TMP_DIR = IOUtil.getTempDirectory();
@@ -42,6 +41,7 @@ public final class QuickSaveAction extends MainWindowAction {
         setName("Quicksave");
         setTooltip("Save current proof to a temporal location.");
         enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickSaveAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/QuickSaveAction.java
@@ -41,7 +41,7 @@ public final class QuickSaveAction extends MainWindowAction {
         super(mainWindow);
         setName("Quicksave");
         setTooltip("Save current proof to a temporal location.");
-        mainWindow.getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SMTInvokeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SMTInvokeAction.java
@@ -23,9 +23,6 @@ import de.uka.ilkd.key.smt.SolverTypeCollection;
  * @author Alicia Appelhagen (move from MainWindow to own class)
  */
 public class SMTInvokeAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -8176122007799747342L;
-
     protected final transient KeYMediator mediator;
 
     /**
@@ -47,6 +44,9 @@ public class SMTInvokeAction extends MainWindowAction {
         if (solverUnion != SolverTypeCollection.EMPTY_COLLECTION) {
             putValue(SHORT_DESCRIPTION, "Invokes " + solverUnion.toString());
         }
+
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     public SolverTypeCollection getSolverUnion() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SMTOptionsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SMTOptionsAction.java
@@ -25,19 +25,5 @@ public class SMTOptionsAction extends MainWindowAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         SettingsManager.getInstance().showSettingsDialog(mainWindow, SettingsManager.SMT_SETTINGS);
-
-        /*
-         * ProofDependentSMTSettings pdSettings = ProofSettings.DEFAULT_SETTINGS.getSMTSettings();
-         * Proof proof = this.getMediator().getSelectedProof(); if (proof != null) { pdSettings =
-         * proof.getSettings().getSMTSettings(); } ProofIndependentSMTSettings piSettings =
-         * ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings();
-         *
-         * TestGenerationSettings tgSettings =
-         * ProofIndependentSettings.DEFAULT_INSTANCE.getTestGenerationSettings(); final
-         * SMTSettingsModel settingsModel = new SMTSettingsModel(new SMTSettings(pdSettings,
-         * piSettings, proof), tgSettings); bottomComponent = new
-         * JLabel("No proof has been loaded: those are the default settings.");
-         */
-
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveBundleAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveBundleAction.java
@@ -5,13 +5,9 @@ package de.uka.ilkd.key.gui.actions;
 
 import java.awt.event.ActionEvent;
 
-import de.uka.ilkd.key.core.KeYSelectionEvent;
-import de.uka.ilkd.key.core.KeYSelectionListener;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.proof.Proof;
-import de.uka.ilkd.key.settings.GeneralSettings;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 /**
  * Saves the currently selected proof as a zip archive with file extension "zproof". The bundle
@@ -34,27 +30,10 @@ public final class SaveBundleAction extends MainWindowAction {
         setIcon(IconFactory.saveBundle(MainWindow.TOOLBAR_ICON_SIZE));
         setTooltip("Save current proof as a bundle containing all files to successfully reload "
             + "the proof (disabled when option \"Allow proof bundle saving\" is set).");
-
-        // react to setting changes
-        GeneralSettings settings = ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
-        settings.addPropertyChangeListener(e -> updateStatus());
-
-        // react to changes of proof selection
-        mainWindow.getMediator().addKeYSelectionListener(new KeYSelectionListener() {
-
-            @Override
-            public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                updateStatus();
-            }
-        });
-
-        updateStatus();
+        enabledWhenNotInAutoMode();
+        enabledOnAnActiveProof();
     }
 
-    private void updateStatus() {
-        // enable only if there is a proof
-        setEnabled(mainWindow.getMediator().getSelectedProof() != null);
-    }
 
     @Override
     public void actionPerformed(ActionEvent e) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveFileAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveFileAction.java
@@ -24,7 +24,7 @@ public final class SaveFileAction extends MainWindowAction {
         setName("Save...");
         setIcon(IconFactory.saveFile(MainWindow.TOOLBAR_ICON_SIZE));
         setTooltip("Save current proof.");
-        mainWindow.getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
     }
 
     public void actionPerformed(ActionEvent e) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveFileAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SaveFileAction.java
@@ -13,18 +13,13 @@ import de.uka.ilkd.key.proof.Proof;
  * Saves the current selected proof.
  */
 public final class SaveFileAction extends MainWindowAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5479654127272775831L;
-
     public SaveFileAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("Save...");
         setIcon(IconFactory.saveFile(MainWindow.TOOLBAR_ICON_SIZE));
         setTooltip("Save current proof.");
         enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     public void actionPerformed(ActionEvent e) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInProofTreeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInProofTreeAction.java
@@ -23,8 +23,8 @@ public class SearchInProofTreeAction extends MainWindowAction {
         setTooltip("Search for rule names or node numbers in the proof tree.");
 
         setAcceleratorKey(de.uka.ilkd.key.gui.prooftree.ProofTreeView.SEARCH_KEY_STROKE);
-        getMediator().enableWhenProofLoaded(this);
-
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInProofTreeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInProofTreeAction.java
@@ -8,14 +8,10 @@ import java.awt.event.ActionEvent;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 
-/*
+/**
  * Menu option for showing the proof tree search bar. Keyboard shortcut: STRG+SHIFT+F.
  */
-
 public class SearchInProofTreeAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -3317991560912504404L;
-
     public SearchInProofTreeAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("Search in Proof Tree");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInSequentAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchInSequentAction.java
@@ -25,7 +25,7 @@ public class SearchInSequentAction extends MainWindowAction {
         setName("Search in Sequent View");
         setIcon(IconFactory.search(16));
         setTooltip("Search for strings in the current sequent.");
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchModeChangeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchModeChangeAction.java
@@ -10,13 +10,11 @@ import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.nodeviews.SequentViewSearchBar;
 
 
-/*
+/**
  * Menu option for showing the next search result of sequent search Keyboard shortcut: F3. This
  * shortcut is set in the KeyStrokemanager
  */
 public class SearchModeChangeAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -9002019635814787502L;
     private final SequentViewSearchBar searchBar;
     private final SequentViewSearchBar.SearchMode mode;
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchModeChangeAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchModeChangeAction.java
@@ -27,7 +27,7 @@ public class SearchModeChangeAction extends MainWindowAction {
 
         setIcon(mode.icon);
         setTooltip("Find the next occurence of current search term in sequent.");
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
         if (mode == SequentViewSearchBar.SearchMode.HIGHLIGHT) {
             setAcceleratorLetter(KeyEvent.VK_H);
         } else if (mode == SequentViewSearchBar.SearchMode.HIDE) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchNextAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchNextAction.java
@@ -23,7 +23,7 @@ public class SearchNextAction extends MainWindowAction {
         setName("Find Next Occurrence");
         setIcon(IconFactory.SEARCH_NEXT.get(16));
         setTooltip("Find the next occurrence of current search term in sequent.");
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.searchBar = searchBar;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchPreviousAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchPreviousAction.java
@@ -24,7 +24,7 @@ public class SearchPreviousAction extends MainWindowAction {
         setName("Find Previous Occurrence");
         setIcon(IconFactory.SEARCH_PREV.get(16));
         setTooltip("Find the previous occurrence of current search term in sequent.");
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.searchBar = searchBar;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchPreviousAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SearchPreviousAction.java
@@ -15,8 +15,6 @@ import de.uka.ilkd.key.gui.nodeviews.SequentViewSearchBar;
  * KeyStrokemanager
  */
 public class SearchPreviousAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -9002009635814787502L;
     private final SequentViewSearchBar searchBar;
 
     public SearchPreviousAction(MainWindow mainWindow, SequentViewSearchBar searchBar) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveTactletOptionsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveTactletOptionsAction.java
@@ -14,14 +14,13 @@ import de.uka.ilkd.key.gui.MainWindow;
  * Now defers to the "Show Active Settings" action to show the taclet options.
  */
 public class ShowActiveTactletOptionsAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -7012564698194718532L;
     private final ShowActiveSettingsAction action;
 
     public ShowActiveTactletOptionsAction(MainWindow mainWindow, ShowActiveSettingsAction action) {
         super(mainWindow);
         setName("Show Active Taclet Options");
         this.action = action;
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowKnownTypesAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowKnownTypesAction.java
@@ -33,7 +33,7 @@ public class ShowKnownTypesAction extends MainWindowAction {
         super(mainWindow);
         setName("Show Known Types");
 
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.proof = proof;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
@@ -58,7 +58,7 @@ public class ShowProofStatistics extends MainWindowAction {
         super(mainWindow);
         setName("Show Proof Statistics");
         setIcon(IconFactory.statistics(16));
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.proof = proof;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowProofStatistics.java
@@ -41,8 +41,6 @@ public class ShowProofStatistics extends MainWindowAction {
     private static final String CSV_SEPERATOR = ";";
     private static final Logger LOGGER = LoggerFactory.getLogger(ShowProofStatistics.class);
 
-    private static final long serialVersionUID = -8814798230037775905L;
-
     /**
      * Regex pattern to check for tooltips in statistics entries.
      */
@@ -58,8 +56,9 @@ public class ShowProofStatistics extends MainWindowAction {
         super(mainWindow);
         setName("Show Proof Statistics");
         setIcon(IconFactory.statistics(16));
-        enabledOnAnActiveProof();
 
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
         this.proof = proof;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowUsedContractsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowUsedContractsAction.java
@@ -23,9 +23,11 @@ public class ShowUsedContractsAction extends MainWindowAction {
         super(mainWindow);
         setName("Show Used Contracts");
 
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
 
         this.proof = proof;
+
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/TacletOptionsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/TacletOptionsAction.java
@@ -26,7 +26,7 @@ public class TacletOptionsAction extends MainWindowAction {
         setName("Show Taclet Options");
         setIcon(IconFactory.configure(16));
 
-        getMediator().enableWhenProofLoaded(this);
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/TermLabelMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/TermLabelMenu.java
@@ -64,18 +64,21 @@ public class TermLabelMenu extends JMenu {
              */
             @Override
             public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-                Set<Name> labelNames =
-                    getOccuringTermLabels(mainWindow.getMediator().getSelectedNode().sequent());
-                for (Entry<Name, TermLabelCheckBox> entry : checkBoxMap.entrySet()) {
-                    TermLabelCheckBox checkBox = entry.getValue();
-                    /*
-                     * Font style indicates whether a label occurs in the currently displayed
-                     * sequent.
-                     */
-                    if (labelNames.contains(entry.getKey())) {
-                        checkBox.setBoldFont();
-                    } else {
-                        checkBox.setItalicFont();
+                final var selectedSequent =
+                    mainWindow.getMediator().getSelectionModel().getSelectedSequent();
+                if (selectedSequent != null) {
+                    Set<Name> labelNames = getOccuringTermLabels(selectedSequent);
+                    for (Entry<Name, TermLabelCheckBox> entry : checkBoxMap.entrySet()) {
+                        TermLabelCheckBox checkBox = entry.getValue();
+                        /*
+                         * Font style indicates whether a label occurs in the currently displayed
+                         * sequent.
+                         */
+                        if (labelNames.contains(entry.getKey())) {
+                            checkBox.setBoldFont();
+                        } else {
+                            checkBox.setItalicFont();
+                        }
                     }
                 }
             }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleConfirmExitAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToggleConfirmExitAction.java
@@ -10,17 +10,13 @@ import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 
 public class ToggleConfirmExitAction extends MainWindowAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3453843972242689758L;
-
     public ToggleConfirmExitAction(MainWindow mainWindow) {
         super(mainWindow);
         setTooltip("Ask for extra confirmation when trying to exit the prover");
         setName("Confirm Exit");
         setSelected(ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().confirmExit());
+
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToolTipOptionsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ToolTipOptionsAction.java
@@ -9,12 +9,6 @@ import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.configuration.ViewSelector;
 
 public class ToolTipOptionsAction extends MainWindowAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -360744615149278733L;
-
     public ToolTipOptionsAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("ToolTip Options");

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofMacroUserAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofMacroUserAction.java
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions.useractions;
 
+import javax.swing.*;
+
 import de.uka.ilkd.key.core.KeYMediator;
+import de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager;
 import de.uka.ilkd.key.macros.ProofMacro;
 import de.uka.ilkd.key.proof.Proof;
 
@@ -29,6 +32,12 @@ public class ProofMacroUserAction extends ProofModifyingUserAction {
         super(mediator, proof);
         this.macro = macro;
         this.pio = pio;
+
+        setTooltip(macro.getDescription());
+        final KeyStroke macroKey = KeyStrokeManager.get(macro);
+        if (macroKey != null && pio == null) { // currently only for global macro applications
+            setAcceleratorKey(macroKey);
+        }
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofModifyingUserAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofModifyingUserAction.java
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions.useractions;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * User action that modifies the proof in some way.
@@ -27,18 +28,18 @@ public abstract class ProofModifyingUserAction extends UserAction {
     /**
      * The node selected before the user action is performed.
      */
-    private final Node originalSelection;
+    private final @Nullable Node originalSelection;
 
     /**
      * Save the current state of the proof.
      *
-     * @param mediator the mediator
+     * @param mediator      the mediator
      * @param originalState the proof
      */
     protected ProofModifyingUserAction(KeYMediator mediator, Proof originalState) {
         super(mediator, originalState);
         this.originalOpenGoals =
-            originalState.openGoals().stream().map(Goal::node).collect(Collectors.toList());
+                originalState.openGoals().stream().map(Goal::node).collect(Collectors.toList());
         this.originalSelection = mediator.getSelectedNode();
     }
 
@@ -46,15 +47,15 @@ public abstract class ProofModifyingUserAction extends UserAction {
      * Save the current state of the proof.
      * Mark the just modified node as an open goal.
      *
-     * @param mediator the mediator
-     * @param originalState the proof
+     * @param mediator         the mediator
+     * @param originalState    the proof
      * @param justModifiedNode just modified node
      */
     protected ProofModifyingUserAction(KeYMediator mediator, Proof originalState,
-            Node justModifiedNode) {
+                                       Node justModifiedNode) {
         super(mediator, originalState);
         List<Node> openGoals =
-            originalState.openGoals().stream().map(Goal::node).collect(Collectors.toList());
+                originalState.openGoals().stream().map(Goal::node).collect(Collectors.toList());
         Node openGoalToReplace = null;
         for (Node openGoal : openGoals) {
             if (openGoal.parent() == justModifiedNode) {
@@ -80,6 +81,7 @@ public abstract class ProofModifyingUserAction extends UserAction {
 
     @Override
     public boolean canUndo() {
-        return originalOpenGoals.stream().allMatch(proof::find) && proof.find(originalSelection);
+        return originalOpenGoals.stream().allMatch(proof::find) &&
+                (originalSelection != null && proof.find(originalSelection));
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ShowOriginAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ShowOriginAction.java
@@ -21,9 +21,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
  * @author lanzinger
  */
 public class ShowOriginAction extends MainWindowAction {
-
-    private static final long serialVersionUID = 4557953425770258852L;
-
     private final PosInSequent pos;
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/ActionHistoryExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/action_history/ActionHistoryExtension.java
@@ -138,7 +138,7 @@ public class ActionHistoryExtension implements UserActionListener,
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        Proof p = e.getSource().getSelectedProof();
+        Proof p = e.source().getSelectedProof();
         currentProof = p;
         if (p == null || registeredProofs.contains(p)) {
             return;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavacExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavacExtension.java
@@ -225,7 +225,7 @@ public class JavacExtension
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        loadProof(e.getSource().getSelectedProof());
+        loadProof(e.source().getSelectedProof());
     }
 }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreePopupFactory.java
@@ -16,7 +16,7 @@ import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.InspectorForDecisionPredicates;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.ProofMacroMenu;
-import de.uka.ilkd.key.gui.actions.KeyAction;
+import de.uka.ilkd.key.gui.actions.MainWindowAction;
 import de.uka.ilkd.key.gui.actions.ShowProofStatistics;
 import de.uka.ilkd.key.gui.actions.useractions.RunStrategyOnNodeUserAction;
 import de.uka.ilkd.key.gui.extension.api.DefaultContextMenuKind;
@@ -604,11 +604,11 @@ public final class ProofTreePopupFactory {
         }
     }
 
-    public static abstract class ProofTreeAction extends KeyAction {
-        private static final long serialVersionUID = 2686349019163064481L;
+    public static abstract class ProofTreeAction extends MainWindowAction {
         protected final ProofTreeContext context;
 
         protected ProofTreeAction(ProofTreeContext context) {
+            super(context.window, true);
             this.context = context;
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -917,7 +917,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             LOGGER.debug("ProofTreeView: initialize with new proof");
             ThreadUtilities.invokeOnEventQueue(() -> {
                 lastGoalNode = null;
-                setProof(e.getSource().getSelectedProof());
+                setProof(e.source().getSelectedProof());
                 delegateView.validate();
             });
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
@@ -216,7 +216,7 @@ public final class SourceView extends JComponent {
             @Override
             public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
                 clear();
-                ensureProofJavaSourceCollectionExists(e.getSource().getSelectedProof());
+                ensureProofJavaSourceCollectionExists(e.source().getSelectedProof());
                 updateGUI();
             }
         });

--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
@@ -120,7 +120,7 @@ public class CachingExtension
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        Proof p = e.getSource().getSelectedProof();
+        Proof p = e.source().getSelectedProof();
         if (p == null || trackedProofs.contains(p)) {
             return;
         }

--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/ReferenceSearchButton.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/ReferenceSearchButton.java
@@ -72,7 +72,7 @@ public class ReferenceSearchButton extends JButton implements ActionListener, Ke
 
     @Override
     public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-        Proof p = e.getSource().getSelectedProof();
+        Proof p = e.source().getSelectedProof();
         updateState(p);
     }
 

--- a/keyext.exploration/src/main/java/org/key_project/exploration/actions/ExplorationAction.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/actions/ExplorationAction.java
@@ -20,11 +20,9 @@ import org.key_project.exploration.ExplorationModeModel;
  * Common functionalities for proof exploration actions.
  */
 public abstract class ExplorationAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -1662459714803539089L;
-
     protected ExplorationAction(MainWindow mw) {
         super(mw);
+        enabledOnAnActiveProof();
         enabledWhenNotInAutoMode();
     }
 

--- a/keyext.exploration/src/main/java/org/key_project/exploration/actions/ExplorationAction.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/actions/ExplorationAction.java
@@ -25,6 +25,7 @@ public abstract class ExplorationAction extends MainWindowAction {
 
     protected ExplorationAction(MainWindow mw) {
         super(mw);
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/keyext.exploration/src/main/java/org/key_project/exploration/actions/ToggleExplorationAction.java
+++ b/keyext.exploration/src/main/java/org/key_project/exploration/actions/ToggleExplorationAction.java
@@ -5,11 +5,8 @@ package org.key_project.exploration.actions;
 
 import java.awt.event.ActionEvent;
 
-import de.uka.ilkd.key.core.KeYSelectionEvent;
-import de.uka.ilkd.key.core.KeYSelectionListener;
 import de.uka.ilkd.key.gui.MainWindow;
-import de.uka.ilkd.key.gui.actions.KeyAction;
-import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.gui.actions.MainWindowAction;
 
 import org.key_project.exploration.ExplorationModeModel;
 import org.key_project.exploration.Icons;
@@ -20,11 +17,12 @@ import org.key_project.exploration.Icons;
  * @author Alexander Weigl
  * @version 1 (22.07.19)
  */
-public class ToggleExplorationAction extends KeyAction {
+public class ToggleExplorationAction extends MainWindowAction {
     public static final String MENU_PATH = "View.Exploration";
     private final transient ExplorationModeModel model;
 
     public ToggleExplorationAction(ExplorationModeModel model, MainWindow mainWindow) {
+        super(mainWindow);
         this.model = model;
 
         setName("Exploration Mode");
@@ -35,24 +33,7 @@ public class ToggleExplorationAction extends KeyAction {
         putValue(CHECKBOX, true);
         model.addPropertyChangeListener(ExplorationModeModel.PROP_EXPLORE_MODE,
             e -> setSelected(model.isExplorationModeSelected()));
-
-        mainWindow.getMediator().getSelectionModel()
-                .addKeYSelectionListener(new KeYSelectionListener() {
-
-                    @Override
-                    public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                        updateEnable(mainWindow);
-                    }
-
-                });
-
-        updateEnable(mainWindow);
-    }
-
-    private void updateEnable(MainWindow mainWindow) {
-        // Only enable if a proof is loaded. Otherwise, the buttons may become out of sync
-        // with the actual settings which are loaded along with the proof.
-        setEnabled(mainWindow.getProofTreeView().getDelegateModel() != null);
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/gui/controller/IsabelleTranslateAllAction.java
+++ b/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/gui/controller/IsabelleTranslateAllAction.java
@@ -22,6 +22,8 @@ public class IsabelleTranslateAllAction extends MainWindowAction {
     public IsabelleTranslateAllAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("Translate all goals to Isabelle");
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/gui/controller/IsabelleTranslationAction.java
+++ b/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/gui/controller/IsabelleTranslationAction.java
@@ -33,6 +33,8 @@ public class IsabelleTranslationAction extends MainWindowAction {
     public IsabelleTranslationAction(MainWindow mainWindow) {
         super(mainWindow);
         setName("Translate to Isabelle");
+        enabledOnAnActiveProof();
+        enabledWhenNotInAutoMode();
     }
 
     @Override

--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingExtension.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingExtension.java
@@ -115,7 +115,7 @@ public class SlicingExtension implements KeYGuiExtension,
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        createTrackerForProof(e.getSource().getSelectedProof());
+        createTrackerForProof(e.source().getSelectedProof());
     }
 
     @Override

--- a/keyext.slicing/src/main/java/org/key_project/slicing/ui/ShowGraphAction.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/ui/ShowGraphAction.java
@@ -17,9 +17,6 @@ import org.key_project.slicing.graph.GraphNode;
  * @author Arne Keller
  */
 public class ShowGraphAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -9022480738622934631L;
-
     /**
      * Dependency tracker to use when generating the graph excerpt.
      */
@@ -42,6 +39,7 @@ public class ShowGraphAction extends MainWindowAction {
         setName("Show dependency graph around this formula");
         this.tracker = tracker;
         this.node = node;
+        enabledOnAnActiveProof();
     }
 
     @Override

--- a/keyext.slicing/src/main/java/org/key_project/slicing/ui/ShowNodeInfoAction.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/ui/ShowNodeInfoAction.java
@@ -29,9 +29,6 @@ import org.key_project.util.collection.Pair;
  * @author Arne Keller
  */
 public class ShowNodeInfoAction extends MainWindowAction {
-
-    private static final long serialVersionUID = -1878750240016534264L;
-
     /**
      * Dependency tracker, used to get the information to display in the dialog.
      */

--- a/keyext.slicing/src/main/java/org/key_project/slicing/ui/SliceToFixedPointDialog.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/ui/SliceToFixedPointDialog.java
@@ -232,13 +232,13 @@ public class SliceToFixedPointDialog extends JDialog implements KeYSelectionList
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        if (e.getSource().getSelectedProof() != null
-                && e.getSource().getSelectedProof().closed()) {
-            if (e.getSource().getSelectedProof() == worker.getSlicedProof()) {
+        if (e.source().getSelectedProof() != null
+                && e.source().getSelectedProof().closed()) {
+            if (e.source().getSelectedProof() == worker.getSlicedProof()) {
                 return; // no need to slice this one again
             }
             // pass previously sliced proof to worker, so that it is disposed of later
-            worker = new SliceToFixedPointWorker(e.getSource().getSelectedProof(),
+            worker = new SliceToFixedPointWorker(e.source().getSelectedProof(),
                 worker.getSlicedProof(), analyzeButton, sliceButton, () -> {
                 });
             worker.execute();

--- a/keyext.slicing/src/main/java/org/key_project/slicing/ui/SlicingLeftPanel.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/ui/SlicingLeftPanel.java
@@ -531,7 +531,7 @@ public class SlicingLeftPanel extends JPanel implements TabPanel, KeYSelectionLi
 
     @Override
     public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-        currentProof = e.getSource().getSelectedProof();
+        currentProof = e.source().getSelectedProof();
         resetLabels();
         resetGraphLabels();
         updateUIState();

--- a/keyext.ui.testgen/src/main/java/de/uka/ilkd/key/gui/testgen/TestGenerationAction.java
+++ b/keyext.ui.testgen/src/main/java/de/uka/ilkd/key/gui/testgen/TestGenerationAction.java
@@ -4,19 +4,11 @@
 package de.uka.ilkd.key.gui.testgen;
 
 import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import javax.swing.*;
 
-import de.uka.ilkd.key.control.AutoModeListener;
-import de.uka.ilkd.key.core.KeYSelectionEvent;
-import de.uka.ilkd.key.core.KeYSelectionListener;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.MainWindowAction;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
-import de.uka.ilkd.key.proof.Node;
-import de.uka.ilkd.key.proof.Proof;
-import de.uka.ilkd.key.proof.ProofEvent;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
 
@@ -27,90 +19,46 @@ import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
  *
  * @author mihai
  */
-public class TestGenerationAction extends MainWindowAction implements PropertyChangeListener {
-    private static final long serialVersionUID = -4911859008849602897L;
-
+public class TestGenerationAction extends MainWindowAction {
     private static final String NAME = "Generate Testcases...";
     private static final String TOOLTIP = "Generate test cases for open goals";
     private static final String TOOLTIP_EXTRA = ". Install Z3 to enable this functionality!";
-    private boolean haveZ3CE = false;
 
     public TestGenerationAction(MainWindow mainWindow) {
         super(mainWindow);
         setName(NAME);
         setTooltip(TOOLTIP);
         Icon icon = IconFactory.testGeneration(MainWindow.TOOLBAR_ICON_SIZE);
-        putValue(SMALL_ICON, icon);
+        setSmallIcon(icon);
         setMenuPath("Proof");
-        init();
-    }
 
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        TGInfoDialog dlg = new TGInfoDialog(mainWindow);
-        dlg.setVisible(true);
-        dlg.setLocationRelativeTo(mainWindow);
-    }
+        enabledOnAnActiveProof();
+        enabledOnAnActiveProof();
 
-
-    /**
-     * Registers the action at some listeners to update its status in a correct fashion. This method
-     * has to be invoked after the Main class has been initialised with the KeYMediator.
-     */
-    public void init() {
-        ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings()
-                .addPropertyChangeListener(this);
-        checkZ3CE();
-
-        final KeYSelectionListener selListener = new KeYSelectionListener() {
-            @Override
-            public void selectedNodeChanged(KeYSelectionEvent<Node> e) {
-                final Proof proof = getMediator().getSelectedProof();
-                setEnabled(haveZ3CE && proof != null);
-            }
-
-            @Override
-            public void selectedProofChanged(KeYSelectionEvent<Proof> e) {
-                final Proof proof = getMediator().getSelectedProof();
-                setEnabled(haveZ3CE && proof != null);
-            }
-        };
-        getMediator().addKeYSelectionListener(selListener);
-        // This method delegates the request only to the UserInterfaceControl which implements the
-        // functionality.
-        // No functionality is allowed in this method body!
-        getMediator().getUI().getProofControl().addAutoModeListener(new AutoModeListener() {
-            @Override
-            public void autoModeStarted(ProofEvent e) {
-                getMediator().removeKeYSelectionListener(selListener);
-                setEnabled(false);
-            }
-
-            @Override
-            public void autoModeStopped(ProofEvent e) {
-                getMediator().addKeYSelectionListener(selListener);
-            }
-        });
-        selListener.selectedNodeChanged(new KeYSelectionEvent<>(getMediator().getSelectionModel()));
+        ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings().addPropertyChangeListener(
+            e -> updateEnabledness());
+        Pred z3CE = this::checkZ3CE;
+        setEnabledWhen(getEnabledWhen().and(z3CE));
     }
 
     /**
      * @return whether Z3 is installed
      */
     private boolean checkZ3CE() {
-        haveZ3CE = SolverTypes.Z3_CE_SOLVER.isInstalled(false);
+        var haveZ3CE = SolverTypes.Z3_CE_SOLVER.isInstalled(false);
         if (!haveZ3CE) {
-            setEnabled(false);
             setTooltip(TOOLTIP + TOOLTIP_EXTRA);
         } else if (!isEnabled()) {
-            setEnabled(getMediator().getSelectedProof() != null);
             setTooltip(TOOLTIP);
         }
         return haveZ3CE;
     }
 
+
     @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        checkZ3CE();
+    public void actionPerformed(ActionEvent e) {
+        TGInfoDialog dlg = new TGInfoDialog(mainWindow);
+        dlg.setVisible(true);
+        dlg.setLocationRelativeTo(mainWindow);
     }
 }


### PR DESCRIPTION
Fixes #3415. 

State: 

* [x] Glasspane removed
* [x] `KeyAction` classes extended for enabledness updates
* [x] Look through actions and decide whether they are safe or not to be executed during auto-mode.