### PR TITLE
repair the axiom generation for adts defined in JavaDL

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -371,9 +371,9 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
 
-    private RewriteTacletBuilder<RewriteTaclet> createAxiomTaclet(
+    private TacletBuilder<NoFindTaclet> createAxiomTaclet(
             KeYParser.Datatype_declContext ctx) {
-        var tacletBuilder = new RewriteTacletBuilder<>();
+        var tacletBuilder = new NoFindTacletBuilder();
         tacletBuilder.setName(new Name(String.format("%s_Axiom", ctx.name.getText())));
         final var sort = sorts().lookup(ctx.name.getText());
         var phi = declareSchemaVariable(ctx, "phi", JavaDLTheory.FORMULA, true,
@@ -383,8 +383,6 @@ public class TacletPBuilder extends ExpressionBuilder {
             true, false, false,
             new SchemaVariableModifierSet.VariableSV());
         var find = tb.all(qvar, tb.var(phi)); // \forall #x #phi
-        tacletBuilder.setFind(find);
-        tacletBuilder.addVarsNotFreeIn(qvar, phi);
 
         var cases = ctx.datatype_constructor().stream()
                 .map(it -> createQuantifiedFormula(it, qvar, tb.var(phi), sort))


### PR DESCRIPTION
## Related Issue

This pull request addresses #3427, but does not solve it.

## Intended Change

The axiom taclet created for adt was not applicable. It is applicable now.

## Plan

* [x] remove the "notFreeIn" clause from the generated taclet
* [x] remove the find clause from the taclet.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I have tested the feature as follows: Looked at the translation of a few examples

It is a small change in the creation of a taclet.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
