### PR TITLE
fixing lexing to support static invariants

### DIFF
--- a/key.core/src/main/antlr4/KeYLexer.g4
+++ b/key.core/src/main/antlr4/KeYLexer.g4
@@ -388,7 +388,7 @@ LESS: '<';
 LESSEQUAL: '<' '=' | '\u2264';
 LGUILLEMETS: '<' '<' | '«' | '‹';
 RGUILLEMETS: '>''>' | '»' | '›';
-IMPLICIT_IDENT: '<' (LETTER)+ '>' ('$lmtd')? -> type(IDENT);
+IMPLICIT_IDENT: '<' '$'? (LETTER)+ '>' ('$lmtd')? -> type(IDENT);
 
 EQV:	'<->' | '\u2194';
 PRIMES:	('\'')+;


### PR DESCRIPTION
## Intended Change

This pull request includes a change to the `IMPLICIT_IDENT` rule in the `KeYLexer.g4` file to allow an optional dollar sign before the letter sequence.

Lexer rule modification:

* [`key.core/src/main/antlr4/KeYLexer.g4`](diffhunk://#diff-6bd99bd35a45e33957236412344cc2b131e25b91957c7287bbaa5d0ecfa5a56cL391-R391): Modified the `IMPLICIT_IDENT` rule to accept an optional dollar sign ('<) before the letter sequence.

The reason is that static invariants are represented as `Classname::<$inv>` which one was not able to use in a manual cut.

But valid key terms should be parseable.

## Plan

It is only a 4 character fix allowing implicit identifiers to start with a `$`.

## Type of pull request

- Bug fix (non-breaking tiny change which fixes an issue)

## Ensuring quality

n/a


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
