### PR TITLE
Add resolves keyword to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ remain since they will be invisible when showing the PR.
 
 <!-- Please remove if this PR is not related to an issue. -->
 <!-- Please add number if it is in answer to an issue. -->
-This pull request addresses #.
+This pull request resolves #.
 
 ## Intended Change
 


### PR DESCRIPTION
## Intended Change

This is just a small cosmetic fix to the GitHub PR template. Currently, the "Related Issue" section used the "addresses" verb. By changing this to "resolves", GitHub recognizes the issue number and will close it automatically when a PR reaches the main branch. (See [GitHub docs on this behavior](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)).

## Type of pull request

- Other: Changes to GitHub metadata

## Ensuring quality

- I have tested the feature as follows: Tested this on my fork

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
