### PR TITLE
Add documentation for soundDefaultContracts feature

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/soundDefaultContracts.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/soundDefaultContracts.key
@@ -1,15 +1,26 @@
 \optionsDecl {
     /*!
-    What default contract to use for unspecified library methods.
+    When there is no explicit contract for a method, KeY adds a default contract. This option determines whether to use
+    a sound or unsound default. Using the unsound default may be useful during development.
     */
     soundDefaultContracts: {
             /*!
-            Default contracts for unspecified library methods use the sound default clauses.
+            Unspecified methods get the following default contract:
+
+            public behavior
+                ensures true;
+                diverges true;
+                signals_only Throwable;
+                assignable \everything;
             */
             on,
 
             /*!
-            Unsoundly assume unspecified library methods to have normal behavior and be strictly pure.
+            Unspecified method get the following unsound default contract:
+
+            public normal_behavior
+                ensures true;
+                assignable \strictly_nothing;
             */
             off
     };

--- a/key.ui/src/main/resources/de/uka/ilkd/key/gui/help/choiceExplanations.xml
+++ b/key.ui/src/main/resources/de/uka/ilkd/key/gui/help/choiceExplanations.xml
@@ -177,6 +177,26 @@ Loading program rules dealing with JML's \bigint datatype can be disabled.
 Loading rules dealing with sequences can be disabled.
 </entry>
 
+<entry key="soundDefaultContracts">
+KeY adds a default contract to any loaded method
+that has no explicit contract (whether that method is in the loaded directory or the classpath).
+
+If this option is turned on, the following sound default is used (note that the method contract rule for such a contract
+can only be applied when proving partial correctness):
+
+    public behavior
+    ensures true;
+    diverges true;
+    signals_only Throwable;
+    assignable \everything;
+
+Otherwise, the following unsound default is used, which may be useful when developing proofs:
+
+    public normal_behavior
+    ensures true;
+    assignable \strictly_nothing;
+</entry>
+
 <entry key="moreSeqRules">
 This option allows more fine-grained control over rules dealing with sequences. By default, it is disabled because the additional rules are known to have a negative impact on overall performance. Activate this option if your problem is concerned with permutations or information flow. 
 </entry>
@@ -232,4 +252,3 @@ Treatment of formulas and terms for welldefinedness checks:
 Welldefinedness checks of JML specifications can be turned on/off. This includes class invariants, operation contracts, model fields as well as JML (annotation) statements as loop invariants and block contracts. The former ones are checked "on-the-fly", i.e., directly when they are applied in the code while proving an operation contract, since the context is needed.
 </entry>
 </properties>
-


### PR DESCRIPTION
Adds documentation for the taclet option added by [#3431](https://github.com/KeYProject/key/pull/3431).