### PR TITLE
Running SMT solvers without type hierarchy encoding

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SmtLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SmtLib2Translator.java
@@ -4,6 +4,8 @@
 package de.uka.ilkd.key.smt;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
 
 import de.uka.ilkd.key.java.Services;
 
@@ -93,8 +95,8 @@ public class SmtLib2Translator extends AbstractSMTTranslator {
      * @param preamble also also not used
      */
     @SuppressWarnings("unused") // can be called via reflection
-    public SmtLib2Translator(String[] handlerNames, String[] handlerOptions,
-            @Nullable String preamble) {
+    public SmtLib2Translator(Collection<String>[] handlerNames, Collection<String>[] handlerOptions,
+                             @Nullable String preamble) {
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SmtLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SmtLib2Translator.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.smt;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import de.uka.ilkd.key.java.Services;
@@ -95,7 +96,7 @@ public class SmtLib2Translator extends AbstractSMTTranslator {
      * @param preamble also also not used
      */
     @SuppressWarnings("unused") // can be called via reflection
-    public SmtLib2Translator(Collection<String>[] handlerNames, Collection<String>[] handlerOptions,
+    public SmtLib2Translator(List<String> handlerNames, Collection<String> handlerOptions,
                              @Nullable String preamble) {
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SolverLauncher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SolverLauncher.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.smt;
 
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Condition;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/BufferedMessageReader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/BufferedMessageReader.java
@@ -6,6 +6,8 @@ package de.uka.ilkd.key.smt.communication;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.HashSet;
 
 import org.key_project.util.java.IOUtil;
 
@@ -39,7 +41,7 @@ class BufferedMessageReader {
     private final Reader reader;
 
     /** the delimiters supported in this instance */
-    private final String[] delimiters;
+    private final Collection<String> delimiters;
 
     /**
      * Creates a new BufferedMessageReader wrapping the given Reader.
@@ -47,9 +49,9 @@ class BufferedMessageReader {
      * @param reader the Reader to wrap
      * @param delimiters the delimiters, where incoming messages should be split
      */
-    public BufferedMessageReader(Reader reader, String[] delimiters) {
+    public BufferedMessageReader(Reader reader, Collection<String> delimiters) {
         this.reader = reader;
-        this.delimiters = delimiters;
+        this.delimiters = new HashSet<>(delimiters);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/ExternalProcessLauncher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/ExternalProcessLauncher.java
@@ -4,6 +4,8 @@
 package de.uka.ilkd.key.smt.communication;
 
 import java.io.*;
+import java.util.Collection;
+import java.util.HashSet;
 
 import org.jspecify.annotations.NonNull;
 
@@ -27,7 +29,7 @@ public class ExternalProcessLauncher {
     /**
      * the delimiters which separate the messages
      */
-    private final @NonNull String[] messageDelimiters;
+    private final @NonNull Collection<String> messageDelimiters;
 
     /**
      * the external process
@@ -46,9 +48,9 @@ public class ExternalProcessLauncher {
      * @param messageDelimiters delimiters which separate the messages
      */
     public ExternalProcessLauncher(@NonNull SolverCommunication session,
-            @NonNull String[] messageDelimiters) {
+            @NonNull Collection<String> messageDelimiters) {
         this.session = session;
-        this.messageDelimiters = messageDelimiters;
+        this.messageDelimiters = new HashSet<>(messageDelimiters);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/LegacyPipe.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/LegacyPipe.java
@@ -6,6 +6,8 @@ package de.uka.ilkd.key.smt.communication;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -38,7 +40,7 @@ class LegacyPipe implements Pipe {
      * specify several delimiters a single message is chosen as small as possible, i.e., it does not
      * contain any delimiter.
      */
-    private final String[] messageDelimiters;
+    private final Collection<String> messageDelimiters;
 
     private static final Message EXCEPTION_MESSAGE = new Message("Exception", MessageType.ERROR);
 
@@ -55,9 +57,9 @@ class LegacyPipe implements Pipe {
     private Process process;
 
 
-    public LegacyPipe(SolverCommunication session, String[] messageDelimiters) {
+    public LegacyPipe(SolverCommunication session, Collection<String> messageDelimiters) {
         this.session = session;
-        this.messageDelimiters = messageDelimiters;
+        this.messageDelimiters = new HashSet<>(messageDelimiters);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/SimplePipe.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/SimplePipe.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.smt.communication;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -72,7 +73,7 @@ public class SimplePipe implements Pipe {
      * @param session the message list where to log the messages to
      * @param process the external process this pipe is connected to
      */
-    public SimplePipe(@NonNull InputStream input, @NonNull String[] messageDelimiters,
+    public SimplePipe(@NonNull InputStream input, @NonNull Collection<String> messageDelimiters,
             @NonNull OutputStream output, @NonNull SolverCommunication session,
             @NonNull Process process) {
         processWriter =

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/BooleanConnectiveHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/BooleanConnectiveHandler.java
@@ -36,8 +36,7 @@ public class BooleanConnectiveHandler implements SMTHandler {
     }
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         BooleanLDT ldt = services.getTypeConverter().getBooleanLDT();
         Operator logicFalse = ldt.getFalseConst();
         supportedOperators.put(logicFalse, "false");

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/CastHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/CastHandler.java
@@ -26,8 +26,7 @@ public class CastHandler implements SMTHandler {
     private SortDependingFunction anyCast;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) throws IOException {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) throws IOException {
         this.anyCast = services.getJavaDLTheory().getCastSymbol(JavaDLTheory.ANY, services);
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/CastingFunctionsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/CastingFunctionsHandler.java
@@ -33,8 +33,7 @@ public class CastingFunctionsHandler implements SMTHandler {
     private SortDependingFunction select;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.seqGet = services.getTypeConverter().getSeqLDT().getSeqGet(JavaDLTheory.ANY, services);
         this.select =
             services.getTypeConverter().getHeapLDT().getSelect(JavaDLTheory.ANY, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/DefinedSymbolsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/DefinedSymbolsHandler.java
@@ -99,8 +99,7 @@ public class DefinedSymbolsHandler implements SMTHandler {
     private boolean enabled;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) throws IOException {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) throws IOException {
         this.services = services;
         this.snippets = handlerSnippets;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/DefinedSymbolsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/DefinedSymbolsHandler.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.NamespaceSet;
 import de.uka.ilkd.key.logic.Term;
@@ -97,11 +98,13 @@ public class DefinedSymbolsHandler implements SMTHandler {
 
     private Properties snippets;
     private boolean enabled;
+    private IntegerLDT integerLDT;
 
     @Override
     public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) throws IOException {
         this.services = services;
         this.snippets = handlerSnippets;
+        this.integerLDT = services.getTypeConverter().getIntegerLDT();
 
         // extract the list of supported suffixes from the keys in the
         // properties.
@@ -192,7 +195,7 @@ public class DefinedSymbolsHandler implements SMTHandler {
         String prefixedname = PREFIX + name;
 
         List<SExpr> children = trans.translate(term.subs(), Type.UNIVERSE);
-        SExpr.Type exprType = term.sort() == JavaDLTheory.FORMULA ? BOOL : UNIVERSE;
+        SExpr.Type exprType = term.sort() == JavaDLTheory.FORMULA ? BOOL : (term.sort() == integerLDT.targetSort() ? Type.INT : UNIVERSE);
         SExpr result = new SExpr(prefixedname, exprType, children);
 
         if (!introduceSymbol(trans, name, op)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
@@ -48,8 +48,7 @@ public class FieldConstantHandler implements SMTHandler {
     private Services services;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.services = services;
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FieldConstantHandler.java
@@ -90,7 +90,7 @@ public class FieldConstantHandler implements SMTHandler {
 
                 trans.addAxiom(
                     new SExpr("assert", new SExpr("=", new SExpr("fieldIdentifier", smtName),
-                        new SExpr("-", IntegerOpHandler.INT, curVal.toString()))));
+                        new SExpr("-", Type.INT, curVal.toString()))));
 
                 state.put(CONSTANT_COUNTER_PROPERTY, curVal + 1);
                 trans.addKnownSymbol(smtName);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FloatHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FloatHandler.java
@@ -56,8 +56,7 @@ public class FloatHandler implements SMTHandler {
     private boolean sqrtNative;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) throws IOException {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) throws IOException {
 
         this.services = services;
         floatLDT = services.getTypeConverter().getFloatLDT();

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FloatRemainderHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/FloatRemainderHandler.java
@@ -33,8 +33,7 @@ public class FloatRemainderHandler implements SMTHandler {
     private Sort doubleSort;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         floatSort = services.getTypeConverter().getFloatLDT().targetSort();
         doubleSort = services.getTypeConverter().getDoubleLDT().targetSort();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/InstanceOfHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/InstanceOfHandler.java
@@ -25,8 +25,7 @@ public class InstanceOfHandler implements SMTHandler {
     private SortDependingFunction instanceOfOp;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.instanceOfOp =
             services.getJavaDLTheory().getInstanceofSymbol(JavaDLTheory.ANY, services);
         this.exactInstanceOfOp =

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -38,8 +38,7 @@ public class IntegerOpHandler implements SMTHandler {
     private IntegerLDT integerLDT;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         supportedOperators.clear();
         this.integerLDT = services.getTypeConverter().getIntegerLDT();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -23,9 +23,7 @@ import de.uka.ilkd.key.smt.newsmt2.SMTHandlerProperty.BooleanProperty;
  */
 public class IntegerOpHandler implements SMTHandler {
 
-    /** to indicate that an expression holds a value of type Int. */
-    //public static final Type INT = new Type("Int", "i2u", "u2i");
-    public static final Type INT = new Type("Int", null, null);
+
 
     public static final SMTHandlerProperty.BooleanProperty PROPERTY_PRESBURGER =
         new BooleanProperty("Presburger", "Limit arithmetics to Presburger arithmetic (LIA)",
@@ -62,11 +60,9 @@ public class IntegerOpHandler implements SMTHandler {
 
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
 
-        if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
-            // sort_int is defined here, declare it as already defined
-            masterHandler.addKnownSymbol("sort_int");
-            masterHandler.addSort(integerLDT.targetSort());
-        }
+        // sort_int is defined here, declare it as already defined
+        masterHandler.addKnownSymbol("sort_int");
+        masterHandler.addSort(integerLDT.targetSort());
 
         this.limitedToPresbuger = PROPERTY_PRESBURGER.get(masterHandler.getTranslationState());
     }
@@ -100,7 +96,7 @@ public class IntegerOpHandler implements SMTHandler {
 
     @Override
     public SExpr handle(MasterHandler trans, Term term) throws SMTTranslationException {
-        List<SExpr> children = trans.translate(term.subs(), IntegerOpHandler.INT);
+        List<SExpr> children = trans.translate(term.subs());
         Operator op = term.op();
         String smtOp = supportedOperators.get(op);
         assert smtOp != null;
@@ -109,7 +105,7 @@ public class IntegerOpHandler implements SMTHandler {
         if (predicateOperators.contains(op)) {
             resultType = Type.BOOL;
         } else {
-            resultType = IntegerOpHandler.INT;
+            resultType = Type.INT;
         }
 
         return new SExpr(smtOp, resultType, children);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -61,8 +61,8 @@ public class IntegerOpHandler implements SMTHandler {
 
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
 
-        // sort_int is defined here, declare it as already defined
-        if(!masterHandler.noTypeEmbedding()) {
+        if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
+            // sort_int is defined here, declare it as already defined
             masterHandler.addKnownSymbol("sort_int");
             masterHandler.addSort(integerLDT.targetSort());
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -24,7 +24,8 @@ import de.uka.ilkd.key.smt.newsmt2.SMTHandlerProperty.BooleanProperty;
 public class IntegerOpHandler implements SMTHandler {
 
     /** to indicate that an expression holds a value of type Int. */
-    public static final Type INT = new Type("Int", "i2u", "u2i");
+    //public static final Type INT = new Type("Int", "i2u", "u2i");
+    public static final Type INT = new Type("Int", null, null);
 
     public static final SMTHandlerProperty.BooleanProperty PROPERTY_PRESBURGER =
         new BooleanProperty("Presburger", "Limit arithmetics to Presburger arithmetic (LIA)",
@@ -61,11 +62,11 @@ public class IntegerOpHandler implements SMTHandler {
 
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
 
-        //if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
+        if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
             // sort_int is defined here, declare it as already defined
             masterHandler.addKnownSymbol("sort_int");
             masterHandler.addSort(integerLDT.targetSort());
-        //}
+        }
 
         this.limitedToPresbuger = PROPERTY_PRESBURGER.get(masterHandler.getTranslationState());
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -96,7 +96,7 @@ public class IntegerOpHandler implements SMTHandler {
 
     @Override
     public SExpr handle(MasterHandler trans, Term term) throws SMTTranslationException {
-        List<SExpr> children = trans.translate(term.subs());
+        List<SExpr> children = trans.translate(term.subs(), Type.INT);
         Operator op = term.op();
         String smtOp = supportedOperators.get(op);
         assert smtOp != null;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -62,8 +62,10 @@ public class IntegerOpHandler implements SMTHandler {
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
 
         // sort_int is defined here, declare it as already defined
-        masterHandler.addKnownSymbol("sort_int");
-        masterHandler.addSort(integerLDT.targetSort());
+        if(!masterHandler.noTypeEmbedding()) {
+            masterHandler.addKnownSymbol("sort_int");
+            masterHandler.addSort(integerLDT.targetSort());
+        }
 
         this.limitedToPresbuger = PROPERTY_PRESBURGER.get(masterHandler.getTranslationState());
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/IntegerOpHandler.java
@@ -61,11 +61,11 @@ public class IntegerOpHandler implements SMTHandler {
 
         masterHandler.addDeclarationsAndAxioms(handlerSnippets);
 
-        if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
+        //if (!masterHandler.isHandlerOptionSet(ModularSMTLib2Translator.NO_TYPE_EMBEDDING)) {
             // sort_int is defined here, declare it as already defined
             masterHandler.addKnownSymbol("sort_int");
             masterHandler.addSort(integerLDT.targetSort());
-        }
+        //}
 
         this.limitedToPresbuger = PROPERTY_PRESBURGER.get(masterHandler.getTranslationState());
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/LogicalVariableHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/LogicalVariableHandler.java
@@ -28,8 +28,7 @@ public class LogicalVariableHandler implements SMTHandler {
     static final String VAR_PREFIX = "var_";
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         // nothing to be done
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/LogicalVariableHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/LogicalVariableHandler.java
@@ -56,7 +56,7 @@ public class LogicalVariableHandler implements SMTHandler {
         if (sort.name().equals(IntegerLDT.NAME)) {
             // Special casing integer quantification: Avoid conversion to "U".
             // Caution: Must be in sync with quantifier treatment.
-            return new SExpr(VAR_PREFIX + name, IntegerOpHandler.INT);
+            return new SExpr(VAR_PREFIX + name, Type.INT);
         } else {
             return new SExpr(VAR_PREFIX + name, Type.UNIVERSE);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
@@ -74,6 +74,11 @@ public class MasterHandler {
     private final Map<Operator, SMTHandler> handlerMap = new IdentityHashMap<>();
 
     /**
+     * Handler Options to be used by all the other SMT handlers.
+     */
+    private final String[] handlerOptions;
+
+    /**
      * Create a new handler with the default set of smt handlers.
      *
      * @param services non-null services
@@ -86,8 +91,13 @@ public class MasterHandler {
     public MasterHandler(Services services, SMTSettings settings, String[] handlerNames,
             String[] handlerOptions) throws IOException {
         getTranslationState().putAll(settings.getNewSettings().getMap());
-        handlers = SMTHandlerServices.getInstance().getFreshHandlers(services, handlerNames,
-            handlerOptions, this);
+        this.handlerOptions = handlerOptions;
+        handlers = SMTHandlerServices.getInstance().getFreshHandlers(services, handlerNames, this);
+    }
+
+    public String[] getHandlerOptions() {
+        // TODO clone array instead?
+        return handlerOptions;
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
@@ -4,16 +4,8 @@
 package de.uka.ilkd.key.smt.newsmt2;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
@@ -98,6 +90,10 @@ public class MasterHandler {
     public String[] getHandlerOptions() {
         // TODO clone array instead?
         return handlerOptions;
+    }
+
+    public boolean noTypeEmbedding () {
+        return Arrays.asList(handlerOptions).contains(ModularSMTLib2Translator.NO_TYPE_EMBEDDING);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
@@ -45,7 +45,7 @@ public class MasterHandler {
     private final List<Writable> axioms = new ArrayList<>();
 
     /** A list of known symbols */
-    private final Set<String> knownSymbols = new HashSet<>();
+    private final Collection<String> knownSymbols = new HashSet<>();
 
     /** A list of untranslatable values */
     private final Map<Term, SExpr> unknownValues = new HashMap<>();
@@ -68,7 +68,7 @@ public class MasterHandler {
     /**
      * Handler Options to be used by all the other SMT handlers.
      */
-    private final String[] handlerOptions;
+    private final Collection<String> handlerOptions;
 
     /**
      * Create a new handler with the default set of smt handlers.
@@ -80,16 +80,17 @@ public class MasterHandler {
      * @param handlerOptions arbitrary String options for the handlers to process
      * @throws IOException if the handlers cannot be loaded
      */
-    public MasterHandler(Services services, SMTSettings settings, String[] handlerNames,
-            String[] handlerOptions) throws IOException {
+    public MasterHandler(Services services, SMTSettings settings,
+                         Collection<String> handlerNames, Collection<String> handlerOptions)
+            throws IOException {
         getTranslationState().putAll(settings.getNewSettings().getMap());
         this.handlerOptions = handlerOptions;
         handlers = SMTHandlerServices.getInstance().getFreshHandlers(services, handlerNames, this);
     }
 
-    public String[] getHandlerOptions() {
+    public Set<String> getHandlerOptions() {
         // TODO clone array instead?
-        return handlerOptions;
+        return new HashSet<>(handlerOptions);
     }
 
     public boolean noTypeEmbedding () {

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/MasterHandler.java
@@ -88,13 +88,8 @@ public class MasterHandler {
         handlers = SMTHandlerServices.getInstance().getFreshHandlers(services, handlerNames, this);
     }
 
-    public Set<String> getHandlerOptions() {
-        // TODO clone array instead?
-        return new HashSet<>(handlerOptions);
-    }
-
-    public boolean noTypeEmbedding () {
-        return Arrays.asList(handlerOptions).contains(ModularSMTLib2Translator.NO_TYPE_EMBEDDING);
+    public boolean isHandlerOptionSet(String optionName) {
+        return handlerOptions.contains(optionName);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -7,9 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Sequent;
@@ -63,11 +61,11 @@ public class ModularSMTLib2Translator implements SMTTranslator {
     /**
      * The fully classified class names of the SMTHandlers used by this translator.
      */
-    private final String[] handlerNames;
+    private final Collection<String> handlerNames;
     /**
      * Arbitrary String options for the SMTHandlers used by this translator.
      */
-    private final String[] handlerOptions;
+    private final Collection<String> handlerOptions;
 
     /**
      * Customizable preamble and {@link SMTHandler} list for this Translator to use instead of the
@@ -78,15 +76,15 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      * @param handlerNames fully classified class names of the SMTHandlers to be used by this
      *        translator
      */
-    public ModularSMTLib2Translator(String[] handlerNames, String[] handlerOptions,
-            @Nullable String preamble) {
+    public ModularSMTLib2Translator(Collection<String> handlerNames, Collection<String> handlerOptions,
+                                    @Nullable String preamble) {
         if (preamble == null) {
             this.preamble = SMTHandlerServices.getInstance().getPreamble();
         } else {
             this.preamble = preamble;
         }
-        this.handlerNames = handlerNames;
-        this.handlerOptions = handlerOptions;
+        this.handlerNames = new HashSet<>(handlerNames);
+        this.handlerOptions = new HashSet<>(handlerOptions);
         /*
          * Make sure to load the needed handlers once so that their smt properties are loaded as
          * well. This is needed so that the properties already exist before first translating
@@ -106,7 +104,7 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      * preamble may be the one from {@link SMTHandlerServices#getPreamble()}.
      */
     public ModularSMTLib2Translator() {
-        this(new String[0], new String[0], null);
+        this(new HashSet<>(), new HashSet<>(), null);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -59,9 +59,10 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      */
     private final String preamble;
     /**
-     * The fully classified class names of the SMTHandlers used by this translator.
+     * The fully classified class names of the SMTHandlers used by this translator. Careful here:
+     * The order is very important!
      */
-    private final Collection<String> handlerNames;
+    private final List<String> handlerNames;
     /**
      * Arbitrary String options for the SMTHandlers used by this translator.
      */
@@ -76,14 +77,14 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      * @param handlerNames fully classified class names of the SMTHandlers to be used by this
      *        translator
      */
-    public ModularSMTLib2Translator(Collection<String> handlerNames, Collection<String> handlerOptions,
+    public ModularSMTLib2Translator(List<String> handlerNames, Collection<String> handlerOptions,
                                     @Nullable String preamble) {
         if (preamble == null) {
             this.preamble = SMTHandlerServices.getInstance().getPreamble();
         } else {
             this.preamble = preamble;
         }
-        this.handlerNames = new HashSet<>(handlerNames);
+        this.handlerNames = new ArrayList<>(handlerNames);
         this.handlerOptions = new HashSet<>(handlerOptions);
         /*
          * Make sure to load the needed handlers once so that their smt properties are loaded as
@@ -104,7 +105,7 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      * preamble may be the one from {@link SMTHandlerServices#getPreamble()}.
      */
     public ModularSMTLib2Translator() {
-        this(new HashSet<>(), new HashSet<>(), null);
+        this(new ArrayList<>(), new HashSet<>(), null);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -54,6 +54,8 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      */
     private static final String GET_UNSAT_CORE = "getUnsatCore";
 
+    public static final String NO_TYPE_EMBEDDING = "noTypeEmbedding";
+
     /**
      * The smt preamble prepended to smt problems that are created with this translator.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/NumberConstantsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/NumberConstantsHandler.java
@@ -24,8 +24,7 @@ public class NumberConstantsHandler implements SMTHandler {
     private Function negNumberSign;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.services = services;
         numberSymbol = services.getTypeConverter().getIntegerLDT().getNumberSymbol();
         negNumberSign = services.getTypeConverter().getIntegerLDT().getNegativeNumberSign();

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/NumberConstantsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/NumberConstantsHandler.java
@@ -39,10 +39,10 @@ public class NumberConstantsHandler implements SMTHandler {
     public SExpr handle(MasterHandler trans, Term term) {
         if (term.sub(0).op() == negNumberSign) {
             String s = AbstractTermTransformer.convertToDecimalString(term, services);
-            return new SExpr("-", IntegerOpHandler.INT, s.substring(1));
+            return new SExpr("-", SExpr.Type.INT, s.substring(1));
         } else {
             String string = AbstractTermTransformer.convertToDecimalString(term, services);
-            return new SExpr(string, IntegerOpHandler.INT);
+            return new SExpr(string, SExpr.Type.INT);
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/PolymorphicHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/PolymorphicHandler.java
@@ -40,13 +40,7 @@ public class PolymorphicHandler implements SMTHandler {
     public SExpr handle(MasterHandler trans, Term term) throws SMTTranslationException {
         Operator op = term.op();
         if (op == Equality.EQUALS) {
-            List<SExpr> children = trans.translate(term.subs());
-                if (term.subs().get(0).sort() == integerLDT.targetSort() && term.subs().get(1).sort() == integerLDT.targetSort()) {
-                    children = trans.translate(term.subs(), Type.INT);
-                } else {
-                    children = trans.translate(term.subs(), Type.UNIVERSE);
-                }
-                return new SExpr("=", Type.BOOL, children);
+            return new SExpr("=", Type.BOOL, trans.translate(term.subs(), Type.UNIVERSE));
         }
 
         if (op == IfThenElse.IF_THEN_ELSE) {

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/PolymorphicHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/PolymorphicHandler.java
@@ -22,8 +22,7 @@ import de.uka.ilkd.key.smt.newsmt2.SExpr.Type;
 public class PolymorphicHandler implements SMTHandler {
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         // nothing to be done
         // there are also no snippets.
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/QuantifierHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/QuantifierHandler.java
@@ -34,8 +34,7 @@ public class QuantifierHandler implements SMTHandler {
     private Services services;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.services = services;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SExpr.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SExpr.java
@@ -45,6 +45,11 @@ public class SExpr implements Writable {
              */
             public static final Type BOOL = new Type("Bool", "b2u", "u2b");
 
+            /** to indicate that an expression holds a value of type Int. */
+            //public static final Type INT = new Type("Int", "i2u", "u2i");
+            public static final Type INT = new Type("Int", null, null);
+
+
         @Override
             public String toString() {
                 return name;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SExprs.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SExprs.java
@@ -43,7 +43,9 @@ public class SExprs {
     /**
      * The constant "0" of type Int
      */
-    public static final SExpr ZERO = new SExpr("0", IntegerOpHandler.INT);
+    public static final SExpr ZERO = new SExpr("0", Type.INT);
+
+
 
     /**
      * Produce a conjunction of SExprs.
@@ -317,18 +319,18 @@ public class SExprs {
     }
 
     public static SExpr greaterEqual(SExpr a, SExpr b) throws SMTTranslationException {
-        return new SExpr(">=", Type.BOOL, SExprs.coerce(a, IntegerOpHandler.INT),
-            SExprs.coerce(b, IntegerOpHandler.INT));
+        return new SExpr(">=", Type.BOOL, SExprs.coerce(a, Type.INT),
+            SExprs.coerce(b, Type.INT));
     }
 
     public static SExpr lessEqual(SExpr a, SExpr b) throws SMTTranslationException {
-        return new SExpr("<=", Type.BOOL, SExprs.coerce(a, IntegerOpHandler.INT),
-            SExprs.coerce(b, IntegerOpHandler.INT));
+        return new SExpr("<=", Type.BOOL, SExprs.coerce(a, Type.INT),
+            SExprs.coerce(b, Type.INT));
     }
 
     public static SExpr lessThan(SExpr a, SExpr b) throws SMTTranslationException {
-        return new SExpr("<", Type.BOOL, SExprs.coerce(a, IntegerOpHandler.INT),
-            SExprs.coerce(b, IntegerOpHandler.INT));
+        return new SExpr("<", Type.BOOL, SExprs.coerce(a, Type.INT),
+            SExprs.coerce(b, Type.INT));
     }
 
     public static SExpr eq(SExpr a, SExpr b) throws SMTTranslationException {
@@ -336,13 +338,13 @@ public class SExprs {
     }
 
     public static SExpr minus(SExpr a, SExpr b) throws SMTTranslationException {
-        return new SExpr("-", IntegerOpHandler.INT, SExprs.coerce(a, IntegerOpHandler.INT),
-            SExprs.coerce(b, IntegerOpHandler.INT));
+        return new SExpr("-", Type.INT, SExprs.coerce(a, Type.INT),
+            SExprs.coerce(b, Type.INT));
     }
 
     public static SExpr plus(SExpr a, SExpr b) throws SMTTranslationException {
-        return new SExpr("+", IntegerOpHandler.INT, SExprs.coerce(a, IntegerOpHandler.INT),
-            SExprs.coerce(b, IntegerOpHandler.INT));
+        return new SExpr("+", Type.INT, SExprs.coerce(a, Type.INT),
+            SExprs.coerce(b, Type.INT));
     }
 
     public static SExpr ite(SExpr cond, SExpr _then, SExpr _else) throws SMTTranslationException {

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandler.java
@@ -68,8 +68,7 @@ public interface SMTHandler {
      * @param handlerOptions arbitrary options for the handler to take into account
      * @throws IOException if resources cannot be read.
      */
-    void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) throws IOException;
+    void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) throws IOException;
 
     /**
      * Query if this handler can translate a term.

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandlerServices.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandlerServices.java
@@ -177,7 +177,7 @@ public class SMTHandlerServices {
      */
 
     public List<SMTHandler> getFreshHandlers(Services services, @NonNull String[] handlerNames,
-            String[] handlerOptions, MasterHandler mh) throws IOException {
+                                             MasterHandler mh) throws IOException {
 
         List<SMTHandler> result = new ArrayList<>();
 
@@ -194,7 +194,7 @@ public class SMTHandlerServices {
                  * modification of the snippetMap while accessing it. snippet =
                  * snippetMap.get(handler); }
                  */
-                copy.init(mh, services, snippetMap.get(handler), handlerOptions);
+                copy.init(mh, services, snippetMap.get(handler));
                 result.add(copy);
             } catch (Exception e) {
                 throw new IOException(e);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandlerServices.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTHandlerServices.java
@@ -103,13 +103,14 @@ public class SMTHandlerServices {
      *         names as well.
      * @throws IOException if loading the snippet Properties for a handler class fails
      */
-    public Collection<SMTHandler> getTemplateHandlers(String[] handlerNames) throws IOException {
+    public Collection<SMTHandler> getTemplateHandlers(Collection<String> handlerNames) throws IOException {
         // If handlerNames is empty, use default handlerNames list.
-        if (handlerNames.length == 0) {
+        if (handlerNames.size() == 0) {
             InputStream stream = SolverPropertiesLoader.class.getResourceAsStream(DEFAULT_HANDLERS);
             BufferedReader reader =
                 new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-            handlerNames = reader.lines().toArray(String[]::new);
+            handlerNames = new HashSet<>();
+            Collections.addAll(handlerNames, reader.lines().toArray(String[]::new));
         }
         Collection<SMTHandler> result = new LinkedList<>();
         for (String name : handlerNames) {
@@ -170,13 +171,12 @@ public class SMTHandlerServices {
      * @param services passed on to the handlers for initialisation
      * @param handlerNames the fully classified class names of the SMTHandlers to be used If this is
      *        empty or null, all existing handlers will be used.
-     * @param handlerOptions arbitrary String options for the SMTHandlers
      * @param mh passed on to the handlers for initialisation
      * @return a freshly created list of freshly created handlers
      * @throws IOException if the resources cannot be read
      */
 
-    public List<SMTHandler> getFreshHandlers(Services services, @NonNull String[] handlerNames,
+    public List<SMTHandler> getFreshHandlers(Services services, @NonNull Collection<String> handlerNames,
                                              MasterHandler mh) throws IOException {
 
         List<SMTHandler> result = new ArrayList<>();

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SeqDefHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SeqDefHandler.java
@@ -143,8 +143,8 @@ public class SeqDefHandler implements SMTHandler {
         // \forall freevars; seqLen(function(params)) = \if(up-lo>=0) \then(up-lo) \else 0
         SExpr app = new SExpr(function, params);
         SExpr seqLen = new SExpr(SEQLEN, app);
-        SExpr len = SExprs.minus(trans.translate(term.sub(1), IntegerOpHandler.INT),
-            trans.translate(term.sub(0), IntegerOpHandler.INT));
+        SExpr len = SExprs.minus(trans.translate(term.sub(1), Type.INT),
+            trans.translate(term.sub(0), Type.INT));
         SExpr ite = SExprs.ite(SExprs.greaterEqual(len, SExprs.ZERO), len, SExprs.ZERO);
         SExpr eq = SExprs.eq(seqLen, ite);
         SExpr forall = SExprs.forall(qvars, eq);
@@ -180,13 +180,13 @@ public class SeqDefHandler implements SMTHandler {
         SExpr i = LogicalVariableHandler.makeVarRef(name, sort);
         qvars.add(LogicalVariableHandler.makeVarDecl(name, sort));
         guards.add(SExprs.lessEqual(SExprs.ZERO, i));
-        SExpr upper = trans.translate(term.sub(1), IntegerOpHandler.INT);
-        SExpr lower = trans.translate(term.sub(0), IntegerOpHandler.INT);
+        SExpr upper = trans.translate(term.sub(1), Type.INT);
+        SExpr lower = trans.translate(term.sub(0), Type.INT);
         SExpr len = SExprs.minus(upper, lower);
         guards.add(SExprs.lessThan(i, len));
         SExpr smtTerm = trans.translate(term.sub(2), Type.UNIVERSE);
         SExpr replacedSMTTerm = SExprs.let(LogicalVariableHandler.VAR_PREFIX + name,
-            SExprs.coerce(SExprs.plus(i, lower), IntegerOpHandler.INT), smtTerm);
+            SExprs.coerce(SExprs.plus(i, lower), Type.INT), smtTerm);
         SExpr seqGet = new SExpr(SEQGET, Type.UNIVERSE, app, new SExpr("i2u", i));
         SExpr imp = SExprs.imp(SExprs.and(guards), SExprs.eq(seqGet, replacedSMTTerm));
         SExpr forall = SExprs.forall(qvars, imp);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SeqDefHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SeqDefHandler.java
@@ -54,8 +54,7 @@ public class SeqDefHandler implements SMTHandler {
     private TermFactory termFactory;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         enabled = !HandlerUtil.PROPERTY_NOBINDERS.get(masterHandler.getTranslationState());
         seqLDT = services.getTypeConverter().getSeqLDT();
         termFactory = services.getTermFactory();

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SumProdHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SumProdHandler.java
@@ -49,10 +49,10 @@ public class SumProdHandler implements SMTHandler {
             }
             List<SExpr> exprs = new LinkedList<>();
             exprs.add(trans.translate(term.sub(0)));
-            exprs.add(SExprs.coerce(trans.translate(term.sub(1)), IntegerOpHandler.INT));
+            exprs.add(SExprs.coerce(trans.translate(term.sub(1)), SExpr.Type.INT));
             String s = String.valueOf(usedBsumTerms.size());
             trans.addDeclaration(bsumOrProdDecl("bsum", s));
-            SExpr ret = new SExpr("bsum" + s, IntegerOpHandler.INT, exprs);
+            SExpr ret = new SExpr("bsum" + s, SExpr.Type.INT, exprs);
             usedBsumTerms.put(term, ret);
             return ret;
         } else if (op == bprodOp) {
@@ -63,10 +63,10 @@ public class SumProdHandler implements SMTHandler {
             }
             List<SExpr> exprs = new LinkedList<>();
             exprs.add(trans.translate(term.sub(0)));
-            exprs.add(SExprs.coerce(trans.translate(term.sub(1)), IntegerOpHandler.INT));
+            exprs.add(SExprs.coerce(trans.translate(term.sub(1)), SExpr.Type.INT));
             String s = String.valueOf(usedBprodTerms.size());
             trans.addDeclaration(bsumOrProdDecl("bprod", s));
-            SExpr ret = new SExpr("bprod" + s, IntegerOpHandler.INT, exprs);
+            SExpr ret = new SExpr("bprod" + s, SExpr.Type.INT, exprs);
             usedBprodTerms.put(term, ret);
             return ret;
         } else { // unreachable
@@ -75,7 +75,7 @@ public class SumProdHandler implements SMTHandler {
     }
 
     private SExpr bsumOrProdDecl(String fun, String number) {
-        return new SExpr("declare-fun", IntegerOpHandler.INT, new SExpr(fun + number),
+        return new SExpr("declare-fun", SExpr.Type.INT, new SExpr(fun + number),
             new SExpr(new SExpr("Int"), new SExpr("Int")), new SExpr("Int"));
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SumProdHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SumProdHandler.java
@@ -26,8 +26,7 @@ public class SumProdHandler implements SMTHandler {
     private final Map<Term, SExpr> usedBprodTerms = new LinkedHashMap<>();
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         bsumOp = services.getTypeConverter().getIntegerLDT().getBsum();
         bprodOp = services.getTypeConverter().getIntegerLDT().getBprod();
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
@@ -8,6 +8,7 @@ import java.util.Properties;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
+import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.JFunction;
 import de.uka.ilkd.key.logic.op.Operator;
@@ -29,12 +30,14 @@ import static de.uka.ilkd.key.smt.newsmt2.SExpr.Type.UNIVERSE;
 public class UninterpretedSymbolsHandler implements SMTHandler {
 
     public final static String PREFIX = "u_";
+    private IntegerLDT integerLDT;
 
     // TODO This flag does not seem to be 100% what it is supposed to. Refactor. MU
     private boolean enableQuantifiers;
 
     @Override
     public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
+        this.integerLDT = services.getTypeConverter().getIntegerLDT();
         enableQuantifiers = !HandlerUtil.NO_QUANTIFIERS.get(services);
     }
 
@@ -68,7 +71,7 @@ public class UninterpretedSymbolsHandler implements SMTHandler {
         }
 
         List<SExpr> children = trans.translate(term.subs(), Type.UNIVERSE);
-        SExpr.Type exprType = term.sort() == JavaDLTheory.FORMULA ? BOOL : UNIVERSE;
+        SExpr.Type exprType = (term.sort() == JavaDLTheory.FORMULA) ? BOOL : (term.sort() == integerLDT.targetSort() ? IntegerOpHandler.INT : UNIVERSE);
         return new SExpr(name, exprType, children);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
@@ -71,7 +71,7 @@ public class UninterpretedSymbolsHandler implements SMTHandler {
         }
 
         List<SExpr> children = trans.translate(term.subs(), Type.UNIVERSE);
-        SExpr.Type exprType = (term.sort() == JavaDLTheory.FORMULA) ? BOOL : (term.sort() == integerLDT.targetSort() ? IntegerOpHandler.INT : UNIVERSE);
+        SExpr.Type exprType = (term.sort() == JavaDLTheory.FORMULA) ? BOOL : (term.sort() == integerLDT.targetSort() ? Type.INT : UNIVERSE);
         return new SExpr(name, exprType, children);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UninterpretedSymbolsHandler.java
@@ -34,8 +34,7 @@ public class UninterpretedSymbolsHandler implements SMTHandler {
     private boolean enableQuantifiers;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         enableQuantifiers = !HandlerUtil.NO_QUANTIFIERS.get(services);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UpdateHandler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/UpdateHandler.java
@@ -26,8 +26,7 @@ public class UpdateHandler implements SMTHandler {
     private Services services;
 
     @Override
-    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets,
-            String[] handlerOptions) {
+    public void init(MasterHandler masterHandler, Services services, Properties handlerSnippets) {
         this.services = services;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverPropertiesLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverPropertiesLoader.java
@@ -243,7 +243,7 @@ public class SolverPropertiesLoader {
         long timeout;
         Class<?> solverSocketClass;
         Class<?> translatorClass;
-        Set<String> handlerNames = new HashSet<>();
+        List<String> handlerNames = new ArrayList<>();
         Set<String> handlerOptions = new HashSet<>();
         Set<String> delimiters = new HashSet<>();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverPropertiesLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverPropertiesLoader.java
@@ -243,9 +243,9 @@ public class SolverPropertiesLoader {
         long timeout;
         Class<?> solverSocketClass;
         Class<?> translatorClass;
-        String[] handlerNames;
-        String[] handlerOptions;
-        String[] delimiters;
+        Set<String> handlerNames = new HashSet<>();
+        Set<String> handlerOptions = new HashSet<>();
+        Set<String> delimiters = new HashSet<>();
 
         // Read props file to create a SolverTypeImplementation object:
 
@@ -279,8 +279,9 @@ public class SolverPropertiesLoader {
 
 
         // the message DELIMITERS used by the created solver in its stdout
-        delimiters = SettingsConverter.readRawStringList(props, SolverPropertiesLoader.DELIMITERS,
-            SPLIT, DEFAULT_DELIMITERS);
+        Collections.addAll(delimiters,
+                SettingsConverter.readRawStringList(props,
+                        SolverPropertiesLoader.DELIMITERS, SPLIT, DEFAULT_DELIMITERS));
 
         // the smt translator (class SMTTranslator) used by the created solver
         try {
@@ -293,10 +294,10 @@ public class SolverPropertiesLoader {
 
         // the SMTHandlers used by the created solver
         // note that this will only take effect when using ModularSMTLib2Translator ...
-        handlerNames = SettingsConverter.readRawStringList(props,
-            SolverPropertiesLoader.HANDLER_NAMES, SPLIT, new String[0]);
-        handlerOptions = SettingsConverter.readRawStringList(props,
-            SolverPropertiesLoader.HANDLER_OPTIONS, SPLIT, new String[0]);
+        Collections.addAll(handlerNames, SettingsConverter.readRawStringList(props,
+            SolverPropertiesLoader.HANDLER_NAMES, SPLIT, new String[0]));
+        Collections.addAll(handlerOptions, SettingsConverter.readRawStringList(props,
+            SolverPropertiesLoader.HANDLER_OPTIONS, SPLIT, new String[0]));
 
         // the solver specific preamble, may be null
         preamble = SettingsConverter.readFile(props, PREAMBLE_FILE, null,

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverType.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverType.java
@@ -23,6 +23,9 @@ import de.uka.ilkd.key.smt.communication.AbstractSolverSocket;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
+
 
 /**
  * This interface is used for modeling different solvers. It provides methods that encode
@@ -142,7 +145,7 @@ public interface SolverType {
      *
      * @return the delimiters of the messages that are sent from the solver to KeY.
      */
-    String[] getDelimiters();
+    Collection<String> getDelimiters();
 
     /**
      * Directly before the problem description is sent to the solver one can modify the problem

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
@@ -10,6 +10,9 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.smt.*;
@@ -85,7 +88,7 @@ public final class SolverTypeImplementation implements SolverType {
     /**
      * The message delimiters used to separate messages in the stdout of processes of this type.
      */
-    private final String[] delimiters;
+    private final Collection<String> delimiters;
 
     /*
      * The current command line parameters, timeout and command to be used instead of the default
@@ -143,13 +146,13 @@ public final class SolverTypeImplementation implements SolverType {
      * The names of the {@link de.uka.ilkd.key.smt.newsmt2.SMTHandler}s to be used by the
      * {@link SMTTranslator} that is created with {@link #createTranslator()}.
      */
-    private final String[] handlerNames;
+    private final Collection<String> handlerNames;
 
     /**
      * Arbitrary options for the {@link de.uka.ilkd.key.smt.newsmt2.SMTHandler}s used by this solver
      * type's {@link #translator} (only takes effect for {@link ModularSMTLib2Translator}).
      */
-    private final String[] handlerOptions;
+    private final Collection<String> handlerOptions;
 
     /**
      * The class of the {@link de.uka.ilkd.key.smt.communication.AbstractSolverSocket} to be created
@@ -203,10 +206,11 @@ public final class SolverTypeImplementation implements SolverType {
      * @param preamble the preamble String for the created {@link SMTTranslator}, may be null
      */
     public SolverTypeImplementation(String name, String info, String defaultParams,
-            String defaultCommand, String versionParameter, String minimumSupportedVersion,
-            long defaultTimeout, String[] delimiters, Class<?> translatorClass,
-            String[] handlerNames, String[] handlerOptions, Class<?> solverSocketClass,
-            String preamble) {
+                                    String defaultCommand, String versionParameter, String minimumSupportedVersion,
+                                    long defaultTimeout, Collection<String> delimiters, Class<?> translatorClass,
+                                    Collection<String> handlerNames, Collection<String> handlerOptions,
+                                    Class<?> solverSocketClass,
+                                    String preamble) {
         this.name = name;
         this.info = info;
         this.defaultParams = defaultParams;
@@ -220,8 +224,8 @@ public final class SolverTypeImplementation implements SolverType {
         this.versionParameter = versionParameter;
         this.translatorClass = translatorClass;
         // copy the array so that it cannot accidentally be manipulated from the outside
-        this.handlerNames = Arrays.copyOf(handlerNames, handlerNames.length);
-        this.handlerOptions = Arrays.copyOf(handlerOptions, handlerOptions.length);
+        this.handlerNames = new HashSet<>(handlerNames);
+        this.handlerOptions = new HashSet<>(handlerOptions);
         this.solverSocketClass = solverSocketClass;
         this.preamble = preamble;
         this.translator = makeTranslator();
@@ -412,9 +416,9 @@ public final class SolverTypeImplementation implements SolverType {
     }
 
     @Override
-    public String[] getDelimiters() {
+    public Collection<String> getDelimiters() {
         // Copy the delimiters array so that it cannot accidentally be manipulated from the outside.
-        return Arrays.copyOf(delimiters, delimiters.length);
+        return new HashSet<>(delimiters);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
@@ -9,10 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.smt.*;
@@ -144,9 +141,10 @@ public final class SolverTypeImplementation implements SolverType {
 
     /**
      * The names of the {@link de.uka.ilkd.key.smt.newsmt2.SMTHandler}s to be used by the
-     * {@link SMTTranslator} that is created with {@link #createTranslator()}.
+     * {@link SMTTranslator} that is created with {@link #createTranslator()}. Careful here:
+     * The order of entries is very important!
      */
-    private final Collection<String> handlerNames;
+    private final List<String> handlerNames;
 
     /**
      * Arbitrary options for the {@link de.uka.ilkd.key.smt.newsmt2.SMTHandler}s used by this solver
@@ -224,7 +222,7 @@ public final class SolverTypeImplementation implements SolverType {
         this.versionParameter = versionParameter;
         this.translatorClass = translatorClass;
         // copy the array so that it cannot accidentally be manipulated from the outside
-        this.handlerNames = new HashSet<>(handlerNames);
+        this.handlerNames = new ArrayList<>(handlerNames);
         this.handlerOptions = new HashSet<>(handlerOptions);
         this.solverSocketClass = solverSocketClass;
         this.preamble = preamble;
@@ -249,7 +247,7 @@ public final class SolverTypeImplementation implements SolverType {
     private SMTTranslator makeTranslator() {
         try {
             return (SMTTranslator) translatorClass
-                    .getDeclaredConstructor(String[].class, String[].class, String.class)
+                    .getDeclaredConstructor(List.class, Collection.class, String.class)
                     .newInstance(handlerNames, handlerOptions, preamble);
         } catch (NoSuchMethodException | IllegalArgumentException | ClassCastException
                 | InstantiationException | IllegalAccessException | InvocationTargetException e) {

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_noTypeEmbedding.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/Z3_noTypeEmbedding.props
@@ -1,0 +1,23 @@
+params=-in -smt2
+timeout=-1
+name=Z3_noTypeEmbedding
+info=Z3 solver by Microsoft.
+command=z3
+version=--version
+minVersion=Z3 version 4.4.1
+handlers=de.uka.ilkd.key.smt.newsmt2.BooleanConnectiveHandler,\
+de.uka.ilkd.key.smt.newsmt2.PolymorphicHandler,\
+de.uka.ilkd.key.smt.newsmt2.QuantifierHandler,\
+de.uka.ilkd.key.smt.newsmt2.LogicalVariableHandler,\
+de.uka.ilkd.key.smt.newsmt2.NumberConstantsHandler,\
+de.uka.ilkd.key.smt.newsmt2.IntegerOpHandler,\
+de.uka.ilkd.key.smt.newsmt2.InstanceOfHandler,\
+de.uka.ilkd.key.smt.newsmt2.CastHandler,\
+de.uka.ilkd.key.smt.newsmt2.SumProdHandler,\
+de.uka.ilkd.key.smt.newsmt2.UpdateHandler,\
+de.uka.ilkd.key.smt.newsmt2.FieldConstantHandler,\
+de.uka.ilkd.key.smt.newsmt2.FloatHandler,\
+de.uka.ilkd.key.smt.newsmt2.CastingFunctionsHandler,\
+de.uka.ilkd.key.smt.newsmt2.DefinedSymbolsHandler,\
+de.uka.ilkd.key.smt.newsmt2.UninterpretedSymbolsHandler
+handlerOptions=getUnsatCore,noTypeEmbedding


### PR DESCRIPTION
## Related Issue

This pull request addresses #1703.

## Intended Change

This PR adds an option which allows disabling the type hierarchy in the SMT translation. With that option set, the translation is still sound, but possibly "less complete" than the original translation, but might find some proofs faster, since the embeddings necessary to encode the type hierarchy can mislead the solvers.

## Plan
> [!IMPORTANT]  
> Note: At the moment, the feature is only partially implemented, which leads to many exceptions when trying to run an SMT solver.! 

* [ ] Fix and finish implementation
* [ ] At the moment, a new solver is added (Z3 variant without type hierarchy translation). Maybe it is better to have a toggle that applies to all solvers.
* [ ] Document the changes

## Type of pull request

- [x] New feature (non-breaking change which adds functionality)
- [x] There are changes to the (Java) code

## Ensuring quality

- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [ ] I have tested the feature as follows: ...
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

This feature was mostly implemented during the 2nd HacKeYthon 2024.
Thanks to @BookWood7th, @roundEaredSengi and @vb213!
     

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
