### PR TITLE
Fixed obtaining results from CVC4 and cvc5

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC4.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC4.props
@@ -1,10 +1,9 @@
-params=--no-print-success -m --interactive --lang smt2
+params=--no-print-success --produce-models --no-interactive --lang smt2
 timeout=-1
 name=CVC4
 info=CVC4 solver (https://cvc4.github.io/index.html).
 command=cvc4
 version=--version
-delimiters=CVC4>
 socketClass=de.uka.ilkd.key.smt.communication.CVC4Socket
 handlers=de.uka.ilkd.key.smt.newsmt2.BooleanConnectiveHandler,\
 de.uka.ilkd.key.smt.newsmt2.PolymorphicHandler,\

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC4_legacy.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC4_legacy.props
@@ -1,5 +1,5 @@
 legacy=true
-params=--no-print-success -m --interactive --lang smt2
+params=--no-print-success --produce-models --no-interactive --lang smt2
 timeout=-1
 name=CVC4 (Legacy Translation)
 info=CVC4 solver

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC5.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC5.props
@@ -1,4 +1,4 @@
-params=--interactive -m --lang smt2
+params=--no-interactive --produce-models --lang smt2
 timeout=-1
 name=CVC5
 info=CVC5 solver (https://cvc5.github.io/).


### PR DESCRIPTION
This small fix removes the delimiters in CVC4.props and also sets CVC4 and also cvc5 to `--no-interactive`, which fixes the (at least most?) crashes with the `Stream closed` error message.

![image](https://github.com/user-attachments/assets/caee722a-0d78-4737-9928-43a4e89db72e)



The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
