### PR TITLE
Improve the SMT translation by translating axiom taclets (mostly for invariants)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/smt/AbstractSMTTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/AbstractSMTTranslator.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
+import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.Taclet;
 import de.uka.ilkd.key.taclettranslation.TacletFormula;
 import de.uka.ilkd.key.taclettranslation.assumptions.DefaultTacletSetTranslation;
@@ -176,10 +177,10 @@ public abstract class AbstractSMTTranslator implements SMTTranslator {
     }
 
     @Override
-    public final StringBuilder translateProblem(Sequent sequent, Services services,
-            SMTSettings settings) throws IllegalFormulaException {
+    public final StringBuilder translateProblem(Goal goal, Services services,
+                                                SMTSettings settings) throws IllegalFormulaException {
         smtSettings = settings;
-        Term problem = sequentToTerm(sequent, services);
+        Term problem = sequentToTerm(goal.sequent(), services);
         StringBuilder hb = translateTerm(problem, new ArrayList<>(), services);
 
         // add one variable for each sort

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/AbstractSMTTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/AbstractSMTTranslator.java
@@ -178,7 +178,7 @@ public abstract class AbstractSMTTranslator implements SMTTranslator {
 
     @Override
     public final StringBuilder translateProblem(Goal goal, Services services,
-                                                SMTSettings settings) throws IllegalFormulaException {
+            SMTSettings settings) throws IllegalFormulaException {
         smtSettings = settings;
         Term problem = sequentToTerm(goal.sequent(), services);
         StringBuilder hb = translateTerm(problem, new ArrayList<>(), services);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
@@ -16,6 +16,7 @@ import de.uka.ilkd.key.rule.MatchConditions;
 import de.uka.ilkd.key.rule.PosTacletApp;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.smt.SMTSolverResult.ThreeValuedTruth;
+import de.uka.ilkd.key.smt.newsmt2.ModularSMTLib2Translator;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
@@ -177,7 +178,9 @@ public final class SMTFocusResults {
 
         String[] labels = lastLine.trim().split(" +");
         // some labels (for non-sequent formulas) are not for the unsat core -> filter them
-        String[] filtered = Arrays.stream(labels).filter(s -> s.startsWith("L_")).toArray(String[]::new);
+        String[] filtered = Arrays.stream(labels)
+                .filter(s -> s.startsWith(ModularSMTLib2Translator.UNSAT_CORE_PREFIX))
+                .toArray(String[]::new);
         Integer[] numbers = new Integer[filtered.length];
         for (int i = 0; i < numbers.length; i++) {
             numbers[i] = Integer.parseInt(filtered[i].substring(2));
@@ -203,6 +206,7 @@ public final class SMTFocusResults {
             if (lines[i].equals("(")) {
                 Integer[] numbers = new Integer[lines.length - 2 - i];
                 for (int j = i + 1; j < lines.length - 1; j++) {
+                    // TODO: substring here is dangerous, should check for UNSAT_CORE_PREFIX ...
                     numbers[j - i - 1] = Integer.parseInt(lines[j].substring(2));
                 }
                 return numbers;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
@@ -176,9 +176,11 @@ public final class SMTFocusResults {
         lastLine = lastLine.substring(1, lastLine.length() - 1);
 
         String[] labels = lastLine.trim().split(" +");
-        Integer[] numbers = new Integer[labels.length];
+        // some labels (for non-sequent formulas) are not for the unsat core -> filter them
+        String[] filtered = Arrays.stream(labels).filter(s -> s.startsWith("L_")).toArray(String[]::new);
+        Integer[] numbers = new Integer[filtered.length];
         for (int i = 0; i < numbers.length; i++) {
-            numbers[i] = Integer.parseInt(labels[i].substring(2));
+            numbers[i] = Integer.parseInt(filtered[i].substring(2));
         }
         return numbers;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTObjTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTObjTranslator.java
@@ -11,10 +11,10 @@ import de.uka.ilkd.key.java.abstraction.KeYJavaType;
 import de.uka.ilkd.key.java.declaration.ClassDeclaration;
 import de.uka.ilkd.key.java.declaration.InterfaceDeclaration;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
-import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
+import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.smt.hierarchy.SortNode;
 import de.uka.ilkd.key.smt.hierarchy.TypeHierarchy;
 import de.uka.ilkd.key.smt.lang.*;
@@ -428,11 +428,11 @@ public class SMTObjTranslator implements SMTTranslator {
     }
 
     @Override
-    public StringBuffer translateProblem(Sequent sequent, Services services, SMTSettings settings)
+    public StringBuffer translateProblem(Goal goal, Services services, SMTSettings settings)
             throws IllegalFormulaException {
         this.settings = settings;
         this.services = services;
-        Term problem = sequentToTerm(sequent, services);
+        Term problem = sequentToTerm(goal.sequent(), services);
         SMTFile file = translateProblem(problem);
         String s = file.toString();
         return new StringBuffer(s);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTSolverImplementation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTSolverImplementation.java
@@ -332,7 +332,8 @@ public final class SMTSolverImplementation implements SMTSolver, Runnable {
 
             SMTObjTranslator objTrans =
                 new SMTObjTranslator(smtSettings, services, typeOfClassUnderTest);
-            problemString = objTrans.translateProblem(problem.getGoal(), services, smtSettings).toString();
+            problemString =
+                objTrans.translateProblem(problem.getGoal(), services, smtSettings).toString();
             ModelExtractor transQuery = objTrans.getQuery();
             getSocket().setQuery(transQuery);
             tacletTranslation = null;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTSolverImplementation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTSolverImplementation.java
@@ -332,7 +332,7 @@ public final class SMTSolverImplementation implements SMTSolver, Runnable {
 
             SMTObjTranslator objTrans =
                 new SMTObjTranslator(smtSettings, services, typeOfClassUnderTest);
-            problemString = objTrans.translateProblem(sequent, services, smtSettings).toString();
+            problemString = objTrans.translateProblem(problem.getGoal(), services, smtSettings).toString();
             ModelExtractor transQuery = objTrans.getQuery();
             getSocket().setQuery(transQuery);
             tacletTranslation = null;
@@ -340,7 +340,7 @@ public final class SMTSolverImplementation implements SMTSolver, Runnable {
         } else {
             SMTTranslator trans = getType().createTranslator();
             problemString =
-                indent(trans.translateProblem(sequent, services, smtSettings).toString());
+                indent(trans.translateProblem(problem.getGoal(), services, smtSettings).toString());
             if (trans instanceof AbstractSMTTranslator) {
                 // Since taclet translation in the old form is no longer used,
                 // this will likely disappear.

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTTranslator.java
@@ -17,7 +17,7 @@ public interface SMTTranslator {
      * Translates a problem into the given syntax. The only difference to
      * <code>translate(Term t, Services services)</code> is that assumptions will be added.
      *
-     * @param goal     the sequent to be translated.
+     * @param goal the sequent to be translated.
      * @param services
      * @return a representation of the term in the given syntax.
      * @throws IllegalFormulaException

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTTranslator.java
@@ -4,7 +4,7 @@
 package de.uka.ilkd.key.smt;
 
 import de.uka.ilkd.key.java.Services;
-import de.uka.ilkd.key.logic.Sequent;
+import de.uka.ilkd.key.proof.Goal;
 
 
 /**
@@ -17,12 +17,12 @@ public interface SMTTranslator {
      * Translates a problem into the given syntax. The only difference to
      * <code>translate(Term t, Services services)</code> is that assumptions will be added.
      *
-     * @param sequent the sequent to be translated.
+     * @param goal     the sequent to be translated.
      * @param services
      * @return a representation of the term in the given syntax.
      * @throws IllegalFormulaException
      */
-    CharSequence translateProblem(Sequent sequent, Services services, SMTSettings settings)
+    CharSequence translateProblem(Goal goal, Services services, SMTSettings settings)
             throws IllegalFormulaException;
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -142,6 +142,8 @@ public class ModularSMTLib2Translator implements SMTTranslator {
             try {
                 Term formula = tacletTranslator.translate(taclet);
                 SExpr smt = master.translate(formula);
+                // we name assertions just for the user, so that it is easier to find them
+                smt = SExprs.named(smt, taclet.name().toString());
                 master.addAxiom(SExprs.assertion(smt));
             } catch (SMTTranslationException e) {
                 throw new RuntimeException(e);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -45,6 +45,19 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(ModularSMTLib2Translator.class);
 
+    // TODO: check this list ... Represents axioms?
+    private static final String[] AXIOM_TACLET_PREFIXES = {
+        "Class_invariant_axiom_for",
+        "Static_class_invariant_axiom_for",
+        "Definition_axiom_for_",
+        "Free_class_invariant_axiom_for_",
+        "Free_static_class_invariant_axiom_for_",
+        "Partial_inv_axiom_for_JML_class_invariant_",
+            // "Query_axiom_for_" // Do we need those (not translatable at the moment (SkolemSV))?
+    };
+
+    public static final String UNSAT_CORE_PREFIX = "L_";
+
     /**
      * Handler option. If provided, the translator will label translations of sequent formulas such
      * that {@link de.uka.ilkd.key.smt.SMTFocusResults} can interpret the unsat core.
@@ -130,18 +143,8 @@ public class ModularSMTLib2Translator implements SMTTranslator {
         sb.append(preamble);
         sb.append(System.lineSeparator());
 
-        // TODO: check this list ... Represents axioms?
-        String[] axiomTacletPrefixes = {
-            "Class_invariant_axiom_for",
-            "Static_class_invariant_axiom_for",
-            "Definition_axiom_for_",
-            "Free_class_invariant_axiom_for_",
-            "Free_static_class_invariant_axiom_for_",
-            "Partial_inv_axiom_for_JML_class_invariant_",
-            //"Query_axiom_for_"  // Do we need those? These contain skolem schema vars ...
-        };
         // add axioms for invariants, static invariants, represents axioms, ...
-        for (String prefix : axiomTacletPrefixes) {
+        for (String prefix : AXIOM_TACLET_PREFIXES) {
             addAxioms(prefix, goal, services, master);
         }
 
@@ -163,7 +166,7 @@ public class ModularSMTLib2Translator implements SMTTranslator {
         int i = 1;
         for (SExpr ass : sequentSMTAsserts) {
             if (getUnsatCore) {
-                String label = "L_" + i;
+                String label = UNSAT_CORE_PREFIX + i;
                 i++;
                 ass = SExprs.named(ass, label);
             }
@@ -202,8 +205,8 @@ public class ModularSMTLib2Translator implements SMTTranslator {
     private void addAxioms(String prefix, Goal goal, Services services, MasterHandler master) {
         Set<NoPosTacletApp> set = goal.ruleAppIndex().tacletIndex().allNoPosTacletApps();
         List<NoPosTacletApp> filtered = set.stream()
-            .filter(t -> t.taclet().name().toString().startsWith(prefix))
-            .toList();
+                .filter(t -> t.taclet().name().toString().startsWith(prefix))
+                .toList();
         for (NoPosTacletApp npta : filtered) {
             Taclet taclet = npta.taclet();
             SMTTacletTranslator tacletTranslator = new SMTTacletTranslator(services);

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
@@ -73,7 +73,7 @@ public class SMTTacletTranslator {
 
         Operator op = term.op();
         if (op instanceof OperatorSV sv) {
-            if (!(sv instanceof TermSV || sv instanceof FormulaSV)) {
+            if (!(sv instanceof TermSV || sv instanceof FormulaSV || sv instanceof VariableSV)) {
                 throw new SMTTranslationException("Only a few schema variables can be translated. "
                     + "This one cannot. Type " + sv.getClass());
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
@@ -12,6 +12,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.rule.FindTaclet;
+import de.uka.ilkd.key.rule.NotFreeIn;
 import de.uka.ilkd.key.rule.Taclet;
 import de.uka.ilkd.key.smt.SMTTranslationException;
 import de.uka.ilkd.key.taclettranslation.DefaultTacletTranslator;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/SMTTacletTranslator.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.rule.FindTaclet;
-import de.uka.ilkd.key.rule.NotFreeIn;
 import de.uka.ilkd.key.rule.Taclet;
 import de.uka.ilkd.key.smt.SMTTranslationException;
 import de.uka.ilkd.key.taclettranslation.DefaultTacletTranslator;
@@ -94,18 +93,20 @@ public class SMTTacletTranslator {
         }
 
         List<QuantifiableVariable> qvars = new ArrayList<>();
-        if (op instanceof Quantifier) {
-            for (QuantifiableVariable boundVar : term.boundVars()) {
-                if (boundVar instanceof OperatorSV sv) {
-                    LogicVariable lv =
-                        variables.computeIfAbsent(sv, x -> new LogicVariable(x.name(), x.sort()));
-                    qvars.add(lv);
-                    changes = true;
-                } else {
-                    qvars.add(boundVar);
-                }
+        // Probably works for binding operators other than Quantifier, such as bsum. It would be
+        // desirable to not create incorrect terms here.
+        // if (op instanceof Quantifier) {
+        for (QuantifiableVariable boundVar : term.boundVars()) {
+            if (boundVar instanceof OperatorSV sv) {
+                LogicVariable lv =
+                    variables.computeIfAbsent(sv, x -> new LogicVariable(x.name(), x.sort()));
+                qvars.add(lv);
+                changes = true;
+            } else {
+                qvars.add(boundVar);
             }
         }
+        // }
 
         if (changes) {
             var bvars = new ImmutableArray<>(qvars);

--- a/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/smt/newsmt2/MasterHandlerTest.java
@@ -152,7 +152,7 @@ public class MasterHandlerTest {
 
                 ModularSMTLib2Translator translator = new ModularSMTLib2Translator();
                 var translation =
-                        translator.translateProblem(sequent, env.getServices(), settings).toString();
+                        translator.translateProblem(proof.getOpenGoal(proof.root()), env.getServices(), settings).toString();
                 return new TestData(name, path, props, translation);
             }
 


### PR DESCRIPTION
This PR adds axioms for some (dynamically generated) taclets to the SMT translation. Most of these taclets are axioms for class invariants (static/non-static, free, ...).

Additionally, the semantics of the bsum binder should be translated (not yet working).

## Related Issue

This pull request addresses (parts of) #3555.

## Plan
The goal was to make SaddleBackSearch and SumAndMax provable with SMT prep. macro + Z3. At the moment, most of the branches close but two subgoals are left open (probably because of bsum).

* [x] Translate generated axiom taclets (static/non-static/free/free static inv., partial inv., represents axioms)
* [ ] Find a way to translate more complicated taclets (varcond, more complex schema variables...)
* [ ] Translate bsum, bprod, etc.? We looked into it a bit, maybe we could use the technique described in "Reasoning about comprehensions with first-order SMT solvers" (Leino and Monahan, 2009, https://dl.acm.org/doi/abs/10.1145/1529282.1529411).
* [ ] Code cleanup
* [ ] Document the changes

## Type of pull request

- [x] New feature (non-breaking change which adds functionality)
- [x] There are changes to the (Java) code

## Ensuring quality
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- [ ] I added new test case(s) for new functionality.
- [ ] I have tested the feature as follows: ...
- [ ] I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Some implementation details and considerations:
* At the moment, assertions for all the (generated invariant, model method definition, and represents) taclets are added eagerly. If that turns out to inflate the problem too much and induce a significant performance decrease, we could in the future try to add them lazily. However, in my manual experiments it did not make a massive difference (was still nearly instant). 
* Note that there is a restriction that taclets with varconds can not be translated at all. Apparently, `\notFreeIn` does not count as a varcond however. This is not a problem here, since all the term schema variables are bound variables after translation.
* There was a restriction that the taclets to translates were only allowed to have SchemaVariables of type `TermSV` and `FormulaSV`. We relaxed that for `VariableSV` now (it worked out of the box with the same code after removing the check), since that is needed to translate taclets containing binders.
* The taclets to be translated are selected by name prefixes. In `ModularSMTLib2Translator` there is a list of prefixes. However, it is probably incomplete at the moment. 

This was done during the 3rd HacKeYthon. Thanks also to @BookWood7th!

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
