### PR TITLE
Cleanup: Removal of the write and read settings using Properties

### DIFF
--- a/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/TestGenerationSettings.java
+++ b/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/TestGenerationSettings.java
@@ -4,7 +4,6 @@
 package de.uka.ilkd.key.testgen;
 
 import java.io.File;
-import java.util.Properties;
 
 import de.uka.ilkd.key.settings.AbstractSettings;
 import de.uka.ilkd.key.settings.Configuration;
@@ -12,8 +11,10 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.SettingsConverter;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class TestGenerationSettings extends AbstractSettings {
     // region Default Values for option fields
     private static final boolean DEFAULT_APPLYSYMBOLICEX = false;
@@ -77,6 +78,15 @@ public class TestGenerationSettings extends AbstractSettings {
 
     }
 
+    /**
+     * @deprecated weigl: This method seems broken. I would expect: copy() = new TGS(this)
+     */
+    @Deprecated(forRemoval = true)
+    public TestGenerationSettings copy(TestGenerationSettings data) {
+        return new TestGenerationSettings(data);
+    }
+
+    public TestGenerationSettings copy() {
     public TestGenerationSettings copy() {
         return new TestGenerationSettings(this);
     }
@@ -109,25 +119,6 @@ public class TestGenerationSettings extends AbstractSettings {
 
     public boolean includePostCondition() {
         return includePostCondition;
-    }
-
-    @Override
-    public void readSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        setApplySymbolicExecution(SettingsConverter.read(props,
-            prefix + PROP_APPLY_SYMBOLIC_EXECUTION, DEFAULT_APPLYSYMBOLICEX));
-        setMaxUnwinds(SettingsConverter.read(props, prefix + PROP_MAX_UWINDS, DEFAULT_MAXUNWINDS));
-        setOutputPath(SettingsConverter.read(props, prefix + PROP_OUTPUT_PATH, DEFAULT_OUTPUTPATH));
-        setRemoveDuplicates(SettingsConverter.read(props,
-            prefix + PROP_REMOVE_DUPLICATES, DEFAULT_REMOVEDUPLICATES));
-        setUseRFL(SettingsConverter.read(props, prefix + PROP_USE_RFL, DEFAULT_USERFL));
-        setConcurrentProcesses(SettingsConverter.read(props,
-            prefix + PROP_CONCURRENT_PROCESSES, DEFAULT_CONCURRENTPROCESSES));
-        setInvariantForAll(SettingsConverter.read(props,
-            prefix + PROP_INVARIANT_FOR_ALL, DEFAULT_INVARIANTFORALL));
-        setIncludePostCondition(SettingsConverter.read(props,
-            PROP_INCLUDE_POST_CONDITION, DEFAULT_INCLUDEPOSTCONDITION));
-        setOnlyTestClasses(SettingsConverter.read(props, PROP_ONLY_TEST_CLASSES, false));
     }
 
     public boolean removeDuplicates() {
@@ -181,19 +172,8 @@ public class TestGenerationSettings extends AbstractSettings {
         return useRFL;
     }
 
-    @Override
-    public void writeSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        SettingsConverter.store(props, prefix + PROP_APPLY_SYMBOLIC_EXECUTION,
-            applySymbolicExecution);
-        SettingsConverter.store(props, prefix + PROP_CONCURRENT_PROCESSES, concurrentProcesses);
-        SettingsConverter.store(props, prefix + PROP_INVARIANT_FOR_ALL, invariantForAll);
-        SettingsConverter.store(props, prefix + PROP_MAX_UWINDS, maxUnwinds);
-        SettingsConverter.store(props, prefix + PROP_OUTPUT_PATH, outputPath);
-        SettingsConverter.store(props, prefix + PROP_REMOVE_DUPLICATES, removeDuplicates);
-        SettingsConverter.store(props, prefix + PROP_USE_RFL, useRFL);
-        SettingsConverter.store(props, prefix + PROP_INCLUDE_POST_CONDITION, includePostCondition);
-        SettingsConverter.store(props, prefix + PROP_ONLY_TEST_CLASSES, onlyTestClasses);
+    public boolean useJunit() {
+        return useJunit;
     }
 
     @Override
@@ -229,7 +209,7 @@ public class TestGenerationSettings extends AbstractSettings {
     }
 
     public void set(TestGenerationSettings settings) {
-        Properties p = new Properties();
+        Configuration p = new Configuration();
         settings.writeSettings(p);
         readSettings(p);
     }

--- a/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/smt/testgen/AbstractTestGenerator.java
+++ b/key.core.testgen/src/main/java/de/uka/ilkd/key/testgen/smt/testgen/AbstractTestGenerator.java
@@ -154,9 +154,9 @@ public abstract class AbstractTestGenerator {
 
         // create special smt settings for test case generation
         final ProofIndependentSMTSettings piSettings =
-            ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings().clone();
+            ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings().copy();
         piSettings.setMaxConcurrentProcesses(settings.getNumberOfProcesses());
-        final ProofDependentSMTSettings pdSettings = proof.getSettings().getSMTSettings().clone();
+        final ProofDependentSMTSettings pdSettings = proof.getSettings().getSMTSettings().copy();
         final NewSMTTranslationSettings newSettings =
             new NewSMTTranslationSettings(proof.getSettings().getNewSMTSettings());
         pdSettings.setInvariantForall(settings.invariantForAll());

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -87,9 +87,8 @@ public abstract class KeyAst<T extends ParserRuleContext> {
             ProofSettings settings = new ProofSettings(ProofSettings.DEFAULT_SETTINGS);
 
             if (ctx.preferences() != null && ctx.preferences().s != null) {
-                String text = StringUtil.trim(ctx.preferences().s.getText(), '"')
-                        .replace("\\\\:", ":");
-                settings.loadSettingsFromPropertyString(text);
+                throw new IllegalStateException("You try to load a KeY file in an deprecated format. " +
+                        "The settings are not a string of properties anymore. Please rewrite to the JSON-like format.");
             } else if (ctx.preferences() != null && ctx.preferences().c != null) {
                 var cb = new ConfigurationBuilder();
                 var c = (Configuration) ctx.preferences().c.accept(cb);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -87,7 +87,8 @@ public abstract class KeyAst<T extends ParserRuleContext> {
             ProofSettings settings = new ProofSettings(ProofSettings.DEFAULT_SETTINGS);
 
             if (ctx.preferences() != null && ctx.preferences().s != null) {
-                throw new IllegalStateException("You try to load a KeY file in an deprecated format. " +
+                throw new IllegalStateException(
+                    "You try to load a KeY file in an deprecated format. " +
                         "The settings are not a string of properties anymore. Please rewrite to the JSON-like format.");
             } else if (ctx.preferences() != null && ctx.preferences().c != null) {
                 var cb = new ConfigurationBuilder();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -173,7 +173,8 @@ public class Proof implements ProofObject<Goal>, Named {
      */
     private Proof(Name name, InitConfig initConfig) {
         this.name = name;
-        this.initConfig = Objects.requireNonNull(initConfig, "Tried to create proof without valid services.");
+        this.initConfig =
+            Objects.requireNonNull(initConfig, "Tried to create proof without valid services.");
 
         if (initConfig.getSettings() == null) {
             // if no settings have been assigned yet, take default settings

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -120,17 +120,18 @@ public class Proof implements ProofObject<Goal>, Named {
      * settings valid independent of a proof
      */
     private final ProofIndependentSettings pis;
+
     /**
      * when different users load and save a proof this vector fills up with Strings containing the
      * usernames.
      */
-    public List<String> userLog;
+    public List<String> userLog = new ArrayList<>();
 
     /**
      * when load and save a proof with different versions of key this vector fills up with Strings
      * containing the GIT versions.
      */
-    public List<String> keyVersionLog;
+    public List<String> keyVersionLog = new ArrayList<>();
 
     private long autoModeTime = 0;
 
@@ -172,8 +173,7 @@ public class Proof implements ProofObject<Goal>, Named {
      */
     private Proof(Name name, InitConfig initConfig) {
         this.name = name;
-        assert initConfig != null : "Tried to create proof without valid services.";
-        this.initConfig = initConfig;
+        this.initConfig = Objects.requireNonNull(initConfig, "Tried to create proof without valid services.");
 
         if (initConfig.getSettings() == null) {
             // if no settings have been assigned yet, take default settings

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
@@ -3,21 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof.io;
 
-import de.uka.ilkd.key.axiom_abstraction.predicateabstraction.AbstractPredicateAbstractionLattice;
-import de.uka.ilkd.key.proof.Proof;
-import de.uka.ilkd.key.proof.io.intermediate.*;
-import de.uka.ilkd.key.settings.ProofSettings;
-import org.key_project.logic.Name;
-import org.key_project.logic.PosInTerm;
-import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
-import org.key_project.util.collection.Pair;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.List;
+
+import de.uka.ilkd.key.axiom_abstraction.predicateabstraction.AbstractPredicateAbstractionLattice;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.io.intermediate.*;
+import de.uka.ilkd.key.settings.ProofSettings;
+
+import org.key_project.logic.Name;
+import org.key_project.logic.PosInTerm;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.Pair;
 
 /**
  * Parses a KeY proof file into an intermediate representation. The parsed intermediate result can
@@ -144,12 +145,12 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
                 tacletInfo.ifDirectFormulaList = tacletInfo.ifDirectFormulaList.append(str);
             }
         case KeY_USER -> // UserLog
-                proof.userLog.add(str);
+            proof.userLog.add(str);
         case KeY_VERSION -> // Version log
-                proof.keyVersionLog.add(str);
-            case KeY_SETTINGS -> // ProofSettings
-                loadPreferences(str);
-            case BUILT_IN_RULE -> { // BuiltIn rules
+            proof.keyVersionLog.add(str);
+        case KeY_SETTINGS -> // ProofSettings
+            loadPreferences(str);
+        case BUILT_IN_RULE -> { // BuiltIn rules
             final AppNodeIntermediate newNode = new AppNodeIntermediate();
             currNode.addChild(newNode);
             currNode = newNode;

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/AbstractPropertiesSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/AbstractPropertiesSettings.java
@@ -4,13 +4,13 @@
 package de.uka.ilkd.key.settings;
 
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
-
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A base class for own settings based on properties.
@@ -154,12 +154,12 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
     /**
      * Creates a string list property.
      *
-     * @param key      the key value of this property inside {@link Properties} instance
+     * @param key the key value of this property inside {@link Properties} instance
      * @param defValue a default value
      * @return returns a {@link PropertyEntry}
      */
     protected PropertyEntry<List<String>> createStringListProperty(@NonNull String key,
-                                                                   @Nullable List<String> defValue) {
+            @Nullable List<String> defValue) {
         PropertyEntry<List<String>> pe = new DirectPropertyEntry<>(key, defValue);
         propertyEntries.add(pe);
         return pe;
@@ -167,19 +167,22 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
 
 
     /// This interface describes properties or options in an [AbstractPropertiesSettings] class.
-    /// A [PropertyEntry] is parameterize in a type its value holds, additionally it has name (to store and read it
+    /// A [PropertyEntry] is parameterize in a type its value holds, additionally it has name (to
+    /// store and read it
     /// from configuration files), often a default.
     ///
     /// @param <T>
     public interface PropertyEntry<T extends @Nullable Object> {
         /**
-         * The name (or key) to find this value inside a configuration file. It should also be the key
+         * The name (or key) to find this value inside a configuration file. It should also be the
+         * key
          * in {@link java.beans.PropertyChangeEvent}s.
          */
         String getKey();
 
         /**
-         * Sets this value of this property. Should trigger {@link java.beans.PropertyChangeEvent} if necessary.
+         * Sets this value of this property. Should trigger {@link java.beans.PropertyChangeEvent}
+         * if necessary.
          *
          * @param value the new configuration value
          */
@@ -192,30 +195,33 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
 
 
         /// This method allows to set the property using an arbitray object which is allowed in
-        /// the configuration hierarchy. This methods may throw an exception on unexpected value types.
+        /// the configuration hierarchy. This methods may throw an exception on unexpected value
+        /// types.
         ///
         /// Especially, the following should not result into change of the value for a property:
         /// ```java
         /// setValue(value())
-        ///```
+        /// ```
         ///
         /// @param value an object of the [Configuration] hierarchy
         void setValue(@Nullable Object value);
 
         /**
-         * Returns the representation of this configuration value to store it inside a {@link Configuration}
+         * Returns the representation of this configuration value to store it inside a
+         * {@link Configuration}
          * object.
          *
          * @return an object compatible with {@link #setValue(Object)}
          */
         Object value();
 
-        ///  returns true if the property is set.
+        /// returns true if the property is set.
         boolean isSet();
     }
 
     /// @param <T>
-    public abstract class SimplePropertyEntry<T extends @Nullable Object> implements PropertyEntry<T> {
+    public abstract class SimplePropertyEntry<T extends @Nullable Object>
+            implements PropertyEntry<T> {
         private final String key;
         private final T defaultValue;
         private T currentValue;
@@ -249,7 +255,8 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
     }
 
     /**
-     * A base class for any configuration properties which is directly supported by the configuration.
+     * A base class for any configuration properties which is directly supported by the
+     * configuration.
      *
      * @param <T> type of the value, supported by {@link Configuration}
      * @see Configuration#allowedValueType(Object)
@@ -280,7 +287,7 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
         private final Function<T, String> toString;
 
         public DefaultPropertyEntry(String key, T defaultValue,
-                                    Function<String, T> convert, Function<T, String> toString) {
+                Function<String, T> convert, Function<T, String> toString) {
             super(key, defaultValue);
             this.convert = convert;
             this.toString = toString;
@@ -298,7 +305,8 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
                 return;
             }
 
-            throw new IllegalArgumentException("Type %s is not supported for option %s".formatted(value.getClass(), getKey()));
+            throw new IllegalArgumentException(
+                "Type %s is not supported for option %s".formatted(value.getClass(), getKey()));
         }
 
         @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
@@ -4,7 +4,14 @@
 package de.uka.ilkd.key.settings;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 import org.key_project.logic.Choice;
 import org.key_project.logic.Name;

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
@@ -151,23 +151,6 @@ public class ChoiceSettings extends AbstractSettings {
     }
 
 
-    /**
-     * implements the method required by the Settings interface. The settings are written to the
-     * given Properties object. Only entries of
-     * the form &lt; key &gt; = &lt; value &gt; (,&lt;
-     * value &gt;)* are allowed.
-     * <p>
-     * * @param props the Properties object where to write the
-     * settings as (key, value) pair
-     */
-    @Override
-    public void writeSettings(Properties props) {
-        var choiceSequence = category2Default.entrySet().stream()
-                .map(entry -> entry.getKey() + "-" + entry.getValue())
-                .collect(Collectors.joining(" , "));
-        props.setProperty("[" + CATEGORY + "]" + KEY_DEFAULT_CHOICES, choiceSequence);
-    }
-
     @Override
     public void readSettings(Configuration props) {
         var category = props.getSection(CATEGORY);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/Configuration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/Configuration.java
@@ -366,6 +366,9 @@ public class Configuration {
     }
 
     public Object set(String name, Object obj) {
+        if(!allowedValueType(obj)) {
+            throw new RuntimeException("Unallowed value type used: " + obj.getClass());
+        }
         return data.put(name, obj);
     }
 
@@ -417,6 +420,32 @@ public class Configuration {
 
     public void overwriteWith(Configuration other) {
         data.putAll(other.data);
+    }
+
+    /**
+     * Predicte for allowed value objects inside the configuration hierarchy and
+     * can be printed.
+     * @param value an arbitrary {@link Object}
+     * @return true if the value is allowed in the hierarchy.
+     */
+    public static boolean allowedValueType(@Nullable Object value) {
+        return value instanceof String
+                || value instanceof Long
+                || value instanceof Integer
+                || value instanceof Double
+                || value instanceof Float
+                || value instanceof Short
+                || value instanceof Byte
+                || value instanceof Boolean
+                || value instanceof Collection
+                || value instanceof Map
+                || value instanceof Configuration
+                || value instanceof Enum<?>
+                || value == null;
+    }
+
+    public Set<String> getKeys() {
+        return this.data.keySet();
     }
 
     // TODO Add documentation for this.

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/Configuration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/Configuration.java
@@ -366,7 +366,7 @@ public class Configuration {
     }
 
     public Object set(String name, Object obj) {
-        if(!allowedValueType(obj)) {
+        if (!allowedValueType(obj)) {
             throw new RuntimeException("Unallowed value type used: " + obj.getClass());
         }
         return data.put(name, obj);
@@ -425,6 +425,7 @@ public class Configuration {
     /**
      * Predicte for allowed value objects inside the configuration hierarchy and
      * can be printed.
+     *
      * @param value an arbitrary {@link Object}
      * @return true if the value is allowed in the hierarchy.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/FeatureSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/FeatureSettings.java
@@ -98,28 +98,6 @@ public class FeatureSettings extends AbstractSettings {
     }
 
     @Override
-    public void readSettings(Properties props) {
-        activatedFeatures.clear();
-        var prefix = "[" + CATEGORY + "]";
-        for (Map.Entry<Object, Object> entries : props.entrySet()) {
-            final var s = entries.getKey().toString();
-            if (s.startsWith(prefix) && isTrue(entries.getValue())) {
-                final var feature = s.substring(prefix.length());
-                activate(feature);
-                LOGGER.info("Activate feature: {}", feature);
-            }
-        }
-    }
-
-    @Override
-    public void writeSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        for (String activatedFeature : activatedFeatures) {
-            props.put(prefix + activatedFeature, "true");
-        }
-    }
-
-    @Override
     public void readSettings(@NonNull Configuration props) {
         activatedFeatures.clear();
         for (String s : props.getStringList(CATEGORY)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/GeneralSettings.java
@@ -223,27 +223,6 @@ public class GeneralSettings extends AbstractSettings {
         }
     }
 
-    /**
-     * implements the method required by the Settings interface. The settings are written to the
-     * given Properties object. Only entries of the form
-     * <key> = <value> (,<value>)* are allowed.
-     *
-     * @param props the Properties object where to write the settings as (key, value) pair
-     */
-    @Override
-    public void writeSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        props.setProperty(prefix + TACLET_FILTER, String.valueOf(tacletFilter));
-        props.setProperty(prefix + DND_DIRECTION_SENSITIVE_KEY,
-            String.valueOf(dndDirectionSensitive));
-        props.setProperty(prefix + RIGHT_CLICK_MACROS_KEY, String.valueOf(rightClickMacros));
-        props.setProperty(prefix + USE_JML_KEY, String.valueOf(useJML));
-        props.setProperty(prefix + AUTO_SAVE, String.valueOf(autoSave));
-        props.setProperty(prefix + ENSURE_SOURCE_CONSISTENCY,
-            String.valueOf(ensureSourceConsistency));
-        props.setProperty(KEY_JML_ENABLED_KEYS, String.join(",", jmlEnabledKeys));
-    }
-
     @Override
     public void readSettings(Configuration props) {
         setTacletFilter(props.getBool(TACLET_FILTER));

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/LemmaGeneratorSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/LemmaGeneratorSettings.java
@@ -36,22 +36,6 @@ public class LemmaGeneratorSettings extends AbstractSettings {
     }
 
     @Override
-    public void readSettings(Properties props) {
-        setShowDialogAddingAxioms(SettingsConverter.read(props,
-            "[" + CATEGORY + "]" + SHOW_DIALOG_ADDING_AXIOMS, true));
-        setShowDialogUsingAxioms(SettingsConverter.read(props,
-            "[" + CATEGORY + "]" + SHOW_DIALOG_USING_AXIOMS, true));
-    }
-
-    @Override
-    public void writeSettings(Properties props) {
-        SettingsConverter.store(props, "[" + CATEGORY + "]" + SHOW_DIALOG_ADDING_AXIOMS,
-            showDialogAddingAxioms);
-        SettingsConverter.store(props, "[" + CATEGORY + "]" + SHOW_DIALOG_USING_AXIOMS,
-            showDialogUsingAxioms);
-    }
-
-    @Override
     public void readSettings(Configuration props) {
         var cat = props.getSection(CATEGORY);
         if (cat == null)

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/LemmaGeneratorSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/LemmaGeneratorSettings.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
-import java.util.Properties;
 
 public class LemmaGeneratorSettings extends AbstractSettings {
     public static final String CATEGORY = "LemmaGenerator";

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/NewSMTTranslationSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/NewSMTTranslationSettings.java
@@ -4,13 +4,13 @@
 package de.uka.ilkd.key.settings;
 
 
+import java.util.*;
+import java.util.Map.Entry;
+
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.Map.Entry;
 
 /**
  * A collection of settings for the new (= 2021) SMT translation.
@@ -68,11 +68,12 @@ public class NewSMTTranslationSettings extends AbstractSettings {
 
         for (var entry : newSmt.getEntries()) {
             final var value = entry.getValue();
-            if( value instanceof String s) {
+            if (value instanceof String s) {
                 map.put(entry.getKey(), s);
-            }else{
-                LOGGER.warn("Settings {} with value {} ignored. Value of type string expected.", entry.getKey(),
-                        entry.getValue());
+            } else {
+                LOGGER.warn("Settings {} with value {} ignored. Value of type string expected.",
+                    entry.getKey(),
+                    entry.getValue());
             }
         }
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/NewSMTTranslationSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/NewSMTTranslationSettings.java
@@ -4,6 +4,11 @@
 package de.uka.ilkd.key.settings;
 
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -21,8 +26,10 @@ import java.util.Map.Entry;
  *
  * @author Mattias Ulbrich
  */
+@NullMarked
 public class NewSMTTranslationSettings extends AbstractSettings {
-    private static final String PREFIX = "[NewSMT]";
+    private static final String CATEGORY = "NewSMT";
+    private static final Logger LOGGER = LoggerFactory.getLogger(NewSMTTranslationSettings.class);
 
     // Using a linked hash map to make the order deterministic in writing to
     // file
@@ -45,45 +52,28 @@ public class NewSMTTranslationSettings extends AbstractSettings {
     }
 
     /**
-     * Create a clone of this object. <code>s.clone()</code> is equivalent to
-     *
-     * <pre>
-     *     new new NewSMTTranslationSettings(s);
-     * </pre>
-     *
-     * @return
+     * Create a deep copy of this object.
      */
-    @Override
-    public NewSMTTranslationSettings clone() {
+    public NewSMTTranslationSettings copy() {
         return new NewSMTTranslationSettings(this);
     }
 
     @Override
-    public void readSettings(Properties props) {
-        for (Object k : props.keySet()) {
-            String key = k.toString();
-            if (key.startsWith(PREFIX)) {
-                map.put(key.substring(PREFIX.length()), props.getProperty(key));
-            }
-        }
-    }
-
-    @Override
-    public void writeSettings(Properties props) {
-        for (Entry<String, String> en : map.entrySet()) {
-            props.put(PREFIX + en.getKey(), en.getValue());
-        }
-    }
-
-    @Override
     public void readSettings(Configuration props) {
-        var newSmt = props.getSection("NewSMT");
-        if (newSmt == null)
+        var newSmt = props.getSection(CATEGORY);
+
+        if (newSmt == null) {
             return;
+        }
+
         for (var entry : newSmt.getEntries()) {
             final var value = entry.getValue();
-            assert value instanceof String;
-            map.put(entry.getKey(), value.toString());
+            if( value instanceof String s) {
+                map.put(entry.getKey(), s);
+            }else{
+                LOGGER.warn("Settings {} with value {} ignored. Value of type string expected.", entry.getKey(),
+                        entry.getValue());
+            }
         }
     }
 
@@ -111,7 +101,7 @@ public class NewSMTTranslationSettings extends AbstractSettings {
      * @param key the key to look up
      * @return the value for the key, null if not present
      */
-    public String get(String key) {
+    public @Nullable String get(String key) {
         return map.get(key);
     }
 
@@ -122,7 +112,7 @@ public class NewSMTTranslationSettings extends AbstractSettings {
      * @param value the non-null value to set
      * @return the value that was in the map prior to the call (see {@link Map#put(Object, Object)}.
      */
-    public String put(String key, String value) {
+    public @Nullable String put(String key, String value) {
         var old = map.get(key);
         String result = map.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
         firePropertyChange(key, old, value);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofDependentSMTSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofDependentSMTSettings.java
@@ -4,11 +4,10 @@
 package de.uka.ilkd.key.settings;
 
 
-import java.util.Properties;
-
 import de.uka.ilkd.key.taclettranslation.assumptions.SupportedTaclets;
+import org.jspecify.annotations.NullMarked;
 
-
+@NullMarked
 public class ProofDependentSMTSettings extends AbstractSettings {
     public static final String CATEGORY = "SMTSettings";
 
@@ -26,7 +25,6 @@ public class ProofDependentSMTSettings extends AbstractSettings {
     public static final String INTEGERS_MINIMUM = "integersMinimum";
     public static final String INVARIANT_FORALL = "invariantForall";
 
-    public static final String PROP_LEGACY_TRANSLATION = "legacyTranslation";
     private static final String PROP_SUPPORTED_TACLETS = "supportedTaclets";
 
     private boolean useExplicitTypeHierarchy = false;
@@ -38,10 +36,8 @@ public class ProofDependentSMTSettings extends AbstractSettings {
     private int maxGenericSorts = 2;
     private int maxInteger = 2147483645;
     private int minInteger = -2147483645;
-    private boolean useLegacyTranslation = false;
 
-
-    private SupportedTaclets supportedTaclets;
+    private SupportedTaclets supportedTaclets = SupportedTaclets.REFERENCE;
 
     private ProofDependentSMTSettings() {
         setSupportedTaclets(SupportedTaclets.REFERENCE);
@@ -69,61 +65,13 @@ public class ProofDependentSMTSettings extends AbstractSettings {
     private static final ProofDependentSMTSettings DEFAULT_DATA = new ProofDependentSMTSettings();
 
     public static ProofDependentSMTSettings getDefaultSettingsData() {
-        return DEFAULT_DATA.clone();
+        return DEFAULT_DATA.copy();
     }
 
-
-    @Override
-    public ProofDependentSMTSettings clone() {
+    public ProofDependentSMTSettings copy() {
         return new ProofDependentSMTSettings(this);
     }
 
-
-    @Override
-    public void readSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        setUseExplicitTypeHierarchy(
-            SettingsConverter.read(props, prefix + EXPLICIT_TYPE_HIERARCHY,
-                useExplicitTypeHierarchy));
-        setUseNullInstantiation(
-            SettingsConverter.read(props, prefix + INSTANTIATE_NULL_PREDICATES,
-                useNullInstantiation));
-        setUseBuiltInUniqueness(
-            SettingsConverter.read(props, prefix + USE_BUILT_IN_UNIQUENESS, useBuiltInUniqueness));
-        setMaxGenericSorts(
-            SettingsConverter.read(props, prefix + MAX_GENERIC_SORTS, maxGenericSorts));
-        setUseUIMultiplication(
-            SettingsConverter.read(props, prefix + USE_UNINTERPRETED_MULTIPLICATION,
-                useUIMultiplication));
-        setUseConstantsForIntegers(
-            SettingsConverter.read(props, prefix + USE_CONSTANTS_FOR_BIGSMALL_INTEGERS,
-                useConstantsForIntegers));
-
-        setMaxInteger(SettingsConverter.read(props, prefix + INTEGERS_MAXIMUM, maxInteger));
-        setMinInteger(SettingsConverter.read(props, prefix + INTEGERS_MINIMUM, minInteger));
-        setInvariantForall(
-            SettingsConverter.read(props, prefix + INVARIANT_FORALL, invariantForall));
-        supportedTaclets.selectTaclets(SettingsConverter.read(props, prefix + TACLET_SELECTION,
-            supportedTaclets.getNamesOfSelectedTaclets()));
-    }
-
-    @Override
-    public void writeSettings(Properties props) {
-        var prefix = "[" + CATEGORY + "]";
-        SettingsConverter.store(props, prefix + EXPLICIT_TYPE_HIERARCHY, useExplicitTypeHierarchy);
-        SettingsConverter.store(props, prefix + INSTANTIATE_NULL_PREDICATES, useNullInstantiation);
-        SettingsConverter.store(props, prefix + MAX_GENERIC_SORTS, maxGenericSorts);
-        SettingsConverter.store(props, prefix + TACLET_SELECTION,
-            supportedTaclets.getNamesOfSelectedTaclets());
-        SettingsConverter.store(props, prefix + USE_BUILT_IN_UNIQUENESS, useBuiltInUniqueness);
-        SettingsConverter.store(props, prefix + USE_UNINTERPRETED_MULTIPLICATION,
-            useUIMultiplication);
-        SettingsConverter.store(props, prefix + USE_CONSTANTS_FOR_BIGSMALL_INTEGERS,
-            useConstantsForIntegers);
-        SettingsConverter.store(props, prefix + INTEGERS_MAXIMUM, maxInteger);
-        SettingsConverter.store(props, prefix + INTEGERS_MINIMUM, minInteger);
-        SettingsConverter.store(props, prefix + INVARIANT_FORALL, invariantForall);
-    }
 
     @Override
     public void readSettings(Configuration props) {
@@ -262,15 +210,5 @@ public class ProofDependentSMTSettings extends AbstractSettings {
         var old = this.supportedTaclets;
         this.supportedTaclets = supportedTaclets;
         firePropertyChange(PROP_SUPPORTED_TACLETS, old, supportedTaclets);
-    }
-
-    public boolean isUseLegacyTranslation() {
-        return useLegacyTranslation;
-    }
-
-    public void setUseLegacyTranslation(boolean useLegacyTranslation) {
-        var old = this.useLegacyTranslation;
-        this.useLegacyTranslation = useLegacyTranslation;
-        firePropertyChange(PROP_LEGACY_TRANSLATION, old, useLegacyTranslation);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofDependentSMTSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofDependentSMTSettings.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.settings;
 
 
 import de.uka.ilkd.key.taclettranslation.assumptions.SupportedTaclets;
+
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
@@ -11,9 +11,11 @@ import java.util.Properties;
 import de.uka.ilkd.key.smt.SolverTypeCollection;
 import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
+import org.jspecify.annotations.NullMarked;
 
 import static de.uka.ilkd.key.settings.FeatureSettings.createFeature;
 
+@NullMarked
 public final class ProofIndependentSMTSettings extends AbstractSettings {
     private static final String CATEGORY = "SMTSettings";
     public static final String ACTIVE_SOLVER = "ActiveSolver";
@@ -315,7 +317,7 @@ public final class ProofIndependentSMTSettings extends AbstractSettings {
     }
 
     public static ProofIndependentSMTSettings getDefaultSettingsData() {
-        return DEFAULT_DATA.clone();
+        return DEFAULT_DATA.copy();
     }
 
     public boolean containsSolver(SolverType type) {
@@ -342,7 +344,7 @@ public final class ProofIndependentSMTSettings extends AbstractSettings {
         type.setSolverParameters(parameters);
     }
 
-    public ProofIndependentSMTSettings clone() {
+    public ProofIndependentSMTSettings copy() {
         return new ProofIndependentSMTSettings(this);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSMTSettings.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import de.uka.ilkd.key.smt.SolverTypeCollection;
 import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
+
 import org.jspecify.annotations.NullMarked;
 
 import static de.uka.ilkd.key.settings.FeatureSettings.createFeature;

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
@@ -38,7 +38,7 @@ public class ProofIndependentSettings {
     }
 
     private final ProofIndependentSMTSettings smtSettings =
-            ProofIndependentSMTSettings.getDefaultSettingsData();
+        ProofIndependentSMTSettings.getDefaultSettingsData();
 
     private final LemmaGeneratorSettings lemmaGeneratorSettings = new LemmaGeneratorSettings();
     private final GeneralSettings generalSettings = new GeneralSettings();
@@ -83,7 +83,7 @@ public class ProofIndependentSettings {
             if (filename.exists()) {
                 if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
                     LOGGER.warn("The settings in {} are *not* read due to flag '{}'", filename,
-                            PathConfig.DISREGARD_SETTINGS_PROPERTY);
+                        PathConfig.DISREGARD_SETTINGS_PROPERTY);
                 } else {
                     load(filename);
                 }
@@ -107,7 +107,7 @@ public class ProofIndependentSettings {
         }
 
         try (var out =
-                     new BufferedWriter(new FileWriter(filename.toString().replace(".props", ".json")))) {
+            new BufferedWriter(new FileWriter(filename.toString().replace(".props", ".json")))) {
             config.save(out, "Proof-Independent-Settings-File. Generated " + new Date());
         } catch (IOException e) {
             LOGGER.error("Could not store settings to {}", filename, e);
@@ -159,7 +159,7 @@ public class ProofIndependentSettings {
      * Defines if pretty printing is enabled or not.
      *
      * @param usePrettyPrinting {@code true} pretty printing is enabled, {@code false} pretty
-     *                          printing is disabled.
+     *        printing is disabled.
      */
     public static void setUsePrettyPrinting(boolean usePrettyPrinting) {
         DEFAULT_INSTANCE.getViewSettings().setUsePretty(usePrettyPrinting);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
@@ -8,7 +8,6 @@ import java.io.*;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 
 import de.uka.ilkd.key.pp.NotationInfo;
 
@@ -39,7 +38,7 @@ public class ProofIndependentSettings {
     }
 
     private final ProofIndependentSMTSettings smtSettings =
-        ProofIndependentSMTSettings.getDefaultSettingsData();
+            ProofIndependentSMTSettings.getDefaultSettingsData();
 
     private final LemmaGeneratorSettings lemmaGeneratorSettings = new LemmaGeneratorSettings();
     private final GeneralSettings generalSettings = new GeneralSettings();
@@ -53,7 +52,6 @@ public class ProofIndependentSettings {
     private final List<Settings> settings = new LinkedList<>();
 
     private final PropertyChangeListener settingsListener = e -> saveSettings();
-    private Properties lastReadedProperties;
     private Configuration lastReadedConfiguration;
 
     private ProofIndependentSettings() {
@@ -74,9 +72,6 @@ public class ProofIndependentSettings {
         if (!this.settings.contains(settings)) {
             this.settings.add(settings);
             settings.addPropertyChangeListener(settingsListener);
-            if (lastReadedProperties != null) {
-                settings.readSettings(lastReadedProperties);
-            }
             if (lastReadedConfiguration != null) {
                 settings.readSettings(lastReadedConfiguration);
             }
@@ -88,7 +83,7 @@ public class ProofIndependentSettings {
             if (filename.exists()) {
                 if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
                     LOGGER.warn("The settings in {} are *not* read due to flag '{}'", filename,
-                        PathConfig.DISREGARD_SETTINGS_PROPERTY);
+                            PathConfig.DISREGARD_SETTINGS_PROPERTY);
                 } else {
                     load(filename);
                 }
@@ -99,54 +94,32 @@ public class ProofIndependentSettings {
     }
 
     private void load(File file) throws IOException {
-        if (!file.getName().endsWith(".json")) {
-            try (FileInputStream in = new FileInputStream(file)) {
-                Properties properties = new Properties();
-                properties.load(in);
-                for (Settings settings : settings) {
-                    settings.readSettings(properties);
-                }
-                lastReadedProperties = properties;
-            }
-        } else {
-            this.lastReadedConfiguration = Configuration.load(file);
-            for (Settings settings : settings) {
-                settings.readSettings(lastReadedConfiguration);
-            }
+        this.lastReadedConfiguration = Configuration.load(file);
+        for (Settings settings : settings) {
+            settings.readSettings(lastReadedConfiguration);
         }
     }
 
     public void saveSettings() {
-        if (!filename.getName().endsWith(".json")) {
-            Properties result = new Properties();
-            for (Settings settings : settings) {
-                settings.writeSettings(result);
-            }
-
-            if (!filename.exists()) {
-                filename.getParentFile().mkdirs();
-            }
-
-            try (var out = new FileOutputStream(filename)) {
-                result.store(out, "Proof-Independent-Settings-File. Generated " + new Date());
-            } catch (IOException e) {
-                LOGGER.error("Could not store settings to {}", filename, e);
-            }
-        }
-
-        Configuration config = new Configuration();
-        for (var settings : settings)
-            settings.writeSettings(config);
+        Configuration config = asConfiguration();
         if (!filename.exists()) {
             filename.getParentFile().mkdirs();
         }
 
         try (var out =
-            new BufferedWriter(new FileWriter(filename.toString().replace(".props", ".json")))) {
+                     new BufferedWriter(new FileWriter(filename.toString().replace(".props", ".json")))) {
             config.save(out, "Proof-Independent-Settings-File. Generated " + new Date());
         } catch (IOException e) {
             LOGGER.error("Could not store settings to {}", filename, e);
         }
+    }
+
+    public Configuration asConfiguration() {
+        Configuration config = new Configuration();
+        for (var settings : settings) {
+            settings.writeSettings(config);
+        }
+        return config;
     }
 
     public GeneralSettings getGeneralSettings() {
@@ -186,7 +159,7 @@ public class ProofIndependentSettings {
      * Defines if pretty printing is enabled or not.
      *
      * @param usePrettyPrinting {@code true} pretty printing is enabled, {@code false} pretty
-     *        printing is disabled.
+     *                          printing is disabled.
      */
     public static void setUsePrettyPrinting(boolean usePrettyPrinting) {
         DEFAULT_INSTANCE.getViewSettings().setUsePretty(usePrettyPrinting);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /// MaximumNumberOfHeuristcsApplications=400
 /// number = "IntegerLDT.class"
 /// boolean = "BooleanLDT.class"
-///```
+/// ```
 ///
 /// @see Properties
 /// @see Settings
@@ -38,7 +38,7 @@ public class ProofSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofSettings.class);
 
     public static final File PROVER_CONFIG_FILE =
-            new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
+        new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
 
     public static final URL PROVER_CONFIG_FILE_TEMPLATE = KeYResourceManager.getManager()
             .getResourceFile(ProofSettings.class, "default-proof-settings.json");
@@ -65,7 +65,7 @@ public class ProofSettings {
     private final StrategySettings strategySettings = new StrategySettings();
     private final ChoiceSettings choiceSettings = new ChoiceSettings();
     private final ProofDependentSMTSettings smtSettings =
-            ProofDependentSMTSettings.getDefaultSettingsData();
+        ProofDependentSMTSettings.getDefaultSettingsData();
     private final NewSMTTranslationSettings newSMTSettings = new NewSMTTranslationSettings();
     private final TermLabelSettings termLabelSettings = new TermLabelSettings();
 
@@ -164,7 +164,7 @@ public class ProofSettings {
     public void loadDefaultJSONSettings() {
         if (PROVER_CONFIG_FILE_TEMPLATE == null) {
             LOGGER.warn(
-                    "default proof-settings file 'default-proof-settings.json' could not be found.");
+                "default proof-settings file 'default-proof-settings.json' could not be found.");
         } else {
             try (var in = new InputStreamReader(PROVER_CONFIG_FILE_TEMPLATE.openStream())) {
                 loadSettingsFromJSONStream(in);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -17,29 +17,31 @@ import org.antlr.v4.runtime.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class is used to load and save settings for proofs such as which data type models are used
- * to represent the java types. Which heuristics have to be loaded and so on. The class loads the
- * file proofsettings.config from the place where you started key. If the file is not available
- * standard settings are used. The loaded file has the following structure: <code>
- * // KeY-Configuration file
- * ActiveHeuristics=simplify_prog , simplify
- * MaximumNumberOfHeuristcsApplications=400
- * number  = IntegerLDT.class
- * boolean = BooleanLDT.class
- * </code>
- *
- * @see Properties
- * @see Settings
- */
+/// This class is used to load and save settings for proofs such as which data type models are used
+/// to represent the java types.
+/// Which heuristics have to be loaded and so on?
+/// The class loads the file `proofsettings.config` from the place where you started key.
+/// If the file is not available, standard settings are used.
+/// The loaded file has the following structure:
+///
+/// ```
+/// // KeY-Configuration file
+/// ActiveHeuristics=["simplify_prog", "simplify"]
+/// MaximumNumberOfHeuristcsApplications=400
+/// number  = "IntegerLDT.class"
+/// boolean = "BooleanLDT.class"
+///```
+///
+/// @see Properties
+/// @see Settings
 public class ProofSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofSettings.class);
 
     public static final File PROVER_CONFIG_FILE =
-        new File(PathConfig.getKeyConfigDir(), "proof-settings.props");
+            new File(PathConfig.getKeyConfigDir(), "proof-settings.props");
 
     public static final File PROVER_CONFIG_FILE_NEW =
-        new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
+            new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
 
     public static final URL PROVER_CONFIG_FILE_TEMPLATE = KeYResourceManager.getManager()
             .getResourceFile(ProofSettings.class, "default-proof-settings.json");
@@ -66,15 +68,14 @@ public class ProofSettings {
     private final StrategySettings strategySettings = new StrategySettings();
     private final ChoiceSettings choiceSettings = new ChoiceSettings();
     private final ProofDependentSMTSettings smtSettings =
-        ProofDependentSMTSettings.getDefaultSettingsData();
+            ProofDependentSMTSettings.getDefaultSettingsData();
     private final NewSMTTranslationSettings newSMTSettings = new NewSMTTranslationSettings();
     private final TermLabelSettings termLabelSettings = new TermLabelSettings();
 
-    private Properties lastLoadedProperties = null;
     private Configuration lastLoadedConfiguration = null;
 
     /**
-     * create a proof settings object. When you add a new settings object, PLEASE UPDATE THE LIST
+     * Create a proof settings object. When you add a new settings object, PLEASE UPDATE THE LIST
      * ABOVE AND USE THOSE CONSTANTS INSTEAD OF USING INTEGERS DIRECTLY
      */
     private ProofSettings() {
@@ -86,44 +87,40 @@ public class ProofSettings {
     }
 
     /*
-     * copy constructor - substitutes .clone() in classes implementing Settings
+     * copy constructor - substitutes .copy() in classes implementing Settings
      */
     public ProofSettings(ProofSettings toCopy) {
         this();
-        Properties result = new Properties();
-        lastLoadedProperties = toCopy.lastLoadedProperties;
-        for (Settings s : toCopy.settings) {
-            s.writeSettings(result);
-        }
+        lastLoadedConfiguration = toCopy.lastLoadedConfiguration;
+        Configuration result = toCopy.asConfiguration();
         for (Settings s : settings) {
             s.readSettings(result);
         }
     }
 
-
-    public void addSettings(Settings settings) {
-        this.settings.add(settings);
-        settings.addPropertyChangeListener(listener);
-        if (lastLoadedProperties != null) {
-            settings.readSettings(lastLoadedProperties);
-        }
-        if (lastLoadedConfiguration != null) {
-            settings.readSettings(lastLoadedConfiguration);
-        }
-    }
-
-    /**
-     * @deprecated {@link #getConfiguration}
-     */
-    @Deprecated
-    public Properties getProperties() {
-        Properties result = new Properties();
+    public Configuration asConfiguration() {
+        Configuration result = new Configuration();
         for (Settings s : settings) {
             s.writeSettings(result);
         }
         return result;
     }
 
+
+    public void addSettings(Settings settings) {
+        this.settings.add(settings);
+        settings.addPropertyChangeListener(listener);
+        if (lastLoadedConfiguration != null) {
+            settings.readSettings(lastLoadedConfiguration);
+        }
+    }
+
+    /**
+     * Serializes the current hierarchy of settings into a {@link Configuration} object which represents
+     * a tree of {@link java.util.Map}s.
+     *
+     * @return the current configuration in form of a {@link Configuration} object.
+     */
     public Configuration getConfiguration() {
         var config = new Configuration();
         for (Settings s : settings) {
@@ -144,11 +141,8 @@ public class ProofSettings {
      */
     public void saveSettings() {
         try {
-            if (!PROVER_CONFIG_FILE_NEW.exists()) {
-                PROVER_CONFIG_FILE.getParentFile().mkdirs();
-            }
             try (Writer out = new BufferedWriter(
-                new FileWriter(PROVER_CONFIG_FILE_NEW, StandardCharsets.UTF_8))) {
+                    new FileWriter(PROVER_CONFIG_FILE_NEW, StandardCharsets.UTF_8))) {
                 settingsToStream(out);
             }
         } catch (IOException e) {
@@ -170,7 +164,7 @@ public class ProofSettings {
     public void loadDefaultJSONSettings() {
         if (PROVER_CONFIG_FILE_TEMPLATE == null) {
             LOGGER.warn(
-                "default proof-settings file 'default-proof-settings.json' could not be found.");
+                    "default proof-settings file 'default-proof-settings.json' could not be found.");
         } else {
             try (var in = new InputStreamReader(PROVER_CONFIG_FILE_TEMPLATE.openStream())) {
                 loadSettingsFromJSONStream(in);
@@ -181,59 +175,21 @@ public class ProofSettings {
     }
 
     /**
-     * Used by loadSettings() and loadSettingsFromString(...)
-     *
-     * @deprecated in favour of {@link #loadSettingsFromJSONStream(Reader)}
-     */
-    @Deprecated
-    public void loadSettingsFromPropertyStream(Reader in) {
-        Properties props = new Properties();
-        try {
-            props.load(in);
-        } catch (IOException e) {
-            LOGGER.warn("Error on loading proof-settings.", e);
-        }
-        lastLoadedProperties = props;
-        lastLoadedConfiguration = null;
-        for (Settings s : settings) {
-            s.readSettings(props);
-        }
-    }
-
-    /**
-     * Loads the former settings from configuration file.
+     * Loads the former settings from a configuration file.
      */
     public void loadSettings() {
         if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
             LOGGER.warn("The settings in {} are *not* read.", PROVER_CONFIG_FILE);
         } else {
-            var isOldFormat = !PROVER_CONFIG_FILE_NEW.exists();
-            var fileToUse = isOldFormat ? PROVER_CONFIG_FILE : PROVER_CONFIG_FILE_NEW;
+            var fileToUse = PROVER_CONFIG_FILE_NEW;
             try (var in = new BufferedReader(new FileReader(fileToUse, StandardCharsets.UTF_8))) {
                 LOGGER.info("Load proof dependent settings from file {}", fileToUse);
-                if (isOldFormat) {
-                    loadDefaultJSONSettings();
-                    loadSettingsFromPropertyStream(in);
-                } else {
-                    loadDefaultJSONSettings();
-                    loadSettingsFromJSONStream(in);
-                }
+                loadDefaultJSONSettings();
+                loadSettingsFromJSONStream(in);
             } catch (IOException e) {
                 LOGGER.warn("No proof-settings could be loaded, using defaults", e);
             }
         }
-    }
-
-
-    /**
-     * Used to load Settings from a .key file
-     */
-    public void loadSettingsFromPropertyString(String s) {
-        if (s == null) {
-            return;
-        }
-        StringReader reader = new StringReader(s);
-        loadSettingsFromPropertyStream(reader);
     }
 
     /**
@@ -277,18 +233,6 @@ public class ProofSettings {
     }
 
     /**
-     * Update the proof settings according to the entries on the properties.
-     *
-     * @param props a non-<code>null</code> object with KeY properties.
-     */
-    public void update(Properties props) {
-        for (Settings s : settings) {
-            s.readSettings(props);
-        }
-    }
-
-
-    /**
      * Returns the term label settings from the proof settings.
      *
      * @return the term label settings
@@ -298,7 +242,6 @@ public class ProofSettings {
     }
 
     public void readSettings(Configuration c) {
-        lastLoadedProperties = null;
         lastLoadedConfiguration = c;
         for (Settings setting : settings)
             setting.readSettings(c);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -28,9 +28,9 @@ import org.slf4j.LoggerFactory;
 /// // KeY-Configuration file
 /// ActiveHeuristics=["simplify_prog", "simplify"]
 /// MaximumNumberOfHeuristcsApplications=400
-/// number  = "IntegerLDT.class"
+/// number = "IntegerLDT.class"
 /// boolean = "BooleanLDT.class"
-///```
+/// ```
 ///
 /// @see Properties
 /// @see Settings
@@ -38,10 +38,10 @@ public class ProofSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofSettings.class);
 
     public static final File PROVER_CONFIG_FILE =
-            new File(PathConfig.getKeyConfigDir(), "proof-settings.props");
+        new File(PathConfig.getKeyConfigDir(), "proof-settings.props");
 
     public static final File PROVER_CONFIG_FILE_NEW =
-            new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
+        new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
 
     public static final URL PROVER_CONFIG_FILE_TEMPLATE = KeYResourceManager.getManager()
             .getResourceFile(ProofSettings.class, "default-proof-settings.json");
@@ -68,7 +68,7 @@ public class ProofSettings {
     private final StrategySettings strategySettings = new StrategySettings();
     private final ChoiceSettings choiceSettings = new ChoiceSettings();
     private final ProofDependentSMTSettings smtSettings =
-            ProofDependentSMTSettings.getDefaultSettingsData();
+        ProofDependentSMTSettings.getDefaultSettingsData();
     private final NewSMTTranslationSettings newSMTSettings = new NewSMTTranslationSettings();
     private final TermLabelSettings termLabelSettings = new TermLabelSettings();
 
@@ -116,7 +116,8 @@ public class ProofSettings {
     }
 
     /**
-     * Serializes the current hierarchy of settings into a {@link Configuration} object which represents
+     * Serializes the current hierarchy of settings into a {@link Configuration} object which
+     * represents
      * a tree of {@link java.util.Map}s.
      *
      * @return the current configuration in form of a {@link Configuration} object.
@@ -142,7 +143,7 @@ public class ProofSettings {
     public void saveSettings() {
         try {
             try (Writer out = new BufferedWriter(
-                    new FileWriter(PROVER_CONFIG_FILE_NEW, StandardCharsets.UTF_8))) {
+                new FileWriter(PROVER_CONFIG_FILE_NEW, StandardCharsets.UTF_8))) {
                 settingsToStream(out);
             }
         } catch (IOException e) {
@@ -164,7 +165,7 @@ public class ProofSettings {
     public void loadDefaultJSONSettings() {
         if (PROVER_CONFIG_FILE_TEMPLATE == null) {
             LOGGER.warn(
-                    "default proof-settings file 'default-proof-settings.json' could not be found.");
+                "default proof-settings file 'default-proof-settings.json' could not be found.");
         } else {
             try (var in = new InputStreamReader(PROVER_CONFIG_FILE_TEMPLATE.openStream())) {
                 loadSettingsFromJSONStream(in);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
+import de.uka.ilkd.key.util.KeYResourceManager;
+import org.antlr.v4.runtime.CharStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.PropertyChangeListener;
 import java.io.*;
 import java.net.URL;
@@ -10,12 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-
-import de.uka.ilkd.key.util.KeYResourceManager;
-
-import org.antlr.v4.runtime.CharStreams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /// This class is used to load and save settings for proofs such as which data type models are used
 /// to represent the java types.
@@ -30,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /// MaximumNumberOfHeuristcsApplications=400
 /// number = "IntegerLDT.class"
 /// boolean = "BooleanLDT.class"
-/// ```
+///```
 ///
 /// @see Properties
 /// @see Settings
@@ -38,10 +37,7 @@ public class ProofSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofSettings.class);
 
     public static final File PROVER_CONFIG_FILE =
-        new File(PathConfig.getKeyConfigDir(), "proof-settings.props");
-
-    public static final File PROVER_CONFIG_FILE_NEW =
-        new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
+            new File(PathConfig.getKeyConfigDir(), "proof-settings.json");
 
     public static final URL PROVER_CONFIG_FILE_TEMPLATE = KeYResourceManager.getManager()
             .getResourceFile(ProofSettings.class, "default-proof-settings.json");
@@ -68,7 +64,7 @@ public class ProofSettings {
     private final StrategySettings strategySettings = new StrategySettings();
     private final ChoiceSettings choiceSettings = new ChoiceSettings();
     private final ProofDependentSMTSettings smtSettings =
-        ProofDependentSMTSettings.getDefaultSettingsData();
+            ProofDependentSMTSettings.getDefaultSettingsData();
     private final NewSMTTranslationSettings newSMTSettings = new NewSMTTranslationSettings();
     private final TermLabelSettings termLabelSettings = new TermLabelSettings();
 
@@ -142,9 +138,11 @@ public class ProofSettings {
      */
     public void saveSettings() {
         try {
-            try (Writer out = new BufferedWriter(
-                new FileWriter(PROVER_CONFIG_FILE_NEW, StandardCharsets.UTF_8))) {
-                settingsToStream(out);
+            if (PROVER_CONFIG_FILE.getParentFile().mkdirs()) {
+                try (Writer out = new BufferedWriter(
+                        new FileWriter(PROVER_CONFIG_FILE, StandardCharsets.UTF_8))) {
+                    settingsToStream(out);
+                }
             }
         } catch (IOException e) {
             LOGGER.warn("Could not save proof-settings.", e);
@@ -165,7 +163,7 @@ public class ProofSettings {
     public void loadDefaultJSONSettings() {
         if (PROVER_CONFIG_FILE_TEMPLATE == null) {
             LOGGER.warn(
-                "default proof-settings file 'default-proof-settings.json' could not be found.");
+                    "default proof-settings file 'default-proof-settings.json' could not be found.");
         } else {
             try (var in = new InputStreamReader(PROVER_CONFIG_FILE_TEMPLATE.openStream())) {
                 loadSettingsFromJSONStream(in);
@@ -182,7 +180,7 @@ public class ProofSettings {
         if (Boolean.getBoolean(PathConfig.DISREGARD_SETTINGS_PROPERTY)) {
             LOGGER.warn("The settings in {} are *not* read.", PROVER_CONFIG_FILE);
         } else {
-            var fileToUse = PROVER_CONFIG_FILE_NEW;
+            var fileToUse = PROVER_CONFIG_FILE;
             try (var in = new BufferedReader(new FileReader(fileToUse, StandardCharsets.UTF_8))) {
                 LOGGER.info("Load proof dependent settings from file {}", fileToUse);
                 loadDefaultJSONSettings();

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofSettings.java
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
-import de.uka.ilkd.key.util.KeYResourceManager;
-import org.antlr.v4.runtime.CharStreams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.beans.PropertyChangeListener;
 import java.io.*;
 import java.net.URL;
@@ -15,6 +10,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+
+import de.uka.ilkd.key.util.KeYResourceManager;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /// This class is used to load and save settings for proofs such as which data type models are used
 /// to represent the java types.
@@ -140,7 +141,7 @@ public class ProofSettings {
         try {
             if (PROVER_CONFIG_FILE.getParentFile().mkdirs()) {
                 try (Writer out = new BufferedWriter(
-                        new FileWriter(PROVER_CONFIG_FILE, StandardCharsets.UTF_8))) {
+                    new FileWriter(PROVER_CONFIG_FILE, StandardCharsets.UTF_8))) {
                     settingsToStream(out);
                 }
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/Settings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/Settings.java
@@ -8,30 +8,14 @@ import java.beans.PropertyChangeSupport;
 import java.util.Properties;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * This interface is implemented by classes that are used to store settings for different proposes
  * (like active heuristics, which LDTs to use etc.)
  */
+@NullMarked
 public interface Settings {
-
-    /**
-     * gets a Properties object and has to perform the necessary steps in order to change this
-     * object in a way that it represents the stored settings
-     *
-     * @deprecated Deprecated in favour of {@link #readSettings(Configuration)}
-     */
-    @Deprecated
-    void readSettings(Properties props);
-
-    /**
-     * The settings to store are written to the given Properties object.
-     *
-     * @param props the Properties object where to write the settings as (key, value) pair
-     * @deprecated Deprecated in favour of {@link #writeSettings(Configuration)}
-     */
-    @Deprecated
-    void writeSettings(Properties props);
 
     /**
      * This method transfers the given configuration information into the local states. The setter
@@ -40,9 +24,9 @@ public interface Settings {
      * <p>
      *
      * @param props a non-null references to a configuration object. The state of this object
-     *        shall not be changed by the implementations.
+     *              shall not be changed by the implementations.
      */
-    void readSettings(@NonNull Configuration props);
+    void readSettings(Configuration props);
 
     /**
      * The internal state is stored in the given configuration object. The stored information must
@@ -52,10 +36,10 @@ public interface Settings {
      * The internal state shall not be changed by the implementations.
      *
      * @param props a non-null reference to a configration object, which state is modified
-     *        accordingly to the local
-     *        internal state.
+     *              accordingly to the local
+     *              internal state.
      */
-    void writeSettings(@NonNull Configuration props);
+    void writeSettings(Configuration props);
 
 
     /**
@@ -64,7 +48,7 @@ public interface Settings {
      * @param listener a non-null reference
      * @see PropertyChangeSupport#addPropertyChangeListener(PropertyChangeListener)
      */
-    void addPropertyChangeListener(@NonNull PropertyChangeListener listener);
+    void addPropertyChangeListener(PropertyChangeListener listener);
 
     /**
      * Removes the given listener.
@@ -78,19 +62,18 @@ public interface Settings {
      * Register a new listener which is triggered for changes on the specified property.
      *
      * @param propertyName the name for identification of the property
-     * @param listener the listener to be added
+     * @param listener     the listener to be added
      * @see PropertyChangeSupport#addPropertyChangeListener(String, PropertyChangeListener)
      */
-    void addPropertyChangeListener(@NonNull String propertyName,
-            @NonNull PropertyChangeListener listener);
+    void addPropertyChangeListener(String propertyName,
+                                   PropertyChangeListener listener);
 
     /**
      * Removes the given listener from being triggered by changes of the specified property.
      *
      * @param propertyName the name for identification of the property
-     * @param listener the listener to be removed
+     * @param listener     the listener to be removed
      * @see PropertyChangeSupport#removePropertyChangeListener(String, PropertyChangeListener)
      */
-    void removePropertyChangeListener(@NonNull String propertyName,
-            @NonNull PropertyChangeListener listener);
+    void removePropertyChangeListener(String propertyName, PropertyChangeListener listener);
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/Settings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/Settings.java
@@ -5,9 +5,7 @@ package de.uka.ilkd.key.settings;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.util.Properties;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -24,7 +22,7 @@ public interface Settings {
      * <p>
      *
      * @param props a non-null references to a configuration object. The state of this object
-     *              shall not be changed by the implementations.
+     *        shall not be changed by the implementations.
      */
     void readSettings(Configuration props);
 
@@ -36,8 +34,8 @@ public interface Settings {
      * The internal state shall not be changed by the implementations.
      *
      * @param props a non-null reference to a configration object, which state is modified
-     *              accordingly to the local
-     *              internal state.
+     *        accordingly to the local
+     *        internal state.
      */
     void writeSettings(Configuration props);
 
@@ -62,17 +60,17 @@ public interface Settings {
      * Register a new listener which is triggered for changes on the specified property.
      *
      * @param propertyName the name for identification of the property
-     * @param listener     the listener to be added
+     * @param listener the listener to be added
      * @see PropertyChangeSupport#addPropertyChangeListener(String, PropertyChangeListener)
      */
     void addPropertyChangeListener(String propertyName,
-                                   PropertyChangeListener listener);
+            PropertyChangeListener listener);
 
     /**
      * Removes the given listener from being triggered by changes of the specified property.
      *
      * @param propertyName the name for identification of the property
-     * @param listener     the listener to be removed
+     * @param listener the listener to be removed
      * @see PropertyChangeSupport#removePropertyChangeListener(String, PropertyChangeListener)
      */
     void removePropertyChangeListener(String propertyName, PropertyChangeListener listener);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.settings;
 
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.TermLabel;
+
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/TermLabelSettings.java
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
-import java.util.Properties;
-
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.TermLabel;
-
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author lanzinger
  */
+@NullMarked
 public class TermLabelSettings extends AbstractSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(TermLabelSettings.class);
 
@@ -26,27 +25,12 @@ public class TermLabelSettings extends AbstractSettings {
     private boolean useOriginLabels = true;
 
     @Override
-    public void readSettings(Properties props) {
-        String str = props.getProperty("[" + CATEGORY + "]" + USE_ORIGIN_LABELS);
-
-        if (str != null && (str.equals("true") || str.equals("false"))) {
-            setUseOriginLabels(Boolean.parseBoolean(str));
-        } else {
-            setUseOriginLabels(true);
-        }
-    }
-
-    @Override
-    public void writeSettings(Properties props) {
-        props.setProperty("[" + CATEGORY + "]" + USE_ORIGIN_LABELS,
-            Boolean.toString(useOriginLabels));
-    }
-
-    @Override
     public void readSettings(Configuration props) {
         var category = props.getSection(CATEGORY);
-        if (category == null)
+        if (category == null) {
             return;
+        }
+
         try {
             setUseOriginLabels(category.getBool(USE_ORIGIN_LABELS));
         } catch (Exception e) {

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
-import javax.swing.*;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.swing.*;
 
 /**
  * This class encapsulates information about: 1) relative font size in the prover view 2) the
@@ -24,19 +24,28 @@ public class ViewSettings extends AbstractPropertiesSettings {
 
     private static final String CLUTTER_RULES = "clutterRules";
 
-    private static final Set<String> CLUTTER_RULES_DEFAULT = new TreeSet<>(Set.of("cut_direct_r", "cut_direct_l",
-            "case_distinction_r", "case_distinction_l", "local_cut", "commute_and_2", "commute_or_2", "boxToDiamond",
+    private static final Set<String> CLUTTER_RULES_DEFAULT =
+        new TreeSet<>(Set.of("cut_direct_r", "cut_direct_l",
+            "case_distinction_r", "case_distinction_l", "local_cut", "commute_and_2",
+            "commute_or_2", "boxToDiamond",
             "pullOut", "typeStatic", "less_is_total", "less_zero_is_total", "apply_eq_monomials" +
-                    "eqTermCut", "instAll", "instEx", "divIncreasingPos", "divIncreasingNeg", "jmodUnique1", "jmodeUnique2",
-            "jmodjmod", "jmodDivisble", "jdivAddMultDenom", "jmodAltZero", "add_non_neq_square", "divide_geq",
-            "add_greatereq", "geq_add_one", "leq_add_one", "polySimp_addOrder", "polySimp_expand", "add_lesseq",
+                "eqTermCut",
+            "instAll", "instEx", "divIncreasingPos", "divIncreasingNeg", "jmodUnique1",
+            "jmodeUnique2",
+            "jmodjmod", "jmodDivisble", "jdivAddMultDenom", "jmodAltZero", "add_non_neq_square",
+            "divide_geq",
+            "add_greatereq", "geq_add_one", "leq_add_one", "polySimp_addOrder", "polySimp_expand",
+            "add_lesseq",
             "divide_equation", "equal_add_one", "add_eq"));
 
     private static final String CLUTTER_RULESSETS = "clutterRuleSets";
 
-    private static final Set<String> CLUTTER_RULESETS_DEFAULT = new TreeSet<>(Set.of("notHumanReadable", "obsolete",
-            "pullOutQuantifierAll", "inEqSimp_commute", "inEqSimp_expand", "pullOutQuantifierEx", "inEqSimp_nonLin_divide",
-            "inEqSimp_special_nonLin", "inEqSimp_nonLin", "polySimp_normalise", "polySimp_directEquations"));
+    private static final Set<String> CLUTTER_RULESETS_DEFAULT =
+        new TreeSet<>(Set.of("notHumanReadable", "obsolete",
+            "pullOutQuantifierAll", "inEqSimp_commute", "inEqSimp_expand", "pullOutQuantifierEx",
+            "inEqSimp_nonLin_divide",
+            "inEqSimp_special_nonLin", "inEqSimp_nonLin", "polySimp_normalise",
+            "polySimp_directEquations"));
 
     /**
      * default max number of displayed tooltip lines is 40
@@ -175,64 +184,64 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Show Taclet uninstantiated in tooltip -- for learning
      */
     private final PropertyEntry<Boolean> showUninstantiatedTaclet =
-            createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
+        createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
     private final PropertyEntry<Boolean> showHeatmap = createBooleanProperty(HEATMAP_SHOW, false);
     private final PropertyEntry<Boolean> heatmapSF = createBooleanProperty(HEATMAP_SF, true);
     /**
      * Highlight most recent formulas/terms (true) or all formulas/terms below specified age (false)
      */
     private final PropertyEntry<Boolean> heatmapNewest =
-            createBooleanProperty(HEATMAP_NEWEST, true);
+        createBooleanProperty(HEATMAP_NEWEST, true);
     /**
      * Maximum age/number of newest terms/formulas for heatmap highlighting
      */
     private final PropertyEntry<Integer> maxAgeForHeatmap =
-            createIntegerProperty(HEATMAP_MAXAGE, 5);
+        createIntegerProperty(HEATMAP_MAXAGE, 5);
     private final PropertyEntry<Double> uiFontSizeFactor =
-            createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
+        createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
     private final PropertyEntry<Integer> maxTooltipLines =
-            createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
+        createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
     private final PropertyEntry<Boolean> hideIntermediateProofsteps =
-            createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
+        createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideAutomodeProofsteps =
-            createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
+        createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideClosedSubtrees =
-            createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
+        createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
     private final PropertyEntry<Boolean> notifyLoadBehaviour =
-            createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
+        createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
     private final PropertyEntry<Boolean> usePretty = createBooleanProperty(PRETTY_SYNTAX, true);
     private final PropertyEntry<Boolean> useUnicode = createBooleanProperty(USE_UNICODE, false);
     private final PropertyEntry<Boolean> useSyntaxHighlighting =
-            createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
+        createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
     private final PropertyEntry<Boolean> hidePackagePrefix =
-            createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
+        createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
     private final PropertyEntry<Boolean> confirmExit = createBooleanProperty(CONFIRM_EXIT, true);
     private final PropertyEntry<Boolean> showLoadExamplesDialog =
-            createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
+        createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
     private final PropertyEntry<Boolean> showWholeTaclet =
-            createBooleanProperty(SHOW_WHOLE_TACLET, false);
+        createBooleanProperty(SHOW_WHOLE_TACLET, false);
     private final PropertyEntry<Integer> sizeIndex = createIntegerProperty(FONT_INDEX, 2);
     private final PropertyEntry<String> lookAndFeel =
         createStringProperty(PROP_LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
     private final PropertyEntry<Boolean> showSequentViewTooltips =
-            createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
+        createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showSourceViewTooltips =
-            createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
+        createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showProofTreeTooltips =
-            createBooleanProperty(PROOF_TREE_TOOLTIP, true);
+        createBooleanProperty(PROOF_TREE_TOOLTIP, true);
     private final PropertyEntry<Boolean> highlightOrigin =
-            createBooleanProperty(HIGHLIGHT_ORIGIN, true);
+        createBooleanProperty(HIGHLIGHT_ORIGIN, true);
     private final PropertyEntry<Set<String>> clutterRules =
-            createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
+        createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
 
     private final PropertyEntry<Set<String>> clutterRuleSets =
-            createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
+        createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
 
     private final PropertyEntry<Boolean> hideInteractiveGoals =
-            createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
+        createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
 
     private final PropertyEntry<String> notificationAfterMacro =
-            createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
+        createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
 
     /**
      * User-definable folder bookmarks.
@@ -241,8 +250,8 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * @see #setFolderBookmarks(List)
      */
     private final PropertyEntry<List<String>> folderBookmarks =
-            createStringListProperty(USER_FOLDER_BOOKMARKS,
-                    List.of(System.getProperty("user.home")));
+        createStringListProperty(USER_FOLDER_BOOKMARKS,
+            List.of(System.getProperty("user.home")));
 
     //
     private boolean isDarkMode;
@@ -321,7 +330,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Sets whether the "Load Examples" dialog window should be shown on startup
      *
      * @param b indicates whether the "Load Examples" dialog window should be shown on startup or
-     *          not
+     *        not
      */
     public void setShowLoadExamplesDialog(boolean b) {
         showLoadExamplesDialog.set(b);
@@ -342,7 +351,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * instantiations of schema-variables or not
      *
      * @param b indicates whether the Find and VarCond part of Taclets should be pretty-printed with
-     *          instantiations of schema-variables or not
+     *        instantiations of schema-variables or not
      */
     public void setShowWholeTaclet(boolean b) {
         showWholeTaclet.set(b);
@@ -536,14 +545,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Updates heatmap settings (all of the at the same time, so that fireSettingsChanged is called
      * only once.
      *
-     * @param showHeatmap      true if heatmap on
-     * @param heatmapSF        true for sequent formulas, false for terms
-     * @param heatmapNewest    true if newest, false for "up to age"
+     * @param showHeatmap true if heatmap on
+     * @param heatmapSF true for sequent formulas, false for terms
+     * @param heatmapNewest true if newest, false for "up to age"
      * @param maxAgeForHeatmap the maximum age for term or sequent formulas, concerning heatmap
-     *                         highlighting
+     *        highlighting
      */
     public void setHeatmapOptions(boolean showHeatmap, boolean heatmapSF, boolean heatmapNewest,
-                                  int maxAgeForHeatmap) {
+            int maxAgeForHeatmap) {
         this.showHeatmap.set(showHeatmap);
         this.heatmapSF.set(heatmapSF);
         this.heatmapNewest.set(heatmapNewest);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.settings;
 
+import javax.swing.*;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * This class encapsulates information about: 1) relative font size in the prover view 2) the
@@ -22,20 +24,19 @@ public class ViewSettings extends AbstractPropertiesSettings {
 
     private static final String CLUTTER_RULES = "clutterRules";
 
-    private static final String CLUTTER_RULES_DEFAULT = "cut_direct_r,cut_direct_l,"
-        + "case_distinction_r,case_distinction_l,local_cut,commute_and_2,commute_or_2,"
-        + "boxToDiamond,pullOut,typeStatic,less_is_total,less_zero_is_total,apply_eq_monomials"
-        + "eqTermCut,instAll,instEx,divIncreasingPos,divIncreasingNeg,jmodUnique1,jmodeUnique2,"
-        + "jmodjmod,jmodDivisble,jdivAddMultDenom,jmodAltZero,add_non_neq_square,divide_geq,"
-        + "add_greatereq,geq_add_one,leq_add_one,polySimp_addOrder,polySimp_expand,add_lesseq,"
-        + "divide_equation,equal_add_one,add_eq";
+    private static final Set<String> CLUTTER_RULES_DEFAULT = new TreeSet<>(Set.of("cut_direct_r", "cut_direct_l",
+            "case_distinction_r", "case_distinction_l", "local_cut", "commute_and_2", "commute_or_2", "boxToDiamond",
+            "pullOut", "typeStatic", "less_is_total", "less_zero_is_total", "apply_eq_monomials" +
+                    "eqTermCut", "instAll", "instEx", "divIncreasingPos", "divIncreasingNeg", "jmodUnique1", "jmodeUnique2",
+            "jmodjmod", "jmodDivisble", "jdivAddMultDenom", "jmodAltZero", "add_non_neq_square", "divide_geq",
+            "add_greatereq", "geq_add_one", "leq_add_one", "polySimp_addOrder", "polySimp_expand", "add_lesseq",
+            "divide_equation", "equal_add_one", "add_eq"));
 
     private static final String CLUTTER_RULESSETS = "clutterRuleSets";
 
-    private static final String CLUTTER_RULESETS_DEFAULT = "notHumanReadable,obsolete,"
-        + "pullOutQuantifierAll,inEqSimp_commute,inEqSimp_expand,pullOutQuantifierEx,"
-        + "inEqSimp_nonLin_divide,inEqSimp_special_nonLin,inEqSimp_nonLin,polySimp_normalise,"
-        + "polySimp_directEquations";
+    private static final Set<String> CLUTTER_RULESETS_DEFAULT = new TreeSet<>(Set.of("notHumanReadable", "obsolete",
+            "pullOutQuantifierAll", "inEqSimp_commute", "inEqSimp_expand", "pullOutQuantifierEx", "inEqSimp_nonLin_divide",
+            "inEqSimp_special_nonLin", "inEqSimp_nonLin", "polySimp_normalise", "polySimp_directEquations"));
 
     /**
      * default max number of displayed tooltip lines is 40
@@ -174,64 +175,64 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Show Taclet uninstantiated in tooltip -- for learning
      */
     private final PropertyEntry<Boolean> showUninstantiatedTaclet =
-        createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
+            createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
     private final PropertyEntry<Boolean> showHeatmap = createBooleanProperty(HEATMAP_SHOW, false);
     private final PropertyEntry<Boolean> heatmapSF = createBooleanProperty(HEATMAP_SF, true);
     /**
      * Highlight most recent formulas/terms (true) or all formulas/terms below specified age (false)
      */
     private final PropertyEntry<Boolean> heatmapNewest =
-        createBooleanProperty(HEATMAP_NEWEST, true);
+            createBooleanProperty(HEATMAP_NEWEST, true);
     /**
      * Maximum age/number of newest terms/formulas for heatmap highlighting
      */
     private final PropertyEntry<Integer> maxAgeForHeatmap =
-        createIntegerProperty(HEATMAP_MAXAGE, 5);
+            createIntegerProperty(HEATMAP_MAXAGE, 5);
     private final PropertyEntry<Double> uiFontSizeFactor =
-        createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
+            createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
     private final PropertyEntry<Integer> maxTooltipLines =
-        createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
+            createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
     private final PropertyEntry<Boolean> hideIntermediateProofsteps =
-        createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
+            createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideAutomodeProofsteps =
-        createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
+            createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideClosedSubtrees =
-        createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
+            createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
     private final PropertyEntry<Boolean> notifyLoadBehaviour =
-        createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
+            createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
     private final PropertyEntry<Boolean> usePretty = createBooleanProperty(PRETTY_SYNTAX, true);
     private final PropertyEntry<Boolean> useUnicode = createBooleanProperty(USE_UNICODE, false);
     private final PropertyEntry<Boolean> useSyntaxHighlighting =
-        createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
+            createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
     private final PropertyEntry<Boolean> hidePackagePrefix =
-        createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
+            createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
     private final PropertyEntry<Boolean> confirmExit = createBooleanProperty(CONFIRM_EXIT, true);
     private final PropertyEntry<Boolean> showLoadExamplesDialog =
-        createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
+            createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
     private final PropertyEntry<Boolean> showWholeTaclet =
-        createBooleanProperty(SHOW_WHOLE_TACLET, false);
+            createBooleanProperty(SHOW_WHOLE_TACLET, false);
     private final PropertyEntry<Integer> sizeIndex = createIntegerProperty(FONT_INDEX, 2);
     private final PropertyEntry<String> lookAndFeel =
         createStringProperty(PROP_LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
     private final PropertyEntry<Boolean> showSequentViewTooltips =
-        createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
+            createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showSourceViewTooltips =
-        createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
+            createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showProofTreeTooltips =
-        createBooleanProperty(PROOF_TREE_TOOLTIP, true);
+            createBooleanProperty(PROOF_TREE_TOOLTIP, true);
     private final PropertyEntry<Boolean> highlightOrigin =
-        createBooleanProperty(HIGHLIGHT_ORIGIN, true);
+            createBooleanProperty(HIGHLIGHT_ORIGIN, true);
     private final PropertyEntry<Set<String>> clutterRules =
-        createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
+            createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
 
     private final PropertyEntry<Set<String>> clutterRuleSets =
-        createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
+            createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
 
     private final PropertyEntry<Boolean> hideInteractiveGoals =
-        createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
+            createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
 
     private final PropertyEntry<String> notificationAfterMacro =
-        createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
+            createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
 
     /**
      * User-definable folder bookmarks.
@@ -240,7 +241,8 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * @see #setFolderBookmarks(List)
      */
     private final PropertyEntry<List<String>> folderBookmarks =
-        createStringListProperty(USER_FOLDER_BOOKMARKS, System.getProperty("user.home"));
+            createStringListProperty(USER_FOLDER_BOOKMARKS,
+                    List.of(System.getProperty("user.home")));
 
     //
     private boolean isDarkMode;
@@ -319,7 +321,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Sets whether the "Load Examples" dialog window should be shown on startup
      *
      * @param b indicates whether the "Load Examples" dialog window should be shown on startup or
-     *        not
+     *          not
      */
     public void setShowLoadExamplesDialog(boolean b) {
         showLoadExamplesDialog.set(b);
@@ -340,7 +342,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * instantiations of schema-variables or not
      *
      * @param b indicates whether the Find and VarCond part of Taclets should be pretty-printed with
-     *        instantiations of schema-variables or not
+     *          instantiations of schema-variables or not
      */
     public void setShowWholeTaclet(boolean b) {
         showWholeTaclet.set(b);
@@ -534,14 +536,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Updates heatmap settings (all of the at the same time, so that fireSettingsChanged is called
      * only once.
      *
-     * @param showHeatmap true if heatmap on
-     * @param heatmapSF true for sequent formulas, false for terms
-     * @param heatmapNewest true if newest, false for "up to age"
+     * @param showHeatmap      true if heatmap on
+     * @param heatmapSF        true for sequent formulas, false for terms
+     * @param heatmapNewest    true if newest, false for "up to age"
      * @param maxAgeForHeatmap the maximum age for term or sequent formulas, concerning heatmap
-     *        highlighting
+     *                         highlighting
      */
     public void setHeatmapOptions(boolean showHeatmap, boolean heatmapSF, boolean heatmapNewest,
-            int maxAgeForHeatmap) {
+                                  int maxAgeForHeatmap) {
         this.showHeatmap.set(showHeatmap);
         this.heatmapSF.set(heatmapSF);
         this.heatmapNewest.set(heatmapNewest);

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProveTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProveTest.java
@@ -5,9 +5,7 @@ package de.uka.ilkd.key.proof.runallproofs;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.StringReader;
 import java.util.List;
 
 import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
@@ -84,10 +82,11 @@ public class ProveTest {
         LOGGER.info("{}: Run Test: {} with {}", caseId, file, testProperty);
 
         // Initialize KeY settings.
-        ProofSettings.DEFAULT_SETTINGS.loadSettingsFromPropertyString(globalSettings);
+        ProofSettings.DEFAULT_SETTINGS.loadSettingsFromJSONStream(new StringReader(globalSettings));
         if (localSettings != null && !localSettings.isEmpty()) {
             // local settings must be complete to have desired effect
-            ProofSettings.DEFAULT_SETTINGS.loadSettingsFromPropertyString(localSettings);
+            ProofSettings.DEFAULT_SETTINGS
+                    .loadSettingsFromJSONStream(new StringReader(localSettings));
         }
 
         LOGGER.info("({}) Active Settings: {}", caseId,

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/proofcollection/TestFile.java
@@ -143,9 +143,9 @@ public class TestFile implements Serializable {
 
             // Initialize KeY settings.
             String gks = settings.getGlobalKeYSettings();
-            ProofSettings.DEFAULT_SETTINGS.loadSettingsFromPropertyString(gks);
+            ProofSettings.DEFAULT_SETTINGS.loadSettingsFromJSONStream(new StringReader(gks));
             String lks = settings.getLocalKeYSettings();
-            ProofSettings.DEFAULT_SETTINGS.loadSettingsFromPropertyString(lks);
+            ProofSettings.DEFAULT_SETTINGS.loadSettingsFromJSONStream(new StringReader(lks));
 
             // Name resolution for the available KeY file.
             Path keyFile = getKeYFile();

--- a/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
@@ -17,6 +17,8 @@ import java.util.stream.Stream;
 
 import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
 import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.logic.Sequent;
+import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.settings.DefaultSMTSettings;
@@ -27,7 +29,7 @@ import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypeImplementation;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
 
-import org.key_project.prover.sequent.Sequent;
+import org.antlr.v4.runtime.CharStreams;
 import org.key_project.util.Streams;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -164,8 +166,10 @@ public class MasterHandlerTest {
                 ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings(),
                 proof.getSettings().getNewSMTSettings(), proof);
 
-            if (smtSettings != null) {
-                settings.getNewSettings().readSettings(smtSettings);
+            String updates = props.get("smt-settings");
+            if (updates != null) {
+                    var map = ParsingFacade.readConfigurationFile(CharStreams.fromString(updates));
+                settings.getNewSettings().readSettings(map);
             }
 
             ModularSMTLib2Translator translator = new ModularSMTLib2Translator();

--- a/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Stream;
 
 import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
@@ -29,9 +28,9 @@ import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypeImplementation;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
 
-import org.antlr.v4.runtime.CharStreams;
 import org.key_project.util.Streams;
 
+import org.antlr.v4.runtime.CharStreams;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.assertj.core.api.Assertions;
@@ -168,7 +167,7 @@ public class MasterHandlerTest {
 
             String updates = props.get("smt-settings");
             if (updates != null) {
-                    var map = ParsingFacade.readConfigurationFile(CharStreams.fromString(updates));
+                var map = ParsingFacade.readConfigurationFile(CharStreams.fromString(updates));
                 settings.getNewSettings().readSettings(map);
             }
 

--- a/key.removegenerics/src/test/java/de/uka/ilkd/key/util/removegenerics/TestMemberReference.java
+++ b/key.removegenerics/src/test/java/de/uka/ilkd/key/util/removegenerics/TestMemberReference.java
@@ -14,7 +14,7 @@ public class TestMemberReference extends ResolveGenericClass {
         registerCU("package java.lang; public class String {}");
         registerCU("package java.lang; public interface Comparator<X extends Comparator<X>> { }");
         registerCU(
-            "package java.lang; public class Object { public String toString() {}; protected final Object clone(); }");
+            "package java.lang; public class Object { public String toString() {}; protected final Object copy(); }");
         registerCU("class G<E> { E[][] array; E field; " + "E m() { return null; } "
             + "E[][] n() { return null; } } " + "class B { void bb(); }");
     }
@@ -156,10 +156,10 @@ public class TestMemberReference extends ResolveGenericClass {
     public void testStortArray() throws Exception {
         String before =
             "class Arrays { public static <T> void sort(T[] a, Comparator<? super T> c) {"
-                + "T[] aux = (T[])a.clone(); } }";
+                + "T[] aux = (T[])a.copy(); } }";
         String after =
             "class Arrays { public static void sort(java.lang.Object[] a, Comparator c) {"
-                + "java.lang.Object[] aux = (java.lang.Object[])a.clone(); } }";
+                + "java.lang.Object[] aux = (java.lang.Object[])a.copy(); } }";
         equalCU(before, after);
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SettingsTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SettingsTreeModel.java
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions;
 
-import de.uka.ilkd.key.gui.smt.OptionContentNode;
-import de.uka.ilkd.key.settings.*;
-
+import java.util.Collection;
+import java.util.Map;
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.MutableTreeNode;
-import java.util.Collection;
-import java.util.Map;
+
+import de.uka.ilkd.key.gui.smt.OptionContentNode;
+import de.uka.ilkd.key.settings.*;
 
 import org.key_project.logic.Choice;
 
@@ -27,7 +27,7 @@ public class SettingsTreeModel extends DefaultTreeModel {
     private DefaultMutableTreeNode tacletOptionsItem;
 
     public SettingsTreeModel(ProofSettings proofSettings,
-                             ProofIndependentSettings independentSettings) {
+            ProofIndependentSettings independentSettings) {
         super(new DefaultMutableTreeNode("All Settings"));
 
         this.proofSettings = proofSettings;
@@ -41,19 +41,19 @@ public class SettingsTreeModel extends DefaultTreeModel {
 
         if (proofSettings == null) {
             OptionContentNode proofSettingsNode =
-                    generateOptionContentNode("Proof Settings", "There is currently no proof loaded!");
+                generateOptionContentNode("Proof Settings", "There is currently no proof loaded!");
             root.add(proofSettingsNode);
         } else {
             OptionContentNode proofSettingsNode =
-                    generateOptionContentNode("Proof Settings",
-                            "These are the proof dependent settings.");
+                generateOptionContentNode("Proof Settings",
+                    "These are the proof dependent settings.");
             root.add(proofSettingsNode);
 
             configurationTable(proofSettingsNode, proofSettings.asConfiguration());
         }
 
         var independentSettingsNode = generateOptionContentNode(
-                "Proof-Independent Settings", "These are the proof independent settings.");
+            "Proof-Independent Settings", "These are the proof independent settings.");
         root.add(independentSettingsNode);
         configurationTable(independentSettingsNode, independentSettings.asConfiguration());
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SettingsTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SettingsTreeModel.java
@@ -3,122 +3,82 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions;
 
-import java.util.Arrays;
-import java.util.Map.Entry;
-import java.util.Properties;
+import de.uka.ilkd.key.gui.smt.OptionContentNode;
+import de.uka.ilkd.key.settings.*;
+
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
-
-import de.uka.ilkd.key.gui.smt.OptionContentNode;
-import de.uka.ilkd.key.settings.ChoiceSettings;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
-import de.uka.ilkd.key.settings.ProofSettings;
-import de.uka.ilkd.key.settings.Settings;
+import javax.swing.tree.MutableTreeNode;
+import java.util.Collection;
+import java.util.Map;
 
 import org.key_project.logic.Choice;
 
 /**
- *
  * A swing model for {@link ShowActiveSettingsAction}.
  *
  * @author Mihai Herda, 2018
  */
 
 public class SettingsTreeModel extends DefaultTreeModel {
-
-    private static final long serialVersionUID = -3282304543262262159L;
-
     private final ProofSettings proofSettings;
-
     private final ProofIndependentSettings independentSettings;
-    private OptionContentNode tacletOptionsItem;
+    private DefaultMutableTreeNode tacletOptionsItem;
 
     public SettingsTreeModel(ProofSettings proofSettings,
-            ProofIndependentSettings independentSettings) {
+                             ProofIndependentSettings independentSettings) {
         super(new DefaultMutableTreeNode("All Settings"));
+
         this.proofSettings = proofSettings;
         this.independentSettings = independentSettings;
+
         generateTree();
     }
 
     private void generateTree() {
-        DefaultMutableTreeNode root = (DefaultMutableTreeNode) this.getRoot();
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("All Settings");
 
         if (proofSettings == null) {
             OptionContentNode proofSettingsNode =
-                generateOptionContentNode("Proof Settings", "There is currently no proof loaded!");
+                    generateOptionContentNode("Proof Settings", "There is currently no proof loaded!");
             root.add(proofSettingsNode);
         } else {
             OptionContentNode proofSettingsNode =
-                generateOptionContentNode("Proof Settings",
-                    "These are the proof dependent settings.");
+                    generateOptionContentNode("Proof Settings",
+                            "These are the proof dependent settings.");
             root.add(proofSettingsNode);
 
-            // ChoiceSettings choiceSettings = proofSettings.getChoiceSettings();
-            ChoiceSettings choiceSettings = proofSettings.getChoiceSettings();
-            tacletOptionsItem = generateTableNode("Taclet Options", choiceSettings);
-            proofSettingsNode.add(tacletOptionsItem);
-
-            Settings strategySettings = proofSettings.getStrategySettings();
-            proofSettingsNode.add(generateTableNode("Strategy", strategySettings));
-
-            Settings smtSettings = proofSettings.getSMTSettings();
-            proofSettingsNode.add(generateTableNode("SMT", smtSettings));
+            configurationTable(proofSettingsNode, proofSettings.asConfiguration());
         }
 
-        OptionContentNode independentSettingsNode = generateOptionContentNode(
-            "Proof-Independent Settings", "These are the proof independent settings.");
+        var independentSettingsNode = generateOptionContentNode(
+                "Proof-Independent Settings", "These are the proof independent settings.");
         root.add(independentSettingsNode);
+        configurationTable(independentSettingsNode, independentSettings.asConfiguration());
 
-        Settings generalSettings = independentSettings.getGeneralSettings();
-        independentSettingsNode.add(generateTableNode("General", generalSettings));
-        Settings lemmaSettings = independentSettings.getLemmaGeneratorSettings();
-        independentSettingsNode.add(generateTableNode("Lemma Generator", lemmaSettings));
-        Settings indSMTSettings = independentSettings.getSMTSettings();
-        independentSettingsNode.add(generateTableNode("SMT", indSMTSettings));
-        // Settings testgenSettings =independentSettings.getTestGenerationSettings();
-        // independentSettingsNode.add(generateTableNode("Testcase Generation", testgenSettings));
-        Settings viewSettings = independentSettings.getViewSettings();
-        independentSettingsNode.add(generateTableNode("View", viewSettings));
-        Settings termLabelSettings = independentSettings.getTermLabelSettings();
-        // Previously, the termLabelSettings were added to the proofSettingsNode, but judging by the
-        // previous line,
-        // it should really be added to the independentSettingsNode
-        independentSettingsNode.add(generateTableNode("Term Labels", termLabelSettings));
+        setRoot(root);
     }
-
 
 
     public JComponent getStartComponent() {
         return generateScrollPane("Here are all settings.");
     }
 
-
-    private Properties getChoicesAsProperties(ChoiceSettings settings) {
-        Properties prop = new Properties();
-
-        for (Choice choice : settings.getDefaultChoicesAsSet()) {
-            prop.put(choice.category(), choice.name());
-        }
-
-        return prop;
+    private MutableTreeNode generateTableNode(String title, Settings settings) {
+        Configuration c = new Configuration();
+        settings.writeSettings(c);
+        var n = new DefaultMutableTreeNode(title);
+        configurationTable(n, c);
+        return n;
     }
 
-    private OptionContentNode generateTableNode(String title, Settings settings) {
-
-        Properties props = new Properties();
-        settings.writeSettings(props);
-
-        return new OptionContentNode(title, generateJTable(props));
-
-    }
-
-    private OptionContentNode generateTableNode(String title, ChoiceSettings settings) {
-        Properties props = getChoicesAsProperties(settings);
-        return new OptionContentNode(title, generateJTable(props));
-
+    private DefaultMutableTreeNode generateTableNode(String title, ChoiceSettings settings) {
+        Configuration c = new Configuration();
+        settings.writeSettings(c);
+        var node = new DefaultMutableTreeNode(title);
+        configurationTable(node, c);
+        return node;
     }
 
 
@@ -127,50 +87,53 @@ public class SettingsTreeModel extends DefaultTreeModel {
         ta.append(text);
         ta.setEditable(false);
         ta.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        JScrollPane scrollpane = new JScrollPane(ta);
-        return scrollpane;
+        return new JScrollPane(ta);
     }
 
-    private JComponent generateJTable(Properties properties) {
-        String[] columnNames = { "Name", "Value" };
-        Object[][] data = new Object[properties.size()][2];
-
-        int i = 0;
-        for (Entry<Object, Object> entry : properties.entrySet()) {
-            data[i][0] = entry.getKey();
-            data[i][1] = entry.getValue();
-            i++;
+    private void configurationTable(DefaultMutableTreeNode parent, Object value) {
+        if (value == null) {
+            parent.add(new DefaultMutableTreeNode(" <not set>"));
+        } else if (value instanceof String || value instanceof Long || value instanceof Integer
+                || value instanceof Double || value instanceof Float
+                || value instanceof Short || value instanceof Byte
+                || value instanceof Boolean || value instanceof Enum<?>) {
+            parent.add(new DefaultMutableTreeNode(value));
+        } else if (value instanceof Collection<?> col) {
+            configurationTable(parent, col);
+        } else if (value instanceof Map map) {
+        } else if (value instanceof Configuration map) {
+            configurationTable(parent, map);
         }
-
-        Arrays.sort(data, (a, b) -> a[0].toString().compareToIgnoreCase(b[0].toString()));
-
-        JTable table = new JTable();
-
-        DefaultTableModel tableModel = new DefaultTableModel() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public boolean isCellEditable(int row, int column) {
-                // all cells false
-                return false;
-            }
-        };
-
-        tableModel.setDataVector(data, columnNames);
-        table.setModel(tableModel);
-        table.setRowHeight(table.getRowHeight() + 10);
-
-        JScrollPane scrollpane = new JScrollPane(table);
-        return scrollpane;
     }
 
+    private void configurationTable(DefaultMutableTreeNode parent, Configuration value) {
+        var names = value.getKeys().stream().sorted().toList();
+
+        for (String name : names) {
+            var v = value.get(name);
+
+            if (v instanceof Collection || v instanceof Map || v instanceof Configuration) {
+                var newChild = new DefaultMutableTreeNode(name);
+                parent.add(newChild);
+                configurationTable(newChild, v);
+            } else {
+                parent.add(new DefaultMutableTreeNode(name + ": " + v));
+            }
+        }
+    }
+
+    private void configurationTable(DefaultMutableTreeNode parent, Collection<?> values) {
+        for (var value : values) {
+            configurationTable(parent, value);
+        }
+    }
 
 
     private OptionContentNode generateOptionContentNode(String title, String text) {
         return new OptionContentNode(title, generateScrollPane(text));
     }
 
-    public OptionContentNode getTacletOptionsItem() {
+    public DefaultMutableTreeNode getTacletOptionsItem() {
         return tacletOptionsItem;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveSettingsAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/ShowActiveSettingsAction.java
@@ -51,7 +51,7 @@ public class ShowActiveSettingsAction extends MainWindowAction {
     public void showAndFocusTacletOptions() {
         ViewSettingsDialog dialog = showDialog();
         SettingsTreeModel model = (SettingsTreeModel) dialog.optionTree.getModel();
-        OptionContentNode item = model.getTacletOptionsItem();
+        var item = model.getTacletOptionsItem();
         dialog.getOptionTree().setSelectionPath(new TreePath(item.getPath()));
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.colors;
 
+import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
+import de.uka.ilkd.key.settings.Configuration;
+import de.uka.ilkd.key.settings.PathConfig;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.*;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -10,17 +18,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.*;
-import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
-
-import de.uka.ilkd.key.settings.Configuration;
-import de.uka.ilkd.key.settings.PathConfig;
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
-
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Configurable colors for KeY.
@@ -30,12 +29,13 @@ import org.slf4j.LoggerFactory;
  * @author Alexander Weigl
  * @version 1 (10.05.19)
  */
+@NullMarked
 public class ColorSettings {
     public static final File SETTINGS_FILE_NEW =
-        new File(PathConfig.getKeyConfigDir(), "colors.json");
+            new File(PathConfig.getKeyConfigDir(), "colors.json");
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorSettings.class);
 
-    private static ColorSettings INSTANCE;
+    private static @Nullable ColorSettings INSTANCE;
     private final Map<String, Object> properties = new TreeMap<>();
     private final List<ColorProperty> propertyEntries = new ArrayList<>(64);
 
@@ -81,7 +81,7 @@ public class ColorSettings {
     public static Color fromHex(String s) {
         long i = Long.decode(s);
         return new Color((int) ((i >> 16) & 0xFF), (int) ((i >> 8) & 0xFF), (int) (i & 0xFF),
-            (int) ((i >> 24) & 0xFF));
+                (int) ((i >> 24) & 0xFF));
     }
 
     public static Color invert(Color c) {
@@ -96,7 +96,10 @@ public class ColorSettings {
     public void save() {
         LOGGER.info("Save color settings to: {}", SETTINGS_FILE_NEW.getAbsolutePath());
         try (Writer writer = new FileWriter(SETTINGS_FILE_NEW)) {
-            var config = new Configuration(properties);
+            var config = new Configuration();
+            for (PropertyEntry<?> entry : propertyEntries) {
+                config.set(entry.getKey(), entry.value());
+            }
             config.save(writer, "KeY's Colors");
             writer.flush();
         } catch (IOException ex) {
@@ -107,7 +110,7 @@ public class ColorSettings {
     private ColorProperty createColorProperty(String key, String description,
             Color defaultLight, Color defaultDark) {
         Optional<ColorProperty> item =
-            getProperties().filter(it -> it.getKey().equals(key)).findFirst();
+                getProperties().filter(it -> it.getKey().equals(key)).findFirst();
         if (item.isPresent()) {
             return item.get();
         }
@@ -154,102 +157,16 @@ public class ColorSettings {
     /**
      * A property for handling colors.
      */
-    public class ColorProperty {
-        private final String key;
+    public class ColorProperty extends DefaultPropertyEntry<Color> {
         private final String description;
-        private Color defaultLightValue;
-        private Color defaultDarkValue;
-
-        private Color lightValue;
-        private Color darkValue;
-
 
         public ColorProperty(String key, String description, Color defaultValue) {
-            this(key, description, defaultValue, defaultValue);
-        }
-
-        public ColorProperty(String key, String description, Color defaultLightValue,
-                Color defaultDarkValue) {
-            this.key = key;
+            super(key, defaultValue, ColorSettings::fromHex, ColorSettings::toHex);
             this.description = description;
-            if (!properties.containsKey(key)) {
-                this.defaultLightValue = defaultLightValue;
-                this.defaultDarkValue = defaultDarkValue;
-            }
-        }
-
-        public Color getCurrentColor() {
-            if (ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()) {
-                return getDarkValue();
-            } else {
-                return getLightValue();
-            }
-        }
-
-        public Color getLightValue() {
-            if (lightValue == null) {
-                update();
-            }
-            return lightValue;
-        }
-
-        public void setLightValue(Color lightValue) {
-            var old = this.lightValue;
-            this.lightValue = lightValue;
-            firePropertyChange(getKey(), old, lightValue);
-        }
-
-        public Color getDarkValue() {
-            if (darkValue == null) {
-                update();
-            }
-            return darkValue;
-        }
-
-        public void setDarkValue(Color darkValue) {
-            var old = this.darkValue;
-            this.darkValue = darkValue;
-            firePropertyChange(getKey(), old, lightValue);
-        }
-
-        public void update() {
-            Object v = properties.get(key);
-            if (v == null) {
-                setLightValue(defaultLightValue);
-                setDarkValue(defaultDarkValue);
-                return;
-            }
-
-            if (v instanceof Color c) {
-                setDarkValue(c);
-                setLightValue(c);
-            } else if (v instanceof String s) {
-                var c = fromHex(s);
-                setDarkValue(c);
-                setLightValue(c);
-            } else if (v instanceof List<?> seq) {
-                setLightValue(fromHex(seq.get(0).toString()));
-                setDarkValue(fromHex(seq.get(1).toString()));
-            } else {
-                throw new IllegalArgumentException(
-                    "Unexpected types for color " + key + " with value " + v);
-            }
-        }
-
-        public Color fromObject(@Nullable Object o) {
-            return fromHex(o.toString());
-        }
-
-        public String getKey() {
-            return key;
         }
 
         public String getDescription() {
             return description;
-        }
-
-        public Color get() {
-            return getCurrentColor();
         }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
@@ -3,14 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.colors;
 
-import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
-import de.uka.ilkd.key.settings.Configuration;
-import de.uka.ilkd.key.settings.PathConfig;
-import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.*;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -20,6 +12,15 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
+import de.uka.ilkd.key.settings.Configuration;
+import de.uka.ilkd.key.settings.PathConfig;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Configurable colors for KeY.
@@ -32,7 +33,7 @@ import java.util.stream.Stream;
 @NullMarked
 public class ColorSettings {
     public static final File SETTINGS_FILE_NEW =
-            new File(PathConfig.getKeyConfigDir(), "colors.json");
+        new File(PathConfig.getKeyConfigDir(), "colors.json");
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorSettings.class);
 
     private static @Nullable ColorSettings INSTANCE;
@@ -81,7 +82,7 @@ public class ColorSettings {
     public static Color fromHex(String s) {
         long i = Long.decode(s);
         return new Color((int) ((i >> 16) & 0xFF), (int) ((i >> 8) & 0xFF), (int) (i & 0xFF),
-                (int) ((i >> 24) & 0xFF));
+            (int) ((i >> 24) & 0xFF));
     }
 
     public static Color invert(Color c) {
@@ -110,7 +111,7 @@ public class ColorSettings {
     private ColorProperty createColorProperty(String key, String description,
             Color defaultLight, Color defaultDark) {
         Optional<ColorProperty> item =
-                getProperties().filter(it -> it.getKey().equals(key)).findFirst();
+            getProperties().filter(it -> it.getKey().equals(key)).findFirst();
         if (item.isPresent()) {
             return item.get();
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/ExtensionSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/extension/impl/ExtensionSettings.java
@@ -16,7 +16,7 @@ public class ExtensionSettings extends AbstractPropertiesSettings {
      * Class names of disabled extensions.
      */
     private final PropertyEntry<Set<String>> forbiddenClasses =
-        createStringSetProperty(KEY_DISABLED, "");
+        createStringSetProperty(KEY_DISABLED, new TreeSet<>());
 
     public ExtensionSettings() {
         super(NAME);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/KeyStrokeSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/KeyStrokeSettings.java
@@ -38,7 +38,7 @@ import static de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager.SHORTCUT_KEY_MAS
  */
 public class KeyStrokeSettings extends AbstractPropertiesSettings {
     public static final File SETTINGS_FILE =
-            new File(PathConfig.getKeyConfigDir(), "keystrokes.json");
+        new File(PathConfig.getKeyConfigDir(), "keystrokes.json");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyStrokeSettings.class);
 
@@ -106,9 +106,9 @@ public class KeyStrokeSettings extends AbstractPropertiesSettings {
         defineDefault(SearchNextAction.class, KeyEvent.VK_F3, 0);
         defineDefault(SearchPreviousAction.class, KeyEvent.VK_F3, InputEvent.SHIFT_DOWN_MASK);
         defineDefault(SelectionBackAction.class, KeyEvent.VK_LEFT,
-                SHORTCUT_KEY_MASK | InputEvent.ALT_DOWN_MASK);
+            SHORTCUT_KEY_MASK | InputEvent.ALT_DOWN_MASK);
         defineDefault(SelectionForwardAction.class, KeyEvent.VK_RIGHT,
-                SHORTCUT_KEY_MASK | InputEvent.ALT_DOWN_MASK);
+            SHORTCUT_KEY_MASK | InputEvent.ALT_DOWN_MASK);
 
         /*
          * Do not use this! It produces strange behavior, as the constructor there calls

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/ShortcutSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/ShortcutSettings.java
@@ -3,20 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.keyshortcuts;
 
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.settings.SettingsProvider;
+import de.uka.ilkd.key.gui.settings.SimpleSettingsPanel;
+import de.uka.ilkd.key.settings.Configuration;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableRowSorter;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
-import javax.swing.*;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableRowSorter;
-
-import de.uka.ilkd.key.gui.MainWindow;
-import de.uka.ilkd.key.gui.settings.SettingsProvider;
-import de.uka.ilkd.key.gui.settings.SimpleSettingsPanel;
 
 /**
  * UI for configuring the {@link KeyStroke}s inside KeY.
@@ -46,18 +45,19 @@ public class ShortcutSettings extends SimpleSettingsPanel implements SettingsPro
     @Override
     public JPanel getPanel(MainWindow window) {
         KeyStrokeSettings settings = KeyStrokeManager.getSettings();
-        Properties p = new Properties();
-        settings.writeSettings(p);
 
-        List<String> actionNames =
-            p.keySet().stream().sorted().map(Object::toString).collect(Collectors.toList());
+        var config = new Configuration();
+        settings.writeSettings(config);
+
+        List<String> actionNames = config.getKeys().stream().sorted().toList();
 
         // for the view, we hide "pressed" to increase readability
-        List<String> shortcuts = actionNames.stream().map(p::getProperty)
-                .map(s -> s.replace("pressed ", "")).collect(Collectors.toList());
+        List<String> shortcuts = actionNames.stream()
+                .map(config::getString)
+                .map(s -> s.replace("pressed ", ""))
+                .toList();
 
-        List<Action> actions =
-            actionNames.stream().map(KeyStrokeManager::findAction).collect(Collectors.toList());
+        List<Action> actions = actionNames.stream().map(KeyStrokeManager::findAction).toList();
 
         modelShortcuts = new ShortcutsTableModel(actionNames, shortcuts, actions);
         tblShortcuts.setModel(modelShortcuts);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/ShortcutSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/ShortcutSettings.java
@@ -3,19 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.keyshortcuts;
 
-import de.uka.ilkd.key.gui.MainWindow;
-import de.uka.ilkd.key.gui.settings.SettingsProvider;
-import de.uka.ilkd.key.gui.settings.SimpleSettingsPanel;
-import de.uka.ilkd.key.settings.Configuration;
-
-import javax.swing.*;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableRowSorter;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableRowSorter;
+
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.settings.SettingsProvider;
+import de.uka.ilkd.key.gui.settings.SimpleSettingsPanel;
+import de.uka.ilkd.key.settings.Configuration;
 
 /**
  * UI for configuring the {@link KeyStroke}s inside KeY.

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SettingsManager.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SettingsManager.java
@@ -4,14 +4,9 @@
 package de.uka.ilkd.key.gui.settings;
 
 import java.awt.event.ActionEvent;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -98,18 +93,6 @@ public class SettingsManager {
          * window.getMediator().getSelectedProof().getSettings().getChoiceSettings(); } else {
          * return ProofSettings.DEFAULT_SETTINGS.getChoiceSettings(); }
          */
-    }
-
-    public static Properties loadProperties(File settingsFile) {
-        Properties props = new Properties();
-        if (settingsFile.exists()) {
-            try (FileReader reader = new FileReader(settingsFile, StandardCharsets.UTF_8)) {
-                props.load(reader);
-            } catch (IOException e) {
-                LOGGER.warn("Failed to load settings", e);
-            }
-        }
-        return props;
     }
 
     public void showSettingsDialog(MainWindow mainWindow) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.gui.settings;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -27,9 +28,9 @@ import com.formdev.flatlaf.themes.FlatMacLightLaf;
  */
 public class StandardUISettings extends SettingsPanel implements SettingsProvider {
     private static final String INFO_CLUTTER_RULESET =
-        "Comma separated list of rule set names, containing clutter rules.";
+            "Comma separated list of rule set names, containing clutter rules.";
     private static final String INFO_CLUTTER_RULE = "Comma separated listof clutter rules, \n"
-        + "which are rules with less priority in the taclet menu";
+            + "which are rules with less priority in the taclet menu";
     private static final String LOOK_AND_FEEL_INFO = """
             Look and feel used by KeY.
             'System' tries to mimic the default looks, 'Metal' is the Java default.
@@ -88,11 +89,11 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         addTitledComponent("Look and feel", lookAndFeel, LOOK_AND_FEEL_INFO);
 
         spFontSizeGlobal =
-            createNumberTextField(new SpinnerNumberModel(1, 0.1, 5, 0.1), emptyValidator());
+                createNumberTextField(new SpinnerNumberModel(1, 0.1, 5, 0.1), emptyValidator());
         addTitledComponent("Global font factor", spFontSizeGlobal, "");
 
         String[] sizes =
-            Arrays.stream(Config.SIZES).boxed().map(it -> it + " pt").toArray(String[]::new);
+                Arrays.stream(Config.SIZES).boxed().map(it -> it + " pt").toArray(String[]::new);
         spFontSizeTreeSequent = this.createSelection(sizes, emptyValidator());
         addTitledComponent("Tree and sequent font size", spFontSizeTreeSequent, "");
 
@@ -103,46 +104,46 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
                 In case of longer tooltips the instantiation will be suppressed.
                 """;
         txtMaxTooltipLines =
-            addNumberField("Maximum line number for tooltips", 1, 100, 5, info, emptyValidator());
+                addNumberField("Maximum line number for tooltips", 1, 100, 5, info, emptyValidator());
 
 
         chkShowLoadExamplesDialog =
-            addCheckBox("Show load examples dialog on startup", "", true, emptyValidator());
+                addCheckBox("Show load examples dialog on startup", "", true, emptyValidator());
 
         chkConfirmExit = addCheckBox("Confirm program exit", "", false, emptyValidator());
 
         spAutoSaveProof =
-            addNumberField("Auto save proof", 0, 10000000, 1000, "", emptyValidator());
+                addNumberField("Auto save proof", 0, 10000000, 1000, "", emptyValidator());
         notificationAfterMacro = addComboBox("Notification after macro finished", "", 1,
-            emptyValidator(), ViewSettings.NOTIFICATION_ALWAYS, ViewSettings.NOTIFICATION_UNFOCUSED,
-            ViewSettings.NOTIFICATION_NEVER);
+                emptyValidator(), ViewSettings.NOTIFICATION_ALWAYS, ViewSettings.NOTIFICATION_UNFOCUSED,
+                ViewSettings.NOTIFICATION_NEVER);
 
         addSeparator("Sequent View");
         chkPrettyPrint = addCheckBox("Pretty print terms", "", false, emptyValidator());
         chkUseUnicode = addCheckBox("Use unicode", "", false, emptyValidator());
         chkSyntaxHighlightning =
-            addCheckBox("Use syntax highlighting", "", false, emptyValidator());
+                addCheckBox("Use syntax highlighting", "", false, emptyValidator());
         chkHidePackagePrefix = addCheckBox("Hide package prefix", "", false, emptyValidator());
         chkRightClickMacros =
-            addCheckBox("Right click for proof macros", "", false, emptyValidator());
+                addCheckBox("Right click for proof macros", "", false, emptyValidator());
 
         addSeparator("Interaction");
         chkShowWholeTacletCB = addCheckBox("Show whole taclet",
-            "Pretty-print whole Taclet including 'name', 'find', 'varCond' and 'heuristics'\n(applies to tooltips in context menu)",
-            false, emptyValidator());
+                "Pretty-print whole Taclet including 'name', 'find', 'varCond' and 'heuristics'\n(applies to tooltips in context menu)",
+                false, emptyValidator());
 
         chkShowUninstantiatedTaclet = addCheckBox("Show uninstantiated taclet",
-            "recommended for unexperienced users", false, emptyValidator());
+                "recommended for unexperienced users", false, emptyValidator());
 
         txtClutterRules = addTextArea("Clutter rules", "", INFO_CLUTTER_RULE, emptyValidator());
 
         txtClutterRuleSets =
-            addTextArea("Clutter Rulesets", "", INFO_CLUTTER_RULESET, emptyValidator());
+                addTextArea("Clutter Rulesets", "", INFO_CLUTTER_RULESET, emptyValidator());
 
         chkMinimizeInteraction = addCheckBox("Minimise interactions", MinimizeInteraction.TOOL_TIP,
-            false, emptyValidator());
+                false, emptyValidator());
         chkEnsureSourceConsistency =
-            addCheckBox("Ensure source consistency", "", true, emptyValidator());
+                addCheckBox("Ensure source consistency", "", true, emptyValidator());
     }
 
 
@@ -155,11 +156,11 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
     public JPanel getPanel(MainWindow window) {
         ViewSettings vs = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
         GeneralSettings generalSettings =
-            ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
+                ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
 
 
-        txtClutterRules.setText(vs.clutterRules().value().replace(',', '\n'));
-        txtClutterRuleSets.setText(vs.clutterRuleSets().value().replace(',', '\n'));
+        txtClutterRules.setText(String.join("\n", vs.clutterRules().get()));
+        txtClutterRuleSets.setText(String.join("\n", vs.clutterRuleSets().get()));
 
         for (int i = 0; i < LAF_CLASSES.size(); i++) {
             if (LAF_CLASSES.get(i).equals(vs.getLookAndFeel())) {
@@ -201,8 +202,10 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         vs.setUIFontSizeFactor((Double) spFontSizeGlobal.getValue());
         vs.setMaxTooltipLines((Integer) txtMaxTooltipLines.getValue());
 
-        vs.clutterRules().parseFrom(txtClutterRules.getText().replace('\n', ','));
-        vs.clutterRuleSets().parseFrom(txtClutterRuleSets.getText().replace('\n', ','));
+        vs.clutterRules().set(
+                Arrays.stream(txtClutterRules.getText().split("\n")).collect(Collectors.toSet()));
+        vs.clutterRuleSets().set(
+                Arrays.stream(txtClutterRuleSets.getText().split("\n")).collect(Collectors.toSet()));
 
         vs.setShowLoadExamplesDialog(chkShowLoadExamplesDialog.isSelected());
         vs.setShowWholeTaclet(chkShowWholeTacletCB.isSelected());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
@@ -28,9 +28,9 @@ import com.formdev.flatlaf.themes.FlatMacLightLaf;
  */
 public class StandardUISettings extends SettingsPanel implements SettingsProvider {
     private static final String INFO_CLUTTER_RULESET =
-            "Comma separated list of rule set names, containing clutter rules.";
+        "Comma separated list of rule set names, containing clutter rules.";
     private static final String INFO_CLUTTER_RULE = "Comma separated listof clutter rules, \n"
-            + "which are rules with less priority in the taclet menu";
+        + "which are rules with less priority in the taclet menu";
     private static final String LOOK_AND_FEEL_INFO = """
             Look and feel used by KeY.
             'System' tries to mimic the default looks, 'Metal' is the Java default.
@@ -89,11 +89,11 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         addTitledComponent("Look and feel", lookAndFeel, LOOK_AND_FEEL_INFO);
 
         spFontSizeGlobal =
-                createNumberTextField(new SpinnerNumberModel(1, 0.1, 5, 0.1), emptyValidator());
+            createNumberTextField(new SpinnerNumberModel(1, 0.1, 5, 0.1), emptyValidator());
         addTitledComponent("Global font factor", spFontSizeGlobal, "");
 
         String[] sizes =
-                Arrays.stream(Config.SIZES).boxed().map(it -> it + " pt").toArray(String[]::new);
+            Arrays.stream(Config.SIZES).boxed().map(it -> it + " pt").toArray(String[]::new);
         spFontSizeTreeSequent = this.createSelection(sizes, emptyValidator());
         addTitledComponent("Tree and sequent font size", spFontSizeTreeSequent, "");
 
@@ -104,46 +104,46 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
                 In case of longer tooltips the instantiation will be suppressed.
                 """;
         txtMaxTooltipLines =
-                addNumberField("Maximum line number for tooltips", 1, 100, 5, info, emptyValidator());
+            addNumberField("Maximum line number for tooltips", 1, 100, 5, info, emptyValidator());
 
 
         chkShowLoadExamplesDialog =
-                addCheckBox("Show load examples dialog on startup", "", true, emptyValidator());
+            addCheckBox("Show load examples dialog on startup", "", true, emptyValidator());
 
         chkConfirmExit = addCheckBox("Confirm program exit", "", false, emptyValidator());
 
         spAutoSaveProof =
-                addNumberField("Auto save proof", 0, 10000000, 1000, "", emptyValidator());
+            addNumberField("Auto save proof", 0, 10000000, 1000, "", emptyValidator());
         notificationAfterMacro = addComboBox("Notification after macro finished", "", 1,
-                emptyValidator(), ViewSettings.NOTIFICATION_ALWAYS, ViewSettings.NOTIFICATION_UNFOCUSED,
-                ViewSettings.NOTIFICATION_NEVER);
+            emptyValidator(), ViewSettings.NOTIFICATION_ALWAYS, ViewSettings.NOTIFICATION_UNFOCUSED,
+            ViewSettings.NOTIFICATION_NEVER);
 
         addSeparator("Sequent View");
         chkPrettyPrint = addCheckBox("Pretty print terms", "", false, emptyValidator());
         chkUseUnicode = addCheckBox("Use unicode", "", false, emptyValidator());
         chkSyntaxHighlightning =
-                addCheckBox("Use syntax highlighting", "", false, emptyValidator());
+            addCheckBox("Use syntax highlighting", "", false, emptyValidator());
         chkHidePackagePrefix = addCheckBox("Hide package prefix", "", false, emptyValidator());
         chkRightClickMacros =
-                addCheckBox("Right click for proof macros", "", false, emptyValidator());
+            addCheckBox("Right click for proof macros", "", false, emptyValidator());
 
         addSeparator("Interaction");
         chkShowWholeTacletCB = addCheckBox("Show whole taclet",
-                "Pretty-print whole Taclet including 'name', 'find', 'varCond' and 'heuristics'\n(applies to tooltips in context menu)",
-                false, emptyValidator());
+            "Pretty-print whole Taclet including 'name', 'find', 'varCond' and 'heuristics'\n(applies to tooltips in context menu)",
+            false, emptyValidator());
 
         chkShowUninstantiatedTaclet = addCheckBox("Show uninstantiated taclet",
-                "recommended for unexperienced users", false, emptyValidator());
+            "recommended for unexperienced users", false, emptyValidator());
 
         txtClutterRules = addTextArea("Clutter rules", "", INFO_CLUTTER_RULE, emptyValidator());
 
         txtClutterRuleSets =
-                addTextArea("Clutter Rulesets", "", INFO_CLUTTER_RULESET, emptyValidator());
+            addTextArea("Clutter Rulesets", "", INFO_CLUTTER_RULESET, emptyValidator());
 
         chkMinimizeInteraction = addCheckBox("Minimise interactions", MinimizeInteraction.TOOL_TIP,
-                false, emptyValidator());
+            false, emptyValidator());
         chkEnsureSourceConsistency =
-                addCheckBox("Ensure source consistency", "", true, emptyValidator());
+            addCheckBox("Ensure source consistency", "", true, emptyValidator());
     }
 
 
@@ -156,7 +156,7 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
     public JPanel getPanel(MainWindow window) {
         ViewSettings vs = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
         GeneralSettings generalSettings =
-                ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
+            ProofIndependentSettings.DEFAULT_INSTANCE.getGeneralSettings();
 
 
         txtClutterRules.setText(String.join("\n", vs.clutterRules().get()));
@@ -203,9 +203,9 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
         vs.setMaxTooltipLines((Integer) txtMaxTooltipLines.getValue());
 
         vs.clutterRules().set(
-                Arrays.stream(txtClutterRules.getText().split("\n")).collect(Collectors.toSet()));
+            Arrays.stream(txtClutterRules.getText().split("\n")).collect(Collectors.toSet()));
         vs.clutterRuleSets().set(
-                Arrays.stream(txtClutterRuleSets.getText().split("\n")).collect(Collectors.toSet()));
+            Arrays.stream(txtClutterRuleSets.getText().split("\n")).collect(Collectors.toSet()));
 
         vs.setShowLoadExamplesDialog(chkShowLoadExamplesDialog.isSelected());
         vs.setShowWholeTaclet(chkShowWholeTacletCB.isSelected());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/OptionContentNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/OptionContentNode.java
@@ -9,13 +9,11 @@ import javax.swing.tree.DefaultMutableTreeNode;
 /**
  * @author Mihai Herda, 2018
  */
-
 public class OptionContentNode extends DefaultMutableTreeNode {
     private static final long serialVersionUID = 1L;
     private final JComponent component;
 
     public OptionContentNode(String title, JComponent component) {
-        super();
         this.component = component;
         this.setUserObject(title);
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/SMTSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/SMTSettingsProvider.java
@@ -170,7 +170,7 @@ public class SMTSettingsProvider extends SettingsPanel implements SettingsProvid
     @Override
     public JPanel getPanel(MainWindow window) {
         ProofIndependentSMTSettings pi = SettingsManager.getSmtPiSettings();
-        setSmtSettings(pi.clone());
+        setSmtSettings(pi.copy());
         return this;
     }
 
@@ -178,7 +178,7 @@ public class SMTSettingsProvider extends SettingsPanel implements SettingsProvid
     public void applySettings(MainWindow window) {
         ProofIndependentSMTSettings pi = SettingsManager.getSmtPiSettings();
         pi.copy(settings);
-        setSmtSettings(pi.clone());
+        setSmtSettings(pi.copy());
     }
 
     private JSpinner createLocSetBoundField() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/SolverOptions.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/SolverOptions.java
@@ -177,7 +177,7 @@ class SolverOptions extends SettingsPanel implements SettingsProvider {
 
     @Override
     public JPanel getPanel(MainWindow window) {
-        setSmtSettings(SettingsManager.getSmtPiSettings().clone());
+        setSmtSettings(SettingsManager.getSmtPiSettings().copy());
         return this;
     }
 
@@ -216,7 +216,7 @@ class SolverOptions extends SettingsPanel implements SettingsProvider {
             // SettingsManager.getSmtPiSettings().setParameters(solverType, params);
             window.updateSMTSelectMenu();
 
-            setSmtSettings(SettingsManager.getSmtPiSettings().clone()); // refresh gui
+            setSmtSettings(SettingsManager.getSmtPiSettings().copy()); // refresh gui
         } else {
             throw new IllegalStateException("Could not find solver data for type: " + solverType);
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/TacletTranslationOptions.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/TacletTranslationOptions.java
@@ -64,8 +64,8 @@ public class TacletTranslationOptions extends SettingsPanel implements SettingsP
 
     @Override
     public JPanel getPanel(MainWindow window) {
-        ProofDependentSMTSettings pdSettings = SettingsManager.getSmtPdSettings(window).clone();
-        ProofIndependentSMTSettings piSettings = SettingsManager.getSmtPiSettings().clone();
+        ProofDependentSMTSettings pdSettings = SettingsManager.getSmtPdSettings(window).copy();
+        ProofIndependentSMTSettings piSettings = SettingsManager.getSmtPiSettings().copy();
         maxNumberOfGenerics.setValue(pdSettings.getMaxGenericSorts());
         fileChooserPanel.setText(piSettings.getPathForTacletTranslation());
         // fileChooserPanel.setEnabled(piSettings.storeTacletTranslationToFile);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/TranslationOptions.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/smt/settings/TranslationOptions.java
@@ -170,7 +170,7 @@ class TranslationOptions extends SettingsPanel implements SettingsProvider {
 
     @Override
     public JPanel getPanel(MainWindow window) {
-        setSmtSettings(SettingsManager.getSmtPdSettings(window).clone());
+        setSmtSettings(SettingsManager.getSmtPdSettings(window).copy());
         return this;
     }
 


### PR DESCRIPTION
This PR removes the deprecated methods for `readSettings(Properties)` and `writeSettings(Properties)`. 

**This will break old KeY files.**

Consequences are a lot of dead code, and some simplifications in the UI. 

"Show all Settings" is now tree-based instead of tables. 


![image](https://github.com/user-attachments/assets/0a68fade-97e7-462f-9dca-b50ac7e4892d)



