### PR TITLE
Improve JavaDocs for Qualifier, SyntaxElement

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/Qualifier.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/Qualifier.java
@@ -7,6 +7,20 @@ import java.util.WeakHashMap;
 
 import org.key_project.logic.TerminalSyntaxElement;
 
+/**
+ * This class is primarily used in logic operations where qualifiers (e.g., types or sorts)
+ * are referenced multiple times, such as in {@link ObserverFunction} and
+ * {@link SortDependingFunction}.
+ * It helps to ensure that qualifiers maintain identity-based equality when reused.
+ * <p>
+ * As a qualifier is part of the structure of a symbol, e.g., function symbols, it has to be its own
+ * AST node. Hence, it is part of the structure reached by navigating through
+ * {@link org.key_project.logic.SyntaxElement} and
+ * {@link org.key_project.logic.SyntaxElementCursor}.
+ * </p>
+ *
+ * @param <T> The type of the qualifier object being wrapped.
+ */
 public class Qualifier<T> implements TerminalSyntaxElement {
     private final T qualifier;
 
@@ -16,6 +30,13 @@ public class Qualifier<T> implements TerminalSyntaxElement {
         this.qualifier = qualifier;
     }
 
+    /**
+     * Get the instance for this qualifier. If none exist yet, create one.
+     *
+     * @param qualifier the qualifier for which we create an instance
+     * @return new instance
+     * @param <T> The type of the qualifier object being wrapped.
+     */
     synchronized static <T> Qualifier<T> create(T qualifier) {
         if (INSTANCES.containsKey(qualifier)) {
             return (Qualifier<T>) INSTANCES.get(qualifier);

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/SortDependingFunction.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/SortDependingFunction.java
@@ -102,7 +102,7 @@ public final class SortDependingFunction extends JFunction {
      * @return the variant for the given sort
      */
     public synchronized SortDependingFunction getInstanceFor(Sort sort, TermServices services) {
-        if (sort == this.sortDependingOn) {
+        if (sort == this.sortDependingOn.getQualifier()) {
             return this;
         }
 

--- a/key.ncore/src/main/java/org/key_project/logic/SyntaxElement.java
+++ b/key.ncore/src/main/java/org/key_project/logic/SyntaxElement.java
@@ -4,8 +4,14 @@
 package org.key_project.logic;
 
 /**
- * This interface declares the methods common to all logic related (terms, formulas, programs)
- * AST nodes.
+ * This interface declares the methods common to all logic related (terms, formulas, and programs)
+ * AST nodes. All tree-like structures should implement this interface.
+ * <p>
+ * For navigating the syntax elements, see {@link SyntaxElementCursor}.
+ * </p>
+ * <p>
+ * If a class has no children, it should implement {@link TerminalSyntaxElement}.
+ * </p>
  */
 public interface SyntaxElement {
     /**
@@ -23,6 +29,9 @@ public interface SyntaxElement {
      */
     int getChildCount();
 
+    /**
+     * @return a new cursor for the subtree with the current node as root.
+     */
     default SyntaxElementCursor getCursor() {
         return new SyntaxElementCursor(this);
     }


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Improve some JavaDocs in `Qualifier` and `SyntaxElement`. Also fixes a minor issue in `SortDependingFunction`, where we compared objects of disjoint types, leading to inefficient comparisons.

Thanks to @mattulbrich for pointing it out!

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
