### PR TITLE
Enable SMT focus goals (unsat cores) for CVC5

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/smt/communication/CVC5Socket.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/communication/CVC5Socket.java
@@ -48,6 +48,7 @@ public class CVC5Socket extends AbstractSolverSocket {
             if (msg.contains("unsat")) {
                 sc.setFinalResult(SMTSolverResult.createValidResult(getName()));
                 sc.setState(FINISH);
+                pipe.sendMessage("(get-unsat-core)");
                 pipe.sendMessage("(exit)");
                 // pipe.close();
             } else if (msg.contains("sat")) {

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/newsmt2/ModularSMTLib2Translator.java
@@ -44,10 +44,7 @@ public class ModularSMTLib2Translator implements SMTTranslator {
      * Handler option. If provided, the translator will label translations of sequent formulas such
      * that {@link de.uka.ilkd.key.smt.SMTFocusResults} can interpret the unsat core.
      * <p>
-     * This option is currently only enabled for Z3.
-     * Currently, this option only works with a CVC5 dev build.
-     * Once <a href="https://github.com/cvc5/cvc5/pull/9353">the fix</a> is included in a release,
-     * add this handler option to the .props file.
+     * This option is currently only enabled for Z3 and CVC5 (needs 1.0.4+).
      * </p>
      * Make sure to also send (get-unsat-core) in the respective socket class when adding this
      * option.

--- a/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC5.props
+++ b/key.core/src/main/resources/de/uka/ilkd/key/smt/solvertypes/CVC5.props
@@ -20,3 +20,4 @@ de.uka.ilkd.key.smt.newsmt2.FloatHandler,\
 de.uka.ilkd.key.smt.newsmt2.CastingFunctionsHandler,\
 de.uka.ilkd.key.smt.newsmt2.DefinedSymbolsHandler,\
 de.uka.ilkd.key.smt.newsmt2.UninterpretedSymbolsHandler
+handlerOptions=getUnsatCore


### PR DESCRIPTION
CVC5 now also supports printing unsat cores, https://github.com/cvc5/cvc5/pull/9353 has been released for years.

## Intended Change

Enable "Focus goals" function for CVC5.

## Type of pull request

- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code
- Other: changes to the SMT properties

## Ensuring quality
    
- [x] I made sure that introduced/changed code is well documented (javadoc and inline comments): javadoc updated
- [ ] I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs). Currently none of the user-facing SMT functions are documented
- [ ] I added new test case(s) for new functionality. SMT tests are currently being reworked #3592
- [x] I have tested the feature as follows: Open Aunt Agatha, run SMT preparation, run CVC5, click "Focus goals". Hides three formulas.
- [x] I have checked that runtime performance has not deteriorated: unsat core production has been turned on already, printing it should not take long.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.