### PR TITLE
Using FlatLAF for a modern look and feel

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.settings;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -253,6 +254,18 @@ public class ViewSettings extends AbstractPropertiesSettings {
         isDarkMode = getLookAndFeel().contains("FlatDark")
                 || getLookAndFeel().contains("FlatDarcula")
                 || getLookAndFeel().contains("FlatMacDarkLaf");
+    }
+
+    @Override
+    public void readSettings(Configuration props) {
+        super.readSettings(props);
+        updateIsDarkMode();
+    }
+
+    @Override
+    public void readSettings(Properties props) {
+        super.readSettings(props);
+        updateIsDarkMode();
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -5,7 +5,6 @@ package de.uka.ilkd.key.settings;
 
 import java.util.List;
 import java.util.Set;
-import javax.swing.*;
 
 /**
  * This class encapsulates information about: 1) relative font size in the prover view 2) the
@@ -23,19 +22,19 @@ public class ViewSettings extends AbstractPropertiesSettings {
     private static final String CLUTTER_RULES = "clutterRules";
 
     private static final String CLUTTER_RULES_DEFAULT = "cut_direct_r,cut_direct_l,"
-            + "case_distinction_r,case_distinction_l,local_cut,commute_and_2,commute_or_2,"
-            + "boxToDiamond,pullOut,typeStatic,less_is_total,less_zero_is_total,apply_eq_monomials"
-            + "eqTermCut,instAll,instEx,divIncreasingPos,divIncreasingNeg,jmodUnique1,jmodeUnique2,"
-            + "jmodjmod,jmodDivisble,jdivAddMultDenom,jmodAltZero,add_non_neq_square,divide_geq,"
-            + "add_greatereq,geq_add_one,leq_add_one,polySimp_addOrder,polySimp_expand,add_lesseq,"
-            + "divide_equation,equal_add_one,add_eq";
+        + "case_distinction_r,case_distinction_l,local_cut,commute_and_2,commute_or_2,"
+        + "boxToDiamond,pullOut,typeStatic,less_is_total,less_zero_is_total,apply_eq_monomials"
+        + "eqTermCut,instAll,instEx,divIncreasingPos,divIncreasingNeg,jmodUnique1,jmodeUnique2,"
+        + "jmodjmod,jmodDivisble,jdivAddMultDenom,jmodAltZero,add_non_neq_square,divide_geq,"
+        + "add_greatereq,geq_add_one,leq_add_one,polySimp_addOrder,polySimp_expand,add_lesseq,"
+        + "divide_equation,equal_add_one,add_eq";
 
     private static final String CLUTTER_RULESSETS = "clutterRuleSets";
 
     private static final String CLUTTER_RULESETS_DEFAULT = "notHumanReadable,obsolete,"
-            + "pullOutQuantifierAll,inEqSimp_commute,inEqSimp_expand,pullOutQuantifierEx,"
-            + "inEqSimp_nonLin_divide,inEqSimp_special_nonLin,inEqSimp_nonLin,polySimp_normalise,"
-            + "polySimp_directEquations";
+        + "pullOutQuantifierAll,inEqSimp_commute,inEqSimp_expand,pullOutQuantifierEx,"
+        + "inEqSimp_nonLin_divide,inEqSimp_special_nonLin,inEqSimp_nonLin,polySimp_normalise,"
+        + "polySimp_directEquations";
 
     /**
      * default max number of displayed tooltip lines is 40
@@ -79,7 +78,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Boolean flag, if activate the LAF draws the decoration by itself. e.g., FlatLAF
      */
     private final PropertyEntry<Boolean> defaultLookAndFeelDecorated =
-            createBooleanProperty(PROP_DEFAULT_LOOK_AND_FEEL_DECORATED, true);
+        createBooleanProperty(PROP_DEFAULT_LOOK_AND_FEEL_DECORATED, true);
 
 
     private static final String SHOW_JAVA_WARNING = "ShowJavaWarning";
@@ -174,64 +173,64 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Show Taclet uninstantiated in tooltip -- for learning
      */
     private final PropertyEntry<Boolean> showUninstantiatedTaclet =
-            createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
+        createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
     private final PropertyEntry<Boolean> showHeatmap = createBooleanProperty(HEATMAP_SHOW, false);
     private final PropertyEntry<Boolean> heatmapSF = createBooleanProperty(HEATMAP_SF, true);
     /**
      * Highlight most recent formulas/terms (true) or all formulas/terms below specified age (false)
      */
     private final PropertyEntry<Boolean> heatmapNewest =
-            createBooleanProperty(HEATMAP_NEWEST, true);
+        createBooleanProperty(HEATMAP_NEWEST, true);
     /**
      * Maximum age/number of newest terms/formulas for heatmap highlighting
      */
     private final PropertyEntry<Integer> maxAgeForHeatmap =
-            createIntegerProperty(HEATMAP_MAXAGE, 5);
+        createIntegerProperty(HEATMAP_MAXAGE, 5);
     private final PropertyEntry<Double> uiFontSizeFactor =
-            createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
+        createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
     private final PropertyEntry<Integer> maxTooltipLines =
-            createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
+        createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
     private final PropertyEntry<Boolean> hideIntermediateProofsteps =
-            createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
+        createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideAutomodeProofsteps =
-            createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
+        createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideClosedSubtrees =
-            createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
+        createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
     private final PropertyEntry<Boolean> notifyLoadBehaviour =
-            createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
+        createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
     private final PropertyEntry<Boolean> usePretty = createBooleanProperty(PRETTY_SYNTAX, true);
     private final PropertyEntry<Boolean> useUnicode = createBooleanProperty(USE_UNICODE, false);
     private final PropertyEntry<Boolean> useSyntaxHighlighting =
-            createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
+        createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
     private final PropertyEntry<Boolean> hidePackagePrefix =
-            createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
+        createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
     private final PropertyEntry<Boolean> confirmExit = createBooleanProperty(CONFIRM_EXIT, true);
     private final PropertyEntry<Boolean> showLoadExamplesDialog =
-            createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
+        createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
     private final PropertyEntry<Boolean> showWholeTaclet =
-            createBooleanProperty(SHOW_WHOLE_TACLET, false);
+        createBooleanProperty(SHOW_WHOLE_TACLET, false);
     private final PropertyEntry<Integer> sizeIndex = createIntegerProperty(FONT_INDEX, 2);
     private final PropertyEntry<String> lookAndFeel =
-            createStringProperty(PROP_LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
+        createStringProperty(PROP_LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
     private final PropertyEntry<Boolean> showSequentViewTooltips =
-            createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
+        createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showSourceViewTooltips =
-            createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
+        createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showProofTreeTooltips =
-            createBooleanProperty(PROOF_TREE_TOOLTIP, true);
+        createBooleanProperty(PROOF_TREE_TOOLTIP, true);
     private final PropertyEntry<Boolean> highlightOrigin =
-            createBooleanProperty(HIGHLIGHT_ORIGIN, true);
+        createBooleanProperty(HIGHLIGHT_ORIGIN, true);
     private final PropertyEntry<Set<String>> clutterRules =
-            createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
+        createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
 
     private final PropertyEntry<Set<String>> clutterRuleSets =
-            createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
+        createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
 
     private final PropertyEntry<Boolean> hideInteractiveGoals =
-            createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
+        createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
 
     private final PropertyEntry<String> notificationAfterMacro =
-            createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
+        createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
 
     /**
      * User-definable folder bookmarks.
@@ -240,7 +239,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * @see #setFolderBookmarks(List)
      */
     private final PropertyEntry<List<String>> folderBookmarks =
-            createStringListProperty(USER_FOLDER_BOOKMARKS, System.getProperty("user.home"));
+        createStringListProperty(USER_FOLDER_BOOKMARKS, System.getProperty("user.home"));
 
     //
     private boolean isDarkMode;
@@ -307,7 +306,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Sets whether the "Load Examples" dialog window should be shown on startup
      *
      * @param b indicates whether the "Load Examples" dialog window should be shown on startup or
-     *          not
+     *        not
      */
     public void setShowLoadExamplesDialog(boolean b) {
         showLoadExamplesDialog.set(b);
@@ -328,7 +327,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * instantiations of schema-variables or not
      *
      * @param b indicates whether the Find and VarCond part of Taclets should be pretty-printed with
-     *          instantiations of schema-variables or not
+     *        instantiations of schema-variables or not
      */
     public void setShowWholeTaclet(boolean b) {
         showWholeTaclet.set(b);
@@ -522,14 +521,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Updates heatmap settings (all of the at the same time, so that fireSettingsChanged is called
      * only once.
      *
-     * @param showHeatmap      true if heatmap on
-     * @param heatmapSF        true for sequent formulas, false for terms
-     * @param heatmapNewest    true if newest, false for "up to age"
+     * @param showHeatmap true if heatmap on
+     * @param heatmapSF true for sequent formulas, false for terms
+     * @param heatmapNewest true if newest, false for "up to age"
      * @param maxAgeForHeatmap the maximum age for term or sequent formulas, concerning heatmap
-     *                         highlighting
+     *        highlighting
      */
     public void setHeatmapOptions(boolean showHeatmap, boolean heatmapSF, boolean heatmapNewest,
-                                  int maxAgeForHeatmap) {
+            int maxAgeForHeatmap) {
         this.showHeatmap.set(showHeatmap);
         this.heatmapSF.set(heatmapSF);
         this.heatmapNewest.set(heatmapNewest);

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ViewSettings.java
@@ -23,19 +23,19 @@ public class ViewSettings extends AbstractPropertiesSettings {
     private static final String CLUTTER_RULES = "clutterRules";
 
     private static final String CLUTTER_RULES_DEFAULT = "cut_direct_r,cut_direct_l,"
-        + "case_distinction_r,case_distinction_l,local_cut,commute_and_2,commute_or_2,"
-        + "boxToDiamond,pullOut,typeStatic,less_is_total,less_zero_is_total,apply_eq_monomials"
-        + "eqTermCut,instAll,instEx,divIncreasingPos,divIncreasingNeg,jmodUnique1,jmodeUnique2,"
-        + "jmodjmod,jmodDivisble,jdivAddMultDenom,jmodAltZero,add_non_neq_square,divide_geq,"
-        + "add_greatereq,geq_add_one,leq_add_one,polySimp_addOrder,polySimp_expand,add_lesseq,"
-        + "divide_equation,equal_add_one,add_eq";
+            + "case_distinction_r,case_distinction_l,local_cut,commute_and_2,commute_or_2,"
+            + "boxToDiamond,pullOut,typeStatic,less_is_total,less_zero_is_total,apply_eq_monomials"
+            + "eqTermCut,instAll,instEx,divIncreasingPos,divIncreasingNeg,jmodUnique1,jmodeUnique2,"
+            + "jmodjmod,jmodDivisble,jdivAddMultDenom,jmodAltZero,add_non_neq_square,divide_geq,"
+            + "add_greatereq,geq_add_one,leq_add_one,polySimp_addOrder,polySimp_expand,add_lesseq,"
+            + "divide_equation,equal_add_one,add_eq";
 
     private static final String CLUTTER_RULESSETS = "clutterRuleSets";
 
     private static final String CLUTTER_RULESETS_DEFAULT = "notHumanReadable,obsolete,"
-        + "pullOutQuantifierAll,inEqSimp_commute,inEqSimp_expand,pullOutQuantifierEx,"
-        + "inEqSimp_nonLin_divide,inEqSimp_special_nonLin,inEqSimp_nonLin,polySimp_normalise,"
-        + "polySimp_directEquations";
+            + "pullOutQuantifierAll,inEqSimp_commute,inEqSimp_expand,pullOutQuantifierEx,"
+            + "inEqSimp_nonLin_divide,inEqSimp_special_nonLin,inEqSimp_nonLin,polySimp_normalise,"
+            + "polySimp_directEquations";
 
     /**
      * default max number of displayed tooltip lines is 40
@@ -69,10 +69,18 @@ public class ViewSettings extends AbstractPropertiesSettings {
      */
     private static final String HIDE_CLOSED_SUBTREES = "HideClosedSubtrees";
 
+    /// Property name for property [#lookAndFeel]
+    public static final String PROP_LOOK_AND_FEEL = "LookAndFeel";
+
+    /// Property name for property [#defaultLookAndFeelDecorated]
+    public static final String PROP_DEFAULT_LOOK_AND_FEEL_DECORATED = "defaultLookAndFeelDecorated";
+
     /**
-     * Which look and feel to use.
+     * Boolean flag, if activate the LAF draws the decoration by itself. e.g., FlatLAF
      */
-    private static final String LOOK_AND_FEEL = "LookAndFeel";
+    private final PropertyEntry<Boolean> defaultLookAndFeelDecorated =
+            createBooleanProperty(PROP_DEFAULT_LOOK_AND_FEEL_DECORATED, true);
+
 
     private static final String SHOW_JAVA_WARNING = "ShowJavaWarning";
 
@@ -110,10 +118,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
 
     private static final String SEQUENT_VIEW_TOOLTIP = "SequentViewTooltips";
 
-    /** this setting enables/disables tool tips in the source view */
+    /**
+     * this setting enables/disables tool tips in the source view
+     */
     private static final String SOURCE_VIEW_TOOLTIP = "SourceViewTooltips";
 
-    /** this setting enables/disables tool tips in the proof tree */
+    /**
+     * this setting enables/disables tool tips in the proof tree
+     */
     private static final String PROOF_TREE_TOOLTIP = "ProofTreeTooltips";
 
     private static final String HIGHLIGHT_ORIGIN = "HighlightOrigin";
@@ -152,8 +164,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
 
     private static final String NOTIFICATION_AFTER_MACRO = "[View]notificationAfterMacro";
 
-    private static final String LOOK_AND_FEEL_DEFAULT =
-        UIManager.getCrossPlatformLookAndFeelClassName();
+    private static final String LOOK_AND_FEEL_DEFAULT = "com.formdev.flatlaf.FlatLightLaf";
 
     public static final String NOTIFICATION_ALWAYS = "Always";
     public static final String NOTIFICATION_UNFOCUSED = "When not focused";
@@ -163,64 +174,64 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Show Taclet uninstantiated in tooltip -- for learning
      */
     private final PropertyEntry<Boolean> showUninstantiatedTaclet =
-        createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
+            createBooleanProperty(SHOW_UNINSTANTIATED_TACLET, true);
     private final PropertyEntry<Boolean> showHeatmap = createBooleanProperty(HEATMAP_SHOW, false);
     private final PropertyEntry<Boolean> heatmapSF = createBooleanProperty(HEATMAP_SF, true);
     /**
      * Highlight most recent formulas/terms (true) or all formulas/terms below specified age (false)
      */
     private final PropertyEntry<Boolean> heatmapNewest =
-        createBooleanProperty(HEATMAP_NEWEST, true);
+            createBooleanProperty(HEATMAP_NEWEST, true);
     /**
      * Maximum age/number of newest terms/formulas for heatmap highlighting
      */
     private final PropertyEntry<Integer> maxAgeForHeatmap =
-        createIntegerProperty(HEATMAP_MAXAGE, 5);
+            createIntegerProperty(HEATMAP_MAXAGE, 5);
     private final PropertyEntry<Double> uiFontSizeFactor =
-        createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
+            createDoubleProperty(FONT_SIZE_FACTOR, 1.0);
     private final PropertyEntry<Integer> maxTooltipLines =
-        createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
+            createIntegerProperty(MAX_TOOLTIP_LINES_KEY, 40);
     private final PropertyEntry<Boolean> hideIntermediateProofsteps =
-        createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
+            createBooleanProperty(HIDE_INTERMEDIATE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideAutomodeProofsteps =
-        createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
+            createBooleanProperty(HIDE_AUTOMODE_PROOFSTEPS, false);
     private final PropertyEntry<Boolean> hideClosedSubtrees =
-        createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
+            createBooleanProperty(HIDE_CLOSED_SUBTREES, false);
     private final PropertyEntry<Boolean> notifyLoadBehaviour =
-        createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
+            createBooleanProperty(NOTIFY_LOAD_BEHAVIOUR, false);
     private final PropertyEntry<Boolean> usePretty = createBooleanProperty(PRETTY_SYNTAX, true);
     private final PropertyEntry<Boolean> useUnicode = createBooleanProperty(USE_UNICODE, false);
     private final PropertyEntry<Boolean> useSyntaxHighlighting =
-        createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
+            createBooleanProperty(SYNTAX_HIGHLIGHTING, true);
     private final PropertyEntry<Boolean> hidePackagePrefix =
-        createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
+            createBooleanProperty(HIDE_PACKAGE_PREFIX, false);
     private final PropertyEntry<Boolean> confirmExit = createBooleanProperty(CONFIRM_EXIT, true);
     private final PropertyEntry<Boolean> showLoadExamplesDialog =
-        createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
+            createBooleanProperty(SHOW_LOAD_EXAMPLES_DIALOG, true);
     private final PropertyEntry<Boolean> showWholeTaclet =
-        createBooleanProperty(SHOW_WHOLE_TACLET, false);
+            createBooleanProperty(SHOW_WHOLE_TACLET, false);
     private final PropertyEntry<Integer> sizeIndex = createIntegerProperty(FONT_INDEX, 2);
     private final PropertyEntry<String> lookAndFeel =
-        createStringProperty(LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
+            createStringProperty(PROP_LOOK_AND_FEEL, LOOK_AND_FEEL_DEFAULT);
     private final PropertyEntry<Boolean> showSequentViewTooltips =
-        createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
+            createBooleanProperty(SEQUENT_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showSourceViewTooltips =
-        createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
+            createBooleanProperty(SOURCE_VIEW_TOOLTIP, true);
     private final PropertyEntry<Boolean> showProofTreeTooltips =
-        createBooleanProperty(PROOF_TREE_TOOLTIP, true);
+            createBooleanProperty(PROOF_TREE_TOOLTIP, true);
     private final PropertyEntry<Boolean> highlightOrigin =
-        createBooleanProperty(HIGHLIGHT_ORIGIN, true);
+            createBooleanProperty(HIGHLIGHT_ORIGIN, true);
     private final PropertyEntry<Set<String>> clutterRules =
-        createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
+            createStringSetProperty(CLUTTER_RULES, CLUTTER_RULES_DEFAULT);
 
     private final PropertyEntry<Set<String>> clutterRuleSets =
-        createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
+            createStringSetProperty(CLUTTER_RULESSETS, CLUTTER_RULESETS_DEFAULT);
 
     private final PropertyEntry<Boolean> hideInteractiveGoals =
-        createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
+            createBooleanProperty(HIDE_INTERACTIVE_GOALS, false);
 
     private final PropertyEntry<String> notificationAfterMacro =
-        createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
+            createStringProperty(NOTIFICATION_AFTER_MACRO, NOTIFICATION_UNFOCUSED);
 
     /**
      * User-definable folder bookmarks.
@@ -229,10 +240,20 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * @see #setFolderBookmarks(List)
      */
     private final PropertyEntry<List<String>> folderBookmarks =
-        createStringListProperty(USER_FOLDER_BOOKMARKS, System.getProperty("user.home"));
+            createStringListProperty(USER_FOLDER_BOOKMARKS, System.getProperty("user.home"));
+
+    //
+    private boolean isDarkMode;
 
     public ViewSettings() {
         super("View");
+        updateIsDarkMode();
+    }
+
+    private void updateIsDarkMode() {
+        isDarkMode = getLookAndFeel().contains("FlatDark")
+                || getLookAndFeel().contains("FlatDarcula")
+                || getLookAndFeel().contains("FlatMacDarkLaf");
     }
 
     /**
@@ -286,7 +307,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Sets whether the "Load Examples" dialog window should be shown on startup
      *
      * @param b indicates whether the "Load Examples" dialog window should be shown on startup or
-     *        not
+     *          not
      */
     public void setShowLoadExamplesDialog(boolean b) {
         showLoadExamplesDialog.set(b);
@@ -307,7 +328,7 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * instantiations of schema-variables or not
      *
      * @param b indicates whether the Find and VarCond part of Taclets should be pretty-printed with
-     *        instantiations of schema-variables or not
+     *          instantiations of schema-variables or not
      */
     public void setShowWholeTaclet(boolean b) {
         showWholeTaclet.set(b);
@@ -330,6 +351,10 @@ public class ViewSettings extends AbstractPropertiesSettings {
     }
 
 
+    public PropertyEntry<String> lookAndFeel() {
+        return lookAndFeel;
+    }
+
     /**
      * @return class name of the look and feel to use
      */
@@ -344,7 +369,17 @@ public class ViewSettings extends AbstractPropertiesSettings {
      */
     public void setLookAndFeel(String className) {
         lookAndFeel.set(className);
+        updateIsDarkMode();
     }
+
+    public boolean isDefaultLookAndFeelDecorated() {
+        return defaultLookAndFeelDecorated.get();
+    }
+
+    public void setDefaultLookAndFeelDecorated(boolean value) {
+        defaultLookAndFeelDecorated.set(value);
+    }
+
 
     /**
      * When loading a Java file, all other java files in the parent directory are loaded as well.
@@ -487,14 +522,14 @@ public class ViewSettings extends AbstractPropertiesSettings {
      * Updates heatmap settings (all of the at the same time, so that fireSettingsChanged is called
      * only once.
      *
-     * @param showHeatmap true if heatmap on
-     * @param heatmapSF true for sequent formulas, false for terms
-     * @param heatmapNewest true if newest, false for "up to age"
+     * @param showHeatmap      true if heatmap on
+     * @param heatmapSF        true for sequent formulas, false for terms
+     * @param heatmapNewest    true if newest, false for "up to age"
      * @param maxAgeForHeatmap the maximum age for term or sequent formulas, concerning heatmap
-     *        highlighting
+     *                         highlighting
      */
     public void setHeatmapOptions(boolean showHeatmap, boolean heatmapSF, boolean heatmapNewest,
-            int maxAgeForHeatmap) {
+                                  int maxAgeForHeatmap) {
         this.showHeatmap.set(showHeatmap);
         this.heatmapSF.set(heatmapSF);
         this.heatmapNewest.set(heatmapNewest);
@@ -596,5 +631,10 @@ public class ViewSettings extends AbstractPropertiesSettings {
         } else {
             throw new IllegalStateException("tried to set wrong value for notification setting");
         }
+    }
+
+    /// Completely based on heuristics.
+    public boolean isDarkMode() {
+        return isDarkMode;
     }
 }

--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation project(":key.core")
     implementation project(":key.core.rifl")
 
+    implementation("com.formdev:flatlaf:3.6")
+
     implementation project(":key.core.proof_references")
     implementation project(":key.core.symbolic_execution")
     implementation project(":key.removegenerics")

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
@@ -3,22 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui;
 
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.io.Serial;
-import java.util.ArrayList;
-import java.util.EventObject;
-import java.util.List;
-import java.util.WeakHashMap;
-import javax.swing.*;
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-
 import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.core.KeYSelectionEvent;
@@ -29,6 +13,7 @@ import de.uka.ilkd.key.gui.extension.api.TabPanel;
 import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.FontAwesomeSolid;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
+import de.uka.ilkd.key.gui.fonticons.IconFontProvider;
 import de.uka.ilkd.key.gui.fonticons.IconFontSwing;
 import de.uka.ilkd.key.gui.prooftree.DisableGoal;
 import de.uka.ilkd.key.logic.label.TermLabel;
@@ -36,27 +21,38 @@ import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.pp.SequentViewLogicPrinter;
 import de.uka.ilkd.key.pp.VisibleTermLabels;
 import de.uka.ilkd.key.proof.*;
-
+import org.jspecify.annotations.NonNull;
 import org.key_project.logic.Name;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.EventObject;
+import java.util.List;
+import java.util.WeakHashMap;
 
 public class GoalList extends JList<Goal> implements TabPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(GoalList.class);
 
-    public static final Icon GOAL_LIST_ICON = IconFontSwing
-            .buildIcon(FontAwesomeSolid.FLAG_CHECKERED, MainWindow.TAB_ICON_SIZE);
-
-    @Serial
-    private static final long serialVersionUID = 1632264315383703798L;
     private final static ImageIcon keyIcon = IconFactory.keyHole(20, 20);
     private final static Icon disabledGoalIcon = IconFactory.keyHoleInteractive(20, 20);
     private final static Icon linkedGoalIcon = IconFactory.keyHoleLinked(20, 20);
+
     private final static int MAX_DISPLAYED_SEQUENT_LENGTH = 100;
+    private static final IconFontProvider GOAL_LIST_ICON = new IconFontProvider(FontAwesomeSolid.FLAG_CHECKERED);
     /**
      * the model used by this view
      */
@@ -107,7 +103,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
 
         updateUI();
         KeYGuiExtensionFacade.installKeyboardShortcuts(mediator, this,
-            KeYGuiExtension.KeyboardShortcuts.GOAL_LIST);
+                KeYGuiExtension.KeyboardShortcuts.GOAL_LIST);
         setMediator(mediator);
     }
 
@@ -118,7 +114,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
 
     @Override
     public Icon getIcon() {
-        return GOAL_LIST_ICON;
+        return GOAL_LIST_ICON.get(MainWindow.TAB_ICON_SIZE);
     }
 
     @Override
@@ -154,7 +150,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
             setFont(myFont);
         } else {
             LOGGER.debug("goallist: Warning: Use standard font. Could not find font: {}",
-                Config.KEY_FONT_GOAL_LIST_VIEW);
+                    Config.KEY_FONT_GOAL_LIST_VIEW);
         }
     }
 
@@ -217,19 +213,19 @@ public class GoalList extends JList<Goal> implements TabPanel {
         String res = seqToString.get(seq);
         if (res == null) {
             LogicPrinter sp =
-                SequentViewLogicPrinter.purePrinter(mediator.getNotationInfo(),
-                    mediator.getServices(),
-                    new VisibleTermLabels() {
-                        @Override
-                        public boolean contains(TermLabel label) {
-                            return false;
-                        }
+                    SequentViewLogicPrinter.purePrinter(mediator.getNotationInfo(),
+                            mediator.getServices(),
+                            new VisibleTermLabels() {
+                                @Override
+                                public boolean contains(TermLabel label) {
+                                    return false;
+                                }
 
-                        @Override
-                        public boolean contains(Name name) {
-                            return false;
-                        }
-                    }); // do not print term labels
+                                @Override
+                                public boolean contains(Name name) {
+                                    return false;
+                                }
+                            }); // do not print term labels
             sp.printSequent(seq);
             res = sp.result().replace('\n', ' ');
             res = res.substring(0, Math.min(MAX_DISPLAYED_SEQUENT_LENGTH, res.length()));
@@ -432,12 +428,12 @@ public class GoalList extends JList<Goal> implements TabPanel {
                 final Goal g = getSelectedValue();
                 putValue(NAME, g.isAutomatic() ? "Interactive Goal" : "Automatic Goal");
                 putValue(SHORT_DESCRIPTION,
-                    g.isAutomatic()
-                            ? "No automatic rules "
+                        g.isAutomatic()
+                                ? "No automatic rules "
                                 + "will be applied when goal is set to interactive."
-                            : "Re-enable automatic rule application for this goal.");
+                                : "Re-enable automatic rule application for this goal.");
                 putValue(SMALL_ICON,
-                    g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
+                        g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
                 enableGoals = !g.isAutomatic();
                 setEnabled(true);
             } else {
@@ -480,12 +476,12 @@ public class GoalList extends JList<Goal> implements TabPanel {
             if (getSelectedValue() != null) {
                 final Goal g = getSelectedValue();
                 putValue(NAME,
-                    g.isAutomatic() ? "Set Other Goals Interactive" : "Set Other Goals Automatic");
+                        g.isAutomatic() ? "Set Other Goals Interactive" : "Set Other Goals Automatic");
                 putValue(SHORT_DESCRIPTION,
-                    g.isAutomatic() ? "No automatic rules " + "will be applied on all other goals."
-                            : "Re-enable automatic rule application for other goals.");
+                        g.isAutomatic() ? "No automatic rules " + "will be applied on all other goals."
+                                : "Re-enable automatic rule application for other goals.");
                 putValue(SMALL_ICON,
-                    g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
+                        g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
                 enableGoals = !g.isAutomatic();
 
                 setEnabled(getModel().getSize() > 1);
@@ -598,8 +594,6 @@ public class GoalList extends JList<Goal> implements TabPanel {
      * used to prevent the display of goals that appear closed for the present user constraint.
      */
     private class SelectingGoalListModel extends AbstractListModel<Goal> {
-        @Serial
-        private static final long serialVersionUID = 7395134147866131926L;
         private final GoalListModel delegate;
         /**
          * List of <code>Integer</code> objects that determine the (strictly monotonic) mapping of
@@ -798,11 +792,11 @@ public class GoalList extends JList<Goal> implements TabPanel {
         }
 
         public Component getListCellRendererComponent(JList<?> list, Object value, // value
-                // to
-                // display
-                int index, // cell index
-                boolean isSelected, // is the cell selected
-                boolean cellHasFocus) // the list and the cell have the focus
+                                                      // to
+                                                      // display
+                                                      int index, // cell index
+                                                      boolean isSelected, // is the cell selected
+                                                      boolean cellHasFocus) // the list and the cell have the focus
         {
             String valueStr;
             Color col = Color.black;
@@ -824,8 +818,8 @@ public class GoalList extends JList<Goal> implements TabPanel {
             }
 
             DefaultListCellRenderer sup =
-                (DefaultListCellRenderer) super.getListCellRendererComponent(list, valueStr, index,
-                    isSelected, cellHasFocus);
+                    (DefaultListCellRenderer) super.getListCellRendererComponent(list, valueStr, index,
+                            isSelected, cellHasFocus);
 
             sup.setIcon(statusIcon);
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
@@ -3,6 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui;
 
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.EventObject;
+import java.util.List;
+import java.util.WeakHashMap;
+import javax.swing.*;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+
 import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.core.KeYSelectionEvent;
@@ -14,35 +30,20 @@ import de.uka.ilkd.key.gui.extension.impl.KeYGuiExtensionFacade;
 import de.uka.ilkd.key.gui.fonticons.FontAwesomeSolid;
 import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.fonticons.IconFontProvider;
-import de.uka.ilkd.key.gui.fonticons.IconFontSwing;
 import de.uka.ilkd.key.gui.prooftree.DisableGoal;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.pp.SequentViewLogicPrinter;
 import de.uka.ilkd.key.pp.VisibleTermLabels;
 import de.uka.ilkd.key.proof.*;
-import org.jspecify.annotations.NonNull;
+
 import org.key_project.logic.Name;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
+
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.io.Serial;
-import java.util.ArrayList;
-import java.util.EventObject;
-import java.util.List;
-import java.util.WeakHashMap;
 
 public class GoalList extends JList<Goal> implements TabPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(GoalList.class);
@@ -52,7 +53,8 @@ public class GoalList extends JList<Goal> implements TabPanel {
     private final static Icon linkedGoalIcon = IconFactory.keyHoleLinked(20, 20);
 
     private final static int MAX_DISPLAYED_SEQUENT_LENGTH = 100;
-    private static final IconFontProvider GOAL_LIST_ICON = new IconFontProvider(FontAwesomeSolid.FLAG_CHECKERED);
+    private static final IconFontProvider GOAL_LIST_ICON =
+        new IconFontProvider(FontAwesomeSolid.FLAG_CHECKERED);
     /**
      * the model used by this view
      */
@@ -103,7 +105,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
 
         updateUI();
         KeYGuiExtensionFacade.installKeyboardShortcuts(mediator, this,
-                KeYGuiExtension.KeyboardShortcuts.GOAL_LIST);
+            KeYGuiExtension.KeyboardShortcuts.GOAL_LIST);
         setMediator(mediator);
     }
 
@@ -150,7 +152,7 @@ public class GoalList extends JList<Goal> implements TabPanel {
             setFont(myFont);
         } else {
             LOGGER.debug("goallist: Warning: Use standard font. Could not find font: {}",
-                    Config.KEY_FONT_GOAL_LIST_VIEW);
+                Config.KEY_FONT_GOAL_LIST_VIEW);
         }
     }
 
@@ -213,19 +215,19 @@ public class GoalList extends JList<Goal> implements TabPanel {
         String res = seqToString.get(seq);
         if (res == null) {
             LogicPrinter sp =
-                    SequentViewLogicPrinter.purePrinter(mediator.getNotationInfo(),
-                            mediator.getServices(),
-                            new VisibleTermLabels() {
-                                @Override
-                                public boolean contains(TermLabel label) {
-                                    return false;
-                                }
+                SequentViewLogicPrinter.purePrinter(mediator.getNotationInfo(),
+                    mediator.getServices(),
+                    new VisibleTermLabels() {
+                        @Override
+                        public boolean contains(TermLabel label) {
+                            return false;
+                        }
 
-                                @Override
-                                public boolean contains(Name name) {
-                                    return false;
-                                }
-                            }); // do not print term labels
+                        @Override
+                        public boolean contains(Name name) {
+                            return false;
+                        }
+                    }); // do not print term labels
             sp.printSequent(seq);
             res = sp.result().replace('\n', ' ');
             res = res.substring(0, Math.min(MAX_DISPLAYED_SEQUENT_LENGTH, res.length()));
@@ -428,12 +430,12 @@ public class GoalList extends JList<Goal> implements TabPanel {
                 final Goal g = getSelectedValue();
                 putValue(NAME, g.isAutomatic() ? "Interactive Goal" : "Automatic Goal");
                 putValue(SHORT_DESCRIPTION,
-                        g.isAutomatic()
-                                ? "No automatic rules "
+                    g.isAutomatic()
+                            ? "No automatic rules "
                                 + "will be applied when goal is set to interactive."
-                                : "Re-enable automatic rule application for this goal.");
+                            : "Re-enable automatic rule application for this goal.");
                 putValue(SMALL_ICON,
-                        g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
+                    g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
                 enableGoals = !g.isAutomatic();
                 setEnabled(true);
             } else {
@@ -476,12 +478,12 @@ public class GoalList extends JList<Goal> implements TabPanel {
             if (getSelectedValue() != null) {
                 final Goal g = getSelectedValue();
                 putValue(NAME,
-                        g.isAutomatic() ? "Set Other Goals Interactive" : "Set Other Goals Automatic");
+                    g.isAutomatic() ? "Set Other Goals Interactive" : "Set Other Goals Automatic");
                 putValue(SHORT_DESCRIPTION,
-                        g.isAutomatic() ? "No automatic rules " + "will be applied on all other goals."
-                                : "Re-enable automatic rule application for other goals.");
+                    g.isAutomatic() ? "No automatic rules " + "will be applied on all other goals."
+                            : "Re-enable automatic rule application for other goals.");
                 putValue(SMALL_ICON,
-                        g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
+                    g.isAutomatic() ? KEY_HOLE_DISABLED_PULL_DOWN_MENU : KEY_HOLE_PULL_DOWN_MENU);
                 enableGoals = !g.isAutomatic();
 
                 setEnabled(getModel().getSize() > 1);
@@ -792,11 +794,11 @@ public class GoalList extends JList<Goal> implements TabPanel {
         }
 
         public Component getListCellRendererComponent(JList<?> list, Object value, // value
-                                                      // to
-                                                      // display
-                                                      int index, // cell index
-                                                      boolean isSelected, // is the cell selected
-                                                      boolean cellHasFocus) // the list and the cell have the focus
+                // to
+                // display
+                int index, // cell index
+                boolean isSelected, // is the cell selected
+                boolean cellHasFocus) // the list and the cell have the focus
         {
             String valueStr;
             Color col = Color.black;
@@ -818,8 +820,8 @@ public class GoalList extends JList<Goal> implements TabPanel {
             }
 
             DefaultListCellRenderer sup =
-                    (DefaultListCellRenderer) super.getListCellRendererComponent(list, valueStr, index,
-                            isSelected, cellHasFocus);
+                (DefaultListCellRenderer) super.getListCellRendererComponent(list, valueStr, index,
+                    isSelected, cellHasFocus);
 
             sup.setIcon(statusIcon);
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -410,6 +410,7 @@ public final class MainWindow extends JFrame {
 
         if (instance == null) {
             updateLookAndFeel();
+            instance = new MainWindow();
             final var viewSettings = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
             final PropertyChangeListener propertyChangeListener = (evt) -> updateLookAndFeel();
             viewSettings.addPropertyChangeListener(
@@ -417,7 +418,6 @@ public final class MainWindow extends JFrame {
             viewSettings.addPropertyChangeListener(
                 ViewSettings.PROP_LOOK_AND_FEEL, propertyChangeListener);
 
-            instance = new MainWindow();
             if (ensureIsVisible) {
                 instance.setVisible(true);
             }
@@ -439,6 +439,14 @@ public final class MainWindow extends JFrame {
             // enable custom window decorations
             JFrame.setDefaultLookAndFeelDecorated(viewSettings.isDefaultLookAndFeelDecorated());
             JDialog.setDefaultLookAndFeelDecorated(viewSettings.isDefaultLookAndFeelDecorated());
+        }
+
+        for (Window w : Window.getWindows()) {
+            SwingUtilities.updateComponentTreeUI(w);
+        }
+
+        if (instance != null) {
+            // SwingUtilities.updateComponentTreeUI(instance);
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -64,7 +64,10 @@ import de.uka.ilkd.key.settings.ViewSettings;
 import de.uka.ilkd.key.smt.SolverTypeCollection;
 import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.ui.AbstractMediatorUserInterfaceControl;
-import de.uka.ilkd.key.util.*;
+import de.uka.ilkd.key.util.KeYConstants;
+import de.uka.ilkd.key.util.KeYResourceManager;
+import de.uka.ilkd.key.util.PreferenceSaver;
+import de.uka.ilkd.key.util.ThreadUtilities;
 
 import org.key_project.logic.Name;
 import org.key_project.prover.rules.RuleApp;
@@ -404,15 +407,15 @@ public final class MainWindow extends JFrame {
             }
             return instance;
         }
-        if (instance == null) {
-            // FlatDarculaLaf.setup();
-            FlatLightLaf.setup();
 
-            if (SystemInfo.isLinux) {
-                // enable custom window decorations
-                JFrame.setDefaultLookAndFeelDecorated(true);
-                JDialog.setDefaultLookAndFeelDecorated(true);
-            }
+        if (instance == null) {
+            updateLookAndFeel();
+            final var viewSettings = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
+            final PropertyChangeListener propertyChangeListener = (evt) -> updateLookAndFeel();
+            viewSettings.addPropertyChangeListener(
+                ViewSettings.PROP_DEFAULT_LOOK_AND_FEEL_DECORATED, propertyChangeListener);
+            viewSettings.addPropertyChangeListener(
+                ViewSettings.PROP_LOOK_AND_FEEL, propertyChangeListener);
 
             instance = new MainWindow();
             if (ensureIsVisible) {
@@ -420,6 +423,23 @@ public final class MainWindow extends JFrame {
             }
         }
         return instance;
+    }
+
+    private static void updateLookAndFeel() {
+        final var viewSettings = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings();
+        String laf = viewSettings.getLookAndFeel();
+        try {
+            UIManager.setLookAndFeel(laf);
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                | UnsupportedLookAndFeelException e) {
+            FlatLightLaf.setup();
+        }
+
+        if (SystemInfo.isLinux) {
+            // enable custom window decorations
+            JFrame.setDefaultLookAndFeelDecorated(viewSettings.isDefaultLookAndFeelDecorated());
+            JDialog.setDefaultLookAndFeelDecorated(viewSettings.isDefaultLookAndFeelDecorated());
+        }
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -26,10 +26,6 @@ import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.event.MouseInputAdapter;
 
-import com.formdev.flatlaf.FlatDarculaLaf;
-import com.formdev.flatlaf.FlatIntelliJLaf;
-import com.formdev.flatlaf.FlatLightLaf;
-import com.formdev.flatlaf.util.SystemInfo;
 import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.control.TermLabelVisibilityManager;
 import de.uka.ilkd.key.core.KeYMediator;
@@ -79,6 +75,8 @@ import bibliothek.gui.dock.common.CControl;
 import bibliothek.gui.dock.common.SingleCDockable;
 import bibliothek.gui.dock.common.intern.CDockable;
 import bibliothek.gui.dock.station.stack.tab.layouting.TabPlacement;
+import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.util.SystemInfo;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -407,13 +405,13 @@ public final class MainWindow extends JFrame {
             return instance;
         }
         if (instance == null) {
-            //FlatDarculaLaf.setup();
+            // FlatDarculaLaf.setup();
             FlatLightLaf.setup();
 
-            if( SystemInfo.isLinux ) {
+            if (SystemInfo.isLinux) {
                 // enable custom window decorations
-                JFrame.setDefaultLookAndFeelDecorated( true );
-                JDialog.setDefaultLookAndFeelDecorated( true );
+                JFrame.setDefaultLookAndFeelDecorated(true);
+                JDialog.setDefaultLookAndFeelDecorated(true);
             }
 
             instance = new MainWindow();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -26,6 +26,10 @@ import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.event.MouseInputAdapter;
 
+import com.formdev.flatlaf.FlatDarculaLaf;
+import com.formdev.flatlaf.FlatIntelliJLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.util.SystemInfo;
 import de.uka.ilkd.key.control.AutoModeListener;
 import de.uka.ilkd.key.control.TermLabelVisibilityManager;
 import de.uka.ilkd.key.core.KeYMediator;
@@ -294,7 +298,6 @@ public final class MainWindow extends JFrame {
         if (!applyTaskbarIcon()) {
             applyMacOsWorkaround();
         }
-        setLaF();
         setIconImages(IconFactory.applicationLogos());
 
 
@@ -404,6 +407,15 @@ public final class MainWindow extends JFrame {
             return instance;
         }
         if (instance == null) {
+            //FlatDarculaLaf.setup();
+            FlatLightLaf.setup();
+
+            if( SystemInfo.isLinux ) {
+                // enable custom window decorations
+                JFrame.setDefaultLookAndFeelDecorated( true );
+                JDialog.setDefaultLookAndFeelDecorated( true );
+            }
+
             instance = new MainWindow();
             if (ensureIsVisible) {
                 instance.setVisible(true);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
@@ -23,17 +23,15 @@ import org.jspecify.annotations.NonNull;
  * search bars.
  */
 public abstract class SearchBar extends JPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4821960226273983607L;
-    public final JTextField searchField = new JTextField(20);
+    protected final JTextField searchField = new JTextField(20);
     private final JButton prev;
     private final JButton next;
     private final JButton close;
     private final ColorSettings.ColorProperty ALERT_COLOR =
-        ColorSettings.define("[searchBar]alert", "", new Color(255, 178, 178));
+        ColorSettings.define("[searchBar]alert", "",
+                new Color(255, 178, 178),
+                new Color(85, 40,40)
+        );
 
     protected SearchBar() {
         prev = new JButton(IconFactory.previous(16));
@@ -118,9 +116,9 @@ public abstract class SearchBar extends JPanel {
     public void search() {
         boolean match = search(searchField.getText());
         if (match) {
-            searchField.setBackground(Color.WHITE);
+            searchField.setBackground(UIManager.getColor("TextField.background"));
         } else {
-            searchField.setBackground(ALERT_COLOR.get());
+            searchField.setBackground(ALERT_COLOR.getCurrentColor());
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/SearchBar.java
@@ -29,9 +29,8 @@ public abstract class SearchBar extends JPanel {
     private final JButton close;
     private final ColorSettings.ColorProperty ALERT_COLOR =
         ColorSettings.define("[searchBar]alert", "",
-                new Color(255, 178, 178),
-                new Color(85, 40,40)
-        );
+            new Color(255, 178, 178),
+            new Color(85, 40, 40));
 
     protected SearchBar() {
         prev = new JButton(IconFactory.previous(16));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/TaskTree.java
@@ -44,11 +44,6 @@ import org.slf4j.LoggerFactory;
 public class TaskTree extends JPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskTree.class);
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6084969108377936099L;
-
     private final JTree delegateView;
 
     /** the KeYMediator */
@@ -160,6 +155,10 @@ public class TaskTree extends JPanel {
             setFont(myFont);
         } else {
             LOGGER.debug(Config.KEY_FONT_PROOF_LIST_VIEW + " not available, use standard font.");
+        }
+
+        if (delegateView != null) {
+            delegateView.setCellRenderer(new TaskTreeIconCellRenderer());
         }
     }
 
@@ -346,7 +345,6 @@ public class TaskTree extends JPanel {
 
 
     private static final class TaskTreeIconCellRenderer extends DefaultTreeCellRenderer {
-        private static final long serialVersionUID = 2423935787625012908L;
         private static final Icon KEY_ICON = IconFactory.keyHole(20, 20);
         private static final Icon KEY_CLOSED_ICON = IconFactory.keyHoleClosed(20);
         private static final Icon KEY_ALMOST_CLOSED_ICON = IconFactory.keyHoleAlmostClosed(20, 20);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
@@ -102,7 +102,7 @@ public abstract class KeyAction extends AbstractAction {
         putValue(SHORT_DESCRIPTION, toolTip);
     }
 
-    public void setIcon(Icon icon) {
+    protected void setIcon(Icon icon) {
         putValue(SMALL_ICON, icon);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/KeyAction.java
@@ -102,7 +102,7 @@ public abstract class KeyAction extends AbstractAction {
         putValue(SHORT_DESCRIPTION, toolTip);
     }
 
-    protected void setIcon(Icon icon) {
+    public void setIcon(Icon icon) {
         putValue(SMALL_ICON, icon);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
@@ -217,6 +217,7 @@ public class ColorSettings {
             if (v == null) {
                 setLightValue(defaultLightValue);
                 setDarkValue(defaultDarkValue);
+                return;
             }
 
             if (v instanceof Color c) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
@@ -16,8 +16,8 @@ import java.util.stream.Stream;
 
 import de.uka.ilkd.key.settings.Configuration;
 import de.uka.ilkd.key.settings.PathConfig;
-
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
+
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ColorSettings {
     public static final File SETTINGS_FILE_NEW =
-            new File(PathConfig.getKeyConfigDir(), "colors.json");
+        new File(PathConfig.getKeyConfigDir(), "colors.json");
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorSettings.class);
 
     private static ColorSettings INSTANCE;
@@ -41,8 +41,7 @@ public class ColorSettings {
 
     public ColorSettings(Configuration load) {
         // props.forEach((k, v) -> this.properties.put(k.toString(), v));
-        load.getEntries().forEach(entry ->
-                properties.put(entry.getKey(), entry.getValue()));
+        load.getEntries().forEach(entry -> properties.put(entry.getKey(), entry.getValue()));
         Runtime.getRuntime().addShutdownHook(new Thread(this::save));
     }
 
@@ -82,7 +81,7 @@ public class ColorSettings {
     public static Color fromHex(String s) {
         long i = Long.decode(s);
         return new Color((int) ((i >> 16) & 0xFF), (int) ((i >> 8) & 0xFF), (int) (i & 0xFF),
-                (int) ((i >> 24) & 0xFF));
+            (int) ((i >> 24) & 0xFF));
     }
 
     public static Color invert(Color c) {
@@ -106,9 +105,9 @@ public class ColorSettings {
     }
 
     private ColorProperty createColorProperty(String key, String description,
-                                              Color defaultLight, Color defaultDark) {
+            Color defaultLight, Color defaultDark) {
         Optional<ColorProperty> item =
-                getProperties().filter(it -> it.getKey().equals(key)).findFirst();
+            getProperties().filter(it -> it.getKey().equals(key)).findFirst();
         if (item.isPresent()) {
             return item.get();
         }
@@ -169,7 +168,8 @@ public class ColorSettings {
             this(key, description, defaultValue, defaultValue);
         }
 
-        public ColorProperty(String key, String description, Color defaultLightValue, Color defaultDarkValue) {
+        public ColorProperty(String key, String description, Color defaultLightValue,
+                Color defaultDarkValue) {
             this.key = key;
             this.description = description;
             if (!properties.containsKey(key)) {
@@ -231,7 +231,8 @@ public class ColorSettings {
                 setLightValue(fromHex(seq.get(0).toString()));
                 setDarkValue(fromHex(seq.get(1).toString()));
             } else {
-                throw new IllegalArgumentException("Unexpected types for color " + key + " with value " + v);
+                throw new IllegalArgumentException(
+                    "Unexpected types for color " + key + " with value " + v);
             }
         }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettings.java
@@ -4,19 +4,20 @@
 package de.uka.ilkd.key.gui.colors;
 
 import java.awt.*;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
+import java.util.List;
 import java.util.stream.Stream;
 
-import de.uka.ilkd.key.settings.AbstractPropertiesSettings;
 import de.uka.ilkd.key.settings.Configuration;
 import de.uka.ilkd.key.settings.PathConfig;
 
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,15 +30,19 @@ import org.slf4j.LoggerFactory;
  * @author Alexander Weigl
  * @version 1 (10.05.19)
  */
-public class ColorSettings extends AbstractPropertiesSettings {
+public class ColorSettings {
     public static final File SETTINGS_FILE_NEW =
-        new File(PathConfig.getKeyConfigDir(), "colors.json");
+            new File(PathConfig.getKeyConfigDir(), "colors.json");
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorSettings.class);
+
     private static ColorSettings INSTANCE;
+    private final Map<String, Object> properties = new TreeMap<>();
+    private final List<ColorProperty> propertyEntries = new ArrayList<>(64);
 
     public ColorSettings(Configuration load) {
-        super("");
-        readSettings(load);
+        // props.forEach((k, v) -> this.properties.put(k.toString(), v));
+        load.getEntries().forEach(entry ->
+                properties.put(entry.getKey(), entry.getValue()));
         Runtime.getRuntime().addShutdownHook(new Thread(this::save));
     }
 
@@ -59,7 +64,11 @@ public class ColorSettings extends AbstractPropertiesSettings {
     }
 
     public static ColorProperty define(String key, String desc, Color color) {
-        return getInstance().createColorProperty(key, desc, color);
+        return getInstance().createColorProperty(key, desc, color, color);
+    }
+
+    public static ColorProperty define(String key, String desc, Color light, Color dark) {
+        return getInstance().createColorProperty(key, desc, light, dark);
     }
 
     public static String toHex(Color c) {
@@ -73,7 +82,7 @@ public class ColorSettings extends AbstractPropertiesSettings {
     public static Color fromHex(String s) {
         long i = Long.decode(s);
         return new Color((int) ((i >> 16) & 0xFF), (int) ((i >> 8) & 0xFF), (int) (i & 0xFF),
-            (int) ((i >> 24) & 0xFF));
+                (int) ((i >> 24) & 0xFF));
     }
 
     public static Color invert(Color c) {
@@ -96,106 +105,149 @@ public class ColorSettings extends AbstractPropertiesSettings {
         }
     }
 
-    private ColorProperty createColorProperty(String key, String description, Color defaultValue) {
+    private ColorProperty createColorProperty(String key, String description,
+                                              Color defaultLight, Color defaultDark) {
         Optional<ColorProperty> item =
-            getProperties().filter(it -> it.getKey().equals(key)).findFirst();
+                getProperties().filter(it -> it.getKey().equals(key)).findFirst();
         if (item.isPresent()) {
             return item.get();
         }
 
-        ColorProperty pe = new ColorProperty(key, description, defaultValue);
+        ColorProperty pe = new ColorProperty(key, description, defaultLight, defaultDark);
         propertyEntries.add(pe);
         return pe;
     }
 
     public Stream<ColorProperty> getProperties() {
-        return propertyEntries.stream().map(ColorProperty.class::cast);
+        return propertyEntries.stream();
+    }
+
+    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    protected void firePropertyChange(String propertyName, int oldValue, int newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    protected void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        propertyChangeSupport.addPropertyChangeListener(propertyName, listener);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.removePropertyChangeListener(listener);
+    }
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.addPropertyChangeListener(listener);
+    }
+
+    public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
     }
 
     /**
      * A property for handling colors.
      */
-    public class ColorProperty implements PropertyEntry<Color> {
+    public class ColorProperty {
         private final String key;
         private final String description;
-        private Color currentValue;
+        private Color defaultLightValue;
+        private Color defaultDarkValue;
+
+        private Color lightValue;
+        private Color darkValue;
+
 
         public ColorProperty(String key, String description, Color defaultValue) {
+            this(key, description, defaultValue, defaultValue);
+        }
+
+        public ColorProperty(String key, String description, Color defaultLightValue, Color defaultDarkValue) {
             this.key = key;
             this.description = description;
             if (!properties.containsKey(key)) {
-                set(defaultValue);
+                this.defaultLightValue = defaultLightValue;
+                this.defaultDarkValue = defaultDarkValue;
             }
         }
 
-        @Override
-        public String value() {
-            if (currentValue != null) {
-                return toHex(currentValue);
-            }
-
-            String v = properties.get(key).toString();
-
-            try {
-                return v;
-            } catch (NumberFormatException e) {
-                return toHex(Color.MAGENTA);
+        public Color getCurrentColor() {
+            if (ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()) {
+                return getDarkValue();
+            } else {
+                return getLightValue();
             }
         }
 
-        @Override
+        public Color getLightValue() {
+            if (lightValue == null) {
+                update();
+            }
+            return lightValue;
+        }
+
+        public void setLightValue(Color lightValue) {
+            var old = this.lightValue;
+            this.lightValue = lightValue;
+            firePropertyChange(getKey(), old, lightValue);
+        }
+
+        public Color getDarkValue() {
+            if (darkValue == null) {
+                update();
+            }
+            return darkValue;
+        }
+
+        public void setDarkValue(Color darkValue) {
+            var old = this.darkValue;
+            this.darkValue = darkValue;
+            firePropertyChange(getKey(), old, lightValue);
+        }
+
+        public void update() {
+            Object v = properties.get(key);
+            if (v == null) {
+                setLightValue(defaultLightValue);
+                setDarkValue(defaultDarkValue);
+            }
+
+            if (v instanceof Color c) {
+                setDarkValue(c);
+                setLightValue(c);
+            } else if (v instanceof String s) {
+                var c = fromHex(s);
+                setDarkValue(c);
+                setLightValue(c);
+            } else if (v instanceof List<?> seq) {
+                setLightValue(fromHex(seq.get(0).toString()));
+                setDarkValue(fromHex(seq.get(1).toString()));
+            } else {
+                throw new IllegalArgumentException("Unexpected types for color " + key + " with value " + v);
+            }
+        }
+
         public Color fromObject(@Nullable Object o) {
             return fromHex(o.toString());
         }
 
-        @Override
-        public void parseFrom(String v) {
-            final var old = value();
-            if (!Objects.equals(old, v)) {
-                currentValue = fromHex(v);
-                properties.put(getKey(), v);
-                firePropertyChange(getKey(), old, currentValue);
-            }
-        }
-
-        @Override
         public String getKey() {
             return key;
-        }
-
-        @Override
-        public void set(Color value) {
-            if (currentValue != value) {
-                var old = currentValue;
-                currentValue = value;
-                properties.put(getKey(), toHex(value));
-                firePropertyChange(getKey(), old, value);
-            }
-        }
-
-        @Override
-        public Color get() {
-            if (currentValue != null) {
-                return currentValue;
-            }
-
-            String v = (String) properties.get(key);
-
-            try {
-                return currentValue = fromHex(v);
-            } catch (NumberFormatException e) {
-                LOGGER.error("Failed to parse color, using magenta", e);
-                return Color.MAGENTA;
-            }
         }
 
         public String getDescription() {
             return description;
         }
-    }
 
-    @Override
-    public void readSettings(Properties props) {
-        props.forEach((k, v) -> this.properties.put(k.toString(), v));
+        public Color get() {
+            return getCurrentColor();
+        }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
@@ -43,7 +43,8 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
     @Override
     public JPanel getPanel(MainWindow window) {
         List<ColorPropertyData> properties = ColorSettings.getInstance().getProperties()
-                .map(it -> new ColorPropertyData(it, it.getLightValue(), it.getDarkValue())).collect(Collectors.toList());
+                .map(it -> new ColorPropertyData(it, it.getLightValue(), it.getDarkValue()))
+                .collect(Collectors.toList());
 
         modelColor = new ColorSettingsTableModel(properties);
         tblColors.setModel(modelColor);
@@ -97,7 +98,8 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
     }
 
     private static class ColorSettingsTableModel extends AbstractTableModel {
-        private static final String[] COLUMNS = { "Key", "Description", "Light Color", "Dark Color" };
+        private static final String[] COLUMNS =
+            { "Key", "Description", "Light Color", "Dark Color" };
         private final List<ColorPropertyData> colorData;
 
         public ColorSettingsTableModel(List<ColorPropertyData> properties) {
@@ -124,8 +126,8 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
             return switch (columnIndex) {
             case 0 -> colorData.get(rowIndex).property.getKey();
             case 1 -> colorData.get(rowIndex).property.getDescription();
-                case 2 -> colorData.get(rowIndex).lightColor;
-                case 3 -> colorData.get(rowIndex).darkColor;
+            case 2 -> colorData.get(rowIndex).lightColor;
+            case 3 -> colorData.get(rowIndex).darkColor;
             default -> "";
             };
         }
@@ -158,7 +160,8 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
         Color darkColor;
         Color lightColor;
 
-        public ColorPropertyData(ColorSettings.ColorProperty property, Color lightColor, Color darkColor) {
+        public ColorPropertyData(ColorSettings.ColorProperty property, Color lightColor,
+                Color darkColor) {
             this.property = property;
             this.lightColor = lightColor;
             this.darkColor = darkColor;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/colors/ColorSettingsProvider.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.gui.settings.SimpleSettingsPanel;
  * @version 1 (10.05.19)
  */
 public class ColorSettingsProvider extends SimpleSettingsPanel implements SettingsProvider {
-    private static final long serialVersionUID = -6253991459166324512L;
     private final JTable tblColors = new JTable();
     private ColorSettingsTableModel modelColor;
 
@@ -44,7 +43,7 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
     @Override
     public JPanel getPanel(MainWindow window) {
         List<ColorPropertyData> properties = ColorSettings.getInstance().getProperties()
-                .map(it -> new ColorPropertyData(it, it.get())).collect(Collectors.toList());
+                .map(it -> new ColorPropertyData(it, it.getLightValue(), it.getDarkValue())).collect(Collectors.toList());
 
         modelColor = new ColorSettingsTableModel(properties);
         tblColors.setModel(modelColor);
@@ -61,8 +60,6 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
         tblColors.getColumnModel().getColumn(2).setCellEditor(HexColorCellEditor.make());
 
         tblColors.setDefaultRenderer(Color.class, new DefaultTableCellRenderer() {
-            private static final long serialVersionUID = -7602735597024671100L;
-
             @Override
             public Component getTableCellRendererComponent(JTable table, Object value,
                     boolean isSelected, boolean hasFocus, int row, int column) {
@@ -93,12 +90,14 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
 
     @Override
     public void applySettings(MainWindow window) {
-        modelColor.colorData.forEach(it -> it.property.set(it.color));
+        for (ColorPropertyData it : modelColor.colorData) {
+            it.property.setLightValue(it.lightColor);
+            it.property.setDarkValue(it.darkColor);
+        }
     }
 
     private static class ColorSettingsTableModel extends AbstractTableModel {
-        private static final long serialVersionUID = 4722928883386296559L;
-        private static final String[] COLUMNS = { "Key", "Description", "Color" };
+        private static final String[] COLUMNS = { "Key", "Description", "Light Color", "Dark Color" };
         private final List<ColorPropertyData> colorData;
 
         public ColorSettingsTableModel(List<ColorPropertyData> properties) {
@@ -125,14 +124,15 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
             return switch (columnIndex) {
             case 0 -> colorData.get(rowIndex).property.getKey();
             case 1 -> colorData.get(rowIndex).property.getDescription();
-            case 2 -> colorData.get(rowIndex).color;
+                case 2 -> colorData.get(rowIndex).lightColor;
+                case 3 -> colorData.get(rowIndex).darkColor;
             default -> "";
             };
         }
 
         @Override
         public Class<?> getColumnClass(int columnIndex) {
-            if (columnIndex == 2) {
+            if (columnIndex == 2 || columnIndex == 3) {
                 return Color.class;
             }
             return String.class;
@@ -141,7 +141,7 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
         @Override
         public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
             if (columnIndex == 2) {
-                colorData.get(rowIndex).color = ColorSettings.fromHex(aValue.toString());
+                colorData.get(rowIndex).lightColor = ColorSettings.fromHex(aValue.toString());
             } else {
                 super.setValueAt(aValue, rowIndex, columnIndex);
             }
@@ -149,17 +149,19 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
 
         @Override
         public boolean isCellEditable(int rowIndex, int columnIndex) {
-            return columnIndex == 2;
+            return columnIndex == 2 || columnIndex == 3;
         }
     }
 
     private static class ColorPropertyData {
         private final ColorSettings.ColorProperty property;
-        Color color;
+        Color darkColor;
+        Color lightColor;
 
-        public ColorPropertyData(ColorSettings.ColorProperty property, Color color) {
+        public ColorPropertyData(ColorSettings.ColorProperty property, Color lightColor, Color darkColor) {
             this.property = property;
-            this.color = color;
+            this.lightColor = lightColor;
+            this.darkColor = darkColor;
         }
     }
 
@@ -168,8 +170,6 @@ public class ColorSettingsProvider extends SimpleSettingsPanel implements Settin
 
 
 class HexColorCellEditor extends DefaultCellEditor {
-    private static final long serialVersionUID = -4352607386521686931L;
-
     HexColorCellEditor(JTextField textField) {
         super(textField);
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/configuration/ViewSelector.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/configuration/ViewSelector.java
@@ -65,11 +65,11 @@ public class ViewSelector extends JDialog {
         maxLinesPanel.setLayout(new BoxLayout(maxLinesPanel, BoxLayout.X_AXIS));
         maxTooltipLinesInputField = new NumberInputField(maxLinesInt, 4);
         maxTooltipLinesInputField.setMaximumSize(new Dimension(40, 30));
-        maxLinesPanel.add(new JLabel("<html><font color=\"#000000\">"
+        maxLinesPanel.add(new JLabel("<html>"
             + "Maximum size (line count) of the tooltips of applicable rules"
             + "<br> with schema variable instantiations displayed. "
             + "In case of longer <br>tooltips the instantiation will be "
-            + "suppressed. </font></html>"));
+            + "suppressed.</html>"));
         maxLinesPanel.add(maxTooltipLinesInputField);
 
         JPanel showUninstantiatedTacletPanel = new JPanel();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -10,6 +10,10 @@ import java.util.HashMap;
 import java.util.List;
 import javax.swing.*;
 
+import de.uka.ilkd.key.gui.actions.KeyAction;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.settings.ViewSettings;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +34,9 @@ public final class IconFactory {
     public static final IconFontProvider PREVIOUS =
         new IconFontProvider(FontAwesomeSolid.ARROW_LEFT);
     public static final IconFontProvider START =
-        new IconFontProvider(FontAwesomeSolid.PLAY, Color.GREEN);
+        new IconFontProvider(FontAwesomeSolid.PLAY, Color.GREEN, Color.GREEN.brighter().brighter());
     public static final IconFontProvider STOP =
-        new IconFontProvider(FontAwesomeSolid.STOP, Color.RED);
+        new IconFontProvider(FontAwesomeSolid.STOP, Color.RED, Color.GREEN.brighter().brighter());
     // an alternative would be TIMES_CIRCLE
     public static final IconFontProvider CLOSE = new IconFontProvider(FontAwesomeSolid.TIMES);
     public static final IconFontProvider CONFIGURE_MENU =
@@ -478,6 +482,20 @@ public final class IconFactory {
 
     public static Icon get(IconProvider provider, float size) {
         return cache.computeIfAbsent(provider.getKey(size), d -> provider.load(size));
+    }
+
+    public static void setIconAndListen(IconProvider provider, float size, JLabel ui) {
+        ui.setIcon(provider.get(size));
+        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                .addPropertyChangeListener(ViewSettings.PROP_LOOK_AND_FEEL,
+                    evt -> ui.setIcon(provider.get(size)));
+    }
+
+    public static void setIconAndListen(IconProvider provider, float size, KeyAction ui) {
+        ui.setIcon(provider.get(size));
+        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
+                .addPropertyChangeListener(ViewSettings.PROP_LOOK_AND_FEEL,
+                    evt -> ui.setIcon(provider.get(size)));
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -10,9 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import javax.swing.*;
 
-import de.uka.ilkd.key.gui.actions.KeyAction;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
-import de.uka.ilkd.key.settings.ViewSettings;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -484,20 +482,6 @@ public final class IconFactory {
         return cache.computeIfAbsent(provider.getKey(size), d -> provider.load(size));
     }
 
-    public static void setIconAndListen(IconProvider provider, float size, JLabel ui) {
-        ui.setIcon(provider.get(size));
-        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                .addPropertyChangeListener(ViewSettings.PROP_LOOK_AND_FEEL,
-                    evt -> ui.setIcon(provider.get(size)));
-    }
-
-    public static void setIconAndListen(IconProvider provider, float size, KeyAction ui) {
-        ui.setIcon(provider.get(size));
-        ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
-                .addPropertyChangeListener(ViewSettings.PROP_LOOK_AND_FEEL,
-                    evt -> ui.setIcon(provider.get(size)));
-    }
-
     /**
      * Returns a list of the application logo (used in Frame, Taskbar, etc) in various predefined
      * sizes.
@@ -546,5 +530,33 @@ class DuneColorScheme {
 
     private static Color hex(String s) {
         return Color.decode(s);
+    }
+}
+
+
+/// An icon that switches between light/dark depending the current [ViewSettings].
+/// @param dark
+/// @param light
+record LightDarkIcon(Icon light, Icon dark) implements Icon {
+    LightDarkIcon {
+        assert (light.getIconHeight() == dark.getIconHeight());
+        assert (light.getIconWidth() == dark.getIconWidth());
+    }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        var isDarkMode = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode();
+        var icon = isDarkMode ? dark : light;
+        icon.paintIcon(c, g, x, y);
+    }
+
+    @Override
+    public int getIconWidth() {
+        return light.getIconWidth();
+    }
+
+    @Override
+    public int getIconHeight() {
+        return light.getIconHeight();
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFontProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFontProvider.java
@@ -6,8 +6,6 @@ package de.uka.ilkd.key.gui.fonticons;
 import java.awt.*;
 import javax.swing.*;
 
-import de.uka.ilkd.key.settings.ProofIndependentSettings;
-
 public class IconFontProvider extends IconProvider {
     private final IconFont iconCode;
     private final Color lightModeColor;
@@ -29,17 +27,13 @@ public class IconFontProvider extends IconProvider {
 
     @Override
     Icon load(float size) {
-        Color color = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()
-                ? darkModeColor
-                : lightModeColor;
-        return IconFontSwing.buildIcon(iconCode, size, color);
+        Icon darkMode = IconFontSwing.buildIcon(iconCode, size, darkModeColor);
+        Icon lightMode = IconFontSwing.buildIcon(iconCode, size, lightModeColor);
+        return new LightDarkIcon(lightMode, darkMode);
     }
 
     @Override
     String getKey(float size) {
-        Color color = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()
-                ? darkModeColor
-                : lightModeColor;
-        return iconCode.toString() + color + size;
+        return iconCode.toString() + size;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFontProvider.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFontProvider.java
@@ -6,26 +6,40 @@ package de.uka.ilkd.key.gui.fonticons;
 import java.awt.*;
 import javax.swing.*;
 
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+
 public class IconFontProvider extends IconProvider {
     private final IconFont iconCode;
-    private final Color color;
+    private final Color lightModeColor;
+    private final Color darkModeColor;
 
     public IconFontProvider(IconFont iconCode) {
-        this(iconCode, Color.black);
+        this(iconCode, Color.black, Color.white);
     }
 
     public IconFontProvider(IconFont iconCode, Color color) {
+        this(iconCode, color, color);
+    }
+
+    public IconFontProvider(IconFont iconCode, Color lightModeColor, Color darkModeColor) {
         this.iconCode = iconCode;
-        this.color = color;
+        this.lightModeColor = lightModeColor;
+        this.darkModeColor = darkModeColor;
     }
 
     @Override
     Icon load(float size) {
+        Color color = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()
+                ? darkModeColor
+                : lightModeColor;
         return IconFontSwing.buildIcon(iconCode, size, color);
     }
 
     @Override
     String getKey(float size) {
+        Color color = ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings().isDarkMode()
+                ? darkModeColor
+                : lightModeColor;
         return iconCode.toString() + color + size;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalView.java
@@ -63,7 +63,7 @@ public final class CurrentGoalView extends SequentView implements Autoscroll {
     public CurrentGoalView(MainWindow mainWindow) {
         super(mainWindow);
         this.mediator = mainWindow.getMediator();
-        setBackground(Color.white);
+
         // disables selection
         setSelectionColor(getBackground());
         listener = new CurrentGoalViewListener(this, getMediator());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalView.java
@@ -33,14 +33,7 @@ import org.slf4j.LoggerFactory;
  * rules (in particular taclets) and drag'n drop instantiation of taclets.
  */
 public final class CurrentGoalView extends SequentView implements Autoscroll {
-
-    private static final long serialVersionUID = 8494000234215913553L;
-
-    // The color constants that used to be here have been moved to SequentView to collect them in
-    // one place.
-
     private static final Logger LOGGER = LoggerFactory.getLogger(CurrentGoalView.class);
-
 
     // the mediator
     private final KeYMediator mediator;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/EmptySequent.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/EmptySequent.java
@@ -11,11 +11,14 @@ import de.uka.ilkd.key.gui.MainWindow;
  * @author Kai Wallisch
  */
 public class EmptySequent extends SequentView {
-
-    private static final long serialVersionUID = 7572244482555772604L;
-
     public EmptySequent(MainWindow mainWindow) {
         super(mainWindow);
+        setBackground(INACTIVE_BACKGROUND_COLOR);
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
         setBackground(INACTIVE_BACKGROUND_COLOR);
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
  * Parent class of CurrentGoalView and InnerNodeView.
  */
 public abstract class SequentView extends JEditorPane {
-    private static final long serialVersionUID = 6867808795064180589L;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(SequentView.class);
 
     public static final Color PERMANENT_HIGHLIGHT_COLOR = new Color(110, 85, 181, 76);
@@ -68,8 +66,8 @@ public abstract class SequentView extends JEditorPane {
         "[currentGoal]mouseSelectionColor", "Color of the mouse selection in the sequent view.",
         new Color(230, 230, 230, 255));
 
-    protected static final Color INACTIVE_BACKGROUND_COLOR =
-        new Color(UIManager.getColor("Panel.background").getRGB());
+    protected static Color INACTIVE_BACKGROUND_COLOR =
+            new Color(UIManager.getColor("Panel.background").getRGB());
 
     private static final HighlightPainter MOUSE_SELECTION_PAINTER =
         new DefaultHighlightPainter(MOUSE_SELECTION_COLOR.get());
@@ -689,6 +687,7 @@ public abstract class SequentView extends JEditorPane {
     public void updateUI() {
         super.updateUI();
         setFont();
+        INACTIVE_BACKGROUND_COLOR = UIManager.getColor("Panel.background");
     }
 
     public static int computeLineWidthFor(JComponent c) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
@@ -7,9 +7,12 @@ import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.*;
 import javax.swing.*;
-import javax.swing.text.*;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultHighlighter;
 import javax.swing.text.DefaultHighlighter.DefaultHighlightPainter;
+import javax.swing.text.Highlighter;
 import javax.swing.text.Highlighter.HighlightPainter;
+import javax.swing.text.JTextComponent;
 import javax.swing.text.html.HTMLDocument;
 
 import de.uka.ilkd.key.gui.MainWindow;
@@ -27,7 +30,6 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ViewSettings;
 import de.uka.ilkd.key.util.DoNothingCaret;
 
-import org.jspecify.annotations.Nullable;
 import org.key_project.logic.PosInTerm;
 import org.key_project.prover.sequent.FormulaChangeInfo;
 import org.key_project.prover.sequent.PosInOccurrence;
@@ -36,6 +38,7 @@ import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,26 +49,25 @@ public abstract class SequentView extends JEditorPane {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequentView.class);
 
     public static final ColorSettings.ColorProperty PERMANENT_HIGHLIGHT_COLOR =
-            ColorSettings.define("[currentGoal]permaHighlight",
-                    "",
-                    new Color(110, 85, 181, 76),
-                    new Color(210, 185, 201, 200));
+        ColorSettings.define("[currentGoal]permaHighlight",
+            "",
+            new Color(110, 85, 181, 76),
+            new Color(210, 185, 201, 200));
 
     public static final ColorSettings.ColorProperty DEFAULT_HIGHLIGHT_COLOR =
         ColorSettings.define("[currentGoal]defaultHighlight", "",
-                new Color(70, 100, 170, 76),
-                new Color(140, 200, 255, 180));
+            new Color(70, 100, 170, 76),
+            new Color(140, 200, 255, 180));
 
     public static final ColorSettings.ColorProperty ADDITIONAL_HIGHLIGHT_COLOR =
         ColorSettings.define("[currentGoal]addtionalHighlight", "",
-                new Color(0, 0, 0, 38),
-                new Color(240, 220, 255, 180));
+            new Color(0, 0, 0, 38),
+            new Color(240, 220, 255, 180));
 
     public static final ColorSettings.ColorProperty UPDATE_HIGHLIGHT_COLOR =
         ColorSettings.define("[currentGoal]updateHighlight", "",
-                new Color(0, 150, 130, 38),
-                new Color(0, 150, 130, 255)
-                );
+            new Color(0, 150, 130, 38),
+            new Color(0, 150, 130, 255));
 
     public static final ColorSettings.ColorProperty DND_HIGHLIGHT_COLOR =
         ColorSettings.define("[currentGoal]dndHighlight", "", new Color(0, 150, 130, 255));
@@ -161,7 +163,7 @@ public abstract class SequentView extends JEditorPane {
                 mainWindow.getMediator().getServices(), getVisibleTermLabels());
 
         setContentType("text/html");
-        HTMLSyntaxHighlighter.addCSSRulesTo((HTMLDocument) getDocument());
+        updateUI();
 
         configChangeListener = new ConfigChangeAdapter(this);
         Config.DEFAULT.addConfigChangeListener(configChangeListener);
@@ -697,6 +699,10 @@ public abstract class SequentView extends JEditorPane {
     @Override
     public void updateUI() {
         super.updateUI();
+        try {
+            HTMLSyntaxHighlighter.addCSSRulesTo((HTMLDocument) getDocument());
+        } catch (ClassCastException ignore) {
+        }
         setFont();
         INACTIVE_BACKGROUND_COLOR = UIManager.getColor("Panel.background");
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
@@ -27,6 +27,7 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ViewSettings;
 import de.uka.ilkd.key.util.DoNothingCaret;
 
+import org.jspecify.annotations.Nullable;
 import org.key_project.logic.PosInTerm;
 import org.key_project.prover.sequent.FormulaChangeInfo;
 import org.key_project.prover.sequent.PosInOccurrence;
@@ -44,16 +45,27 @@ import org.slf4j.LoggerFactory;
 public abstract class SequentView extends JEditorPane {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequentView.class);
 
-    public static final Color PERMANENT_HIGHLIGHT_COLOR = new Color(110, 85, 181, 76);
+    public static final ColorSettings.ColorProperty PERMANENT_HIGHLIGHT_COLOR =
+            ColorSettings.define("[currentGoal]permaHighlight",
+                    "",
+                    new Color(110, 85, 181, 76),
+                    new Color(210, 185, 201, 200));
 
     public static final ColorSettings.ColorProperty DEFAULT_HIGHLIGHT_COLOR =
-        ColorSettings.define("[currentGoal]defaultHighlight", "", new Color(70, 100, 170, 76));
+        ColorSettings.define("[currentGoal]defaultHighlight", "",
+                new Color(70, 100, 170, 76),
+                new Color(140, 200, 255, 180));
 
     public static final ColorSettings.ColorProperty ADDITIONAL_HIGHLIGHT_COLOR =
-        ColorSettings.define("[currentGoal]addtionalHighlight", "", new Color(0, 0, 0, 38));
+        ColorSettings.define("[currentGoal]addtionalHighlight", "",
+                new Color(0, 0, 0, 38),
+                new Color(240, 220, 255, 180));
 
     public static final ColorSettings.ColorProperty UPDATE_HIGHLIGHT_COLOR =
-        ColorSettings.define("[currentGoal]updateHighlight", "", new Color(0, 150, 130, 38));
+        ColorSettings.define("[currentGoal]updateHighlight", "",
+                new Color(0, 150, 130, 38),
+                new Color(0, 150, 130, 255)
+                );
 
     public static final ColorSettings.ColorProperty DND_HIGHLIGHT_COLOR =
         ColorSettings.define("[currentGoal]dndHighlight", "", new Color(0, 150, 130, 255));
@@ -66,8 +78,7 @@ public abstract class SequentView extends JEditorPane {
         "[currentGoal]mouseSelectionColor", "Color of the mouse selection in the sequent view.",
         new Color(230, 230, 230, 255));
 
-    protected static Color INACTIVE_BACKGROUND_COLOR =
-            new Color(UIManager.getColor("Panel.background").getRGB());
+    protected static Color INACTIVE_BACKGROUND_COLOR = UIManager.getColor("Panel.background");
 
     private static final HighlightPainter MOUSE_SELECTION_PAINTER =
         new DefaultHighlightPainter(MOUSE_SELECTION_COLOR.get());
@@ -132,9 +143,9 @@ public abstract class SequentView extends JEditorPane {
 
     private final SequentViewInputListener sequentViewInputListener;
 
-    private Object userSelectionHighlight = null;
-    private Range userSelectionHighlightRange = null;
-    private PosInSequent userSelectionHighlightPis = null;
+    private @Nullable Object userSelectionHighlight = null;
+    private @Nullable Range userSelectionHighlightRange = null;
+    private @Nullable PosInSequent userSelectionHighlightPis = null;
 
     protected SequentView(MainWindow mainWindow) {
         this.mainWindow = mainWindow;
@@ -199,7 +210,7 @@ public abstract class SequentView extends JEditorPane {
     }
 
     @Override
-    public String getToolTipText(MouseEvent event) {
+    public @Nullable String getToolTipText(MouseEvent event) {
         if (!ProofIndependentSettings.DEFAULT_INSTANCE.getViewSettings()
                 .isShowSequentViewTooltips()) {
             return null;
@@ -345,14 +356,14 @@ public abstract class SequentView extends JEditorPane {
     /**
      * @return the initial position table
      */
-    protected InitialPositionTable getInitialPositionTable() {
+    protected @Nullable InitialPositionTable getInitialPositionTable() {
         return printer == null ? null : printer.layouter().getInitialPositionTable();
     }
 
     /**
      * Get a PosInSequent object for a given coordinate of the displayed sequent.
      */
-    protected synchronized PosInSequent getPosInSequent(Point p) {
+    protected synchronized @Nullable PosInSequent getPosInSequent(Point p) {
         String seqText = getText();
         if (seqText != null && !seqText.isEmpty()) {
             final InitialPositionTable initialPositionTable = getInitialPositionTable();
@@ -586,7 +597,7 @@ public abstract class SequentView extends JEditorPane {
             userSelectionHighlightRange = new Range(range.start() + 1, range.end() + 1);
             userSelectionHighlight = getHighlighter().addHighlight(
                 userSelectionHighlightRange.start(), userSelectionHighlightRange.end(),
-                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR));
+                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR.getCurrentColor()));
 
             sequentViewInputListener.highlightOriginInSourceView(pis);
         } catch (BadLocationException e) {
@@ -602,7 +613,7 @@ public abstract class SequentView extends JEditorPane {
             userSelectionHighlightRange = getHighlightRange(point);
             userSelectionHighlight = getHighlighter().addHighlight(
                 userSelectionHighlightRange.start(), userSelectionHighlightRange.end(),
-                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR));
+                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR.getCurrentColor()));
 
             sequentViewInputListener.highlightOriginInSourceView(userSelectionHighlightPis);
         } catch (BadLocationException e) {
@@ -657,7 +668,7 @@ public abstract class SequentView extends JEditorPane {
             userSelectionHighlightRange = new Range(pis.getBounds().start(), pis.getBounds().end());
             userSelectionHighlight = getHighlighter().addHighlight(
                 userSelectionHighlightRange.start(), userSelectionHighlightRange.end(),
-                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR));
+                new DefaultHighlightPainter(PERMANENT_HIGHLIGHT_COLOR.getCurrentColor()));
 
             sequentViewInputListener.highlightOriginInSourceView(pis);
         } catch (BadLocationException e) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -30,6 +30,7 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
 
         setName("Toggle Term Origin Tracking");
         setTooltip("Track where in the JML specification a every term in the sequent originates.");
+        IconFactory.setIconAndListen(IconFactory.ORIGIN_LABELS, MainWindow.TOOLBAR_ICON_SIZE, this);
         setIcon(IconFactory.ORIGIN_LABELS.get(MainWindow.TOOLBAR_ICON_SIZE));
 
         setEnabled(true);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/ToggleTermOriginTrackingAction.java
@@ -30,7 +30,6 @@ public class ToggleTermOriginTrackingAction extends MainWindowAction {
 
         setName("Toggle Term Origin Tracking");
         setTooltip("Track where in the JML specification a every term in the sequent originates.");
-        IconFactory.setIconAndListen(IconFactory.ORIGIN_LABELS, MainWindow.TOOLBAR_ICON_SIZE, this);
         setIcon(IconFactory.ORIGIN_LABELS.get(MainWindow.TOOLBAR_ICON_SIZE));
 
         setEnabled(true);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
@@ -17,8 +17,6 @@ import org.key_project.util.collection.Pair;
 import org.jspecify.annotations.NonNull;
 
 class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
-
-    private static final long serialVersionUID = 683318838568020629L;
     private final ProofTreeView proofTreeView;
     private int startRow = 0;
     private int currentRow = 0;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -39,13 +39,13 @@ import de.uka.ilkd.key.proof.reference.ClosedBy;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.ThreadUtilities;
 
-import org.jspecify.annotations.Nullable;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
 
 import bibliothek.gui.dock.common.action.CAction;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,22 +66,23 @@ public class ProofTreeView extends JPanel implements TabPanel {
      */
     public static final ColorSettings.ColorProperty DARK_GREEN_COLOR =
         ColorSettings.define("[proofTree]darkGreen", "",
-                new Color(0, 128, 51),
-                new Color(100, 255, 102));
+            new Color(0, 128, 51),
+            new Color(100, 255, 102));
 
     public static final ColorSettings.ColorProperty DARK_RED_COLOR =
-        ColorSettings.define("[proofTree]darkRed", "", new Color(191, 0, 0),
-                new Color(191, 120, 120));
+        ColorSettings.define("[proofTree]darkRed", "",
+            new Color(191, 0, 0),
+            new Color(191, 120, 120));
     /**
      * Color used for linked goals.
      */
     public static final ColorSettings.ColorProperty PINK_COLOR =
         ColorSettings.define("[proofTree]pink", "",
-                new Color(255, 0, 240));
+            new Color(255, 0, 240));
     public static final ColorSettings.ColorProperty ORANGE_COLOR =
         ColorSettings.define("[proofTree]orange", "",
-                new Color(255, 140, 0),
-                new Color(255, 180, 40));
+            new Color(255, 140, 0),
+            new Color(255, 180, 40));
 
     /**
      * KeYStroke for the search panel: STRG+SHIFT+F
@@ -1071,7 +1072,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
         }
 
         public void add(Styler<GUIAbstractTreeNode> guiAbstractTreeNodeStyler) {
-            stylers.add(0, guiAbstractTreeNodeStyler);
+            stylers.addFirst(guiAbstractTreeNodeStyler);
         }
 
         private void render(Style style, GUIAbstractTreeNode node) {
@@ -1176,7 +1177,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
         private void renderNonLeaf(Style style, GUIAbstractTreeNode treeNode) {
             Node node = treeNode.getNode();
-            style.foreground = Color.black;
 
             style.tooltip.addRule(node.getAppliedRuleApp().rule().name().toString());
             PosInOccurrence pio = node.getAppliedRuleApp().posInOccurrence();
@@ -1249,7 +1249,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 if (node.getNodeInfo().getActiveStatement() != null) {
                     style.background = LIGHT_BLUE_COLOR.get();
                 } else {
-                    style.background = Color.white;
+                    // style.background = Color.white;
                 }
             }
         }
@@ -1287,7 +1287,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 setBorder(BorderFactory.createLineBorder(style.border));
             } else {
                 // set default
-                setBorder(BorderFactory.createLineBorder(Color.WHITE));
+                setBorder(BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
             }
 
             setFont(getFont().deriveFont(Font.PLAIN));
@@ -1316,7 +1316,9 @@ public class ProofTreeView extends JPanel implements TabPanel {
             style.tooltip = new Style.Tooltip();
             style.icon = null;
 
-            stylers.forEach(it -> it.style(style, node));
+            for (Styler<GUIAbstractTreeNode> it : stylers) {
+                it.style(style, node);
+            }
             return style;
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -39,6 +39,7 @@ import de.uka.ilkd.key.proof.reference.ClosedBy;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.util.ThreadUtilities;
 
+import org.jspecify.annotations.Nullable;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
@@ -56,31 +57,37 @@ public class ProofTreeView extends JPanel implements TabPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofTreeView.class);
 
     public static final ColorSettings.ColorProperty GRAY_COLOR =
-        ColorSettings.define("[proofTree]gray", "", Color.DARK_GRAY);
+        ColorSettings.define("[proofTree]gray", "", Color.DARK_GRAY, Color.LIGHT_GRAY);
+
     public static final ColorSettings.ColorProperty LIGHT_BLUE_COLOR =
         ColorSettings.define("[proofTree]lightBlue", "", new Color(230, 254, 255));
     /**
      * Color used for closed goals.
      */
     public static final ColorSettings.ColorProperty DARK_GREEN_COLOR =
-        ColorSettings.define("[proofTree]darkGreen", "", new Color(0, 128, 51));
+        ColorSettings.define("[proofTree]darkGreen", "",
+                new Color(0, 128, 51),
+                new Color(100, 255, 102));
+
     public static final ColorSettings.ColorProperty DARK_RED_COLOR =
-        ColorSettings.define("[proofTree]darkRed", "", new Color(191, 0, 0));
+        ColorSettings.define("[proofTree]darkRed", "", new Color(191, 0, 0),
+                new Color(191, 120, 120));
     /**
      * Color used for linked goals.
      */
     public static final ColorSettings.ColorProperty PINK_COLOR =
-        ColorSettings.define("[proofTree]pink", "", new Color(255, 0, 240));
+        ColorSettings.define("[proofTree]pink", "",
+                new Color(255, 0, 240));
     public static final ColorSettings.ColorProperty ORANGE_COLOR =
-        ColorSettings.define("[proofTree]orange", "", new Color(255, 140, 0));
+        ColorSettings.define("[proofTree]orange", "",
+                new Color(255, 140, 0),
+                new Color(255, 180, 40));
 
     /**
      * KeYStroke for the search panel: STRG+SHIFT+F
      */
     public static final KeyStroke SEARCH_KEY_STROKE = KeyStroke.getKeyStroke(KeyEvent.VK_F,
         KeyStrokeManager.MULTI_KEY_MASK);
-
-    private static final long serialVersionUID = 3732875161168302809L;
 
     /**
      * Whether to expand oss nodes when using expand all
@@ -175,10 +182,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
         proofListener = new GUIProofTreeProofListener();
         guiListener = new GUIProofTreeGUIListener();
         delegateView = new JTree(new DefaultMutableTreeNode("No proof loaded")) {
-            private static final long serialVersionUID = 6555955929759162324L;
-
             @Override
-            public String getToolTipText(MouseEvent mouseEvent) {
+            public @Nullable String getToolTipText(MouseEvent mouseEvent) {
                 /*
                  * For performance reasons, we want to make sure that the tooltips are only rendered
                  * when they are really needed. Therefore, they are now lazily generated and can
@@ -1303,8 +1308,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
          */
         public Style initStyleForNode(GUIAbstractTreeNode node) {
             Style style = new Style();
-            style.foreground = getForeground();
-            style.background = getBackground();
+            style.foreground = UIManager.getColor("Label.foreground");
+            style.background = UIManager.getColor("Label.background");
             // Normalize whitespace
             style.text = node.toString().replaceAll("\\s+", " ");
             style.border = null;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -368,7 +368,6 @@ public class ProofTreeView extends JPanel implements TabPanel {
      * layout the component
      */
     protected void layoutKeYComponent() {
-        delegateView.setBackground(Color.white);
         delegateView.setCellRenderer(renderer);
         delegateView.putClientProperty("JTree.lineStyle", "Angled");
         delegateView.setVisible(true);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -12,6 +12,7 @@ import javax.swing.Icon;
 import de.uka.ilkd.key.pp.LogicPrinter;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Alexander Weigl
@@ -22,7 +23,7 @@ public class Style {
     public String text;
 
     /** the tooltip */
-    public Tooltip tooltip;
+    public @Nullable Tooltip tooltip;
 
     /** foreground color of the node */
     public Color foreground;
@@ -31,10 +32,10 @@ public class Style {
     public Color background;
 
     /** border color of the node */
-    public Color border;
+    public @Nullable Color border;
 
     /** icon of the node */
-    public Icon icon;
+    public @Nullable Icon icon;
 
     /** Wrapper class for the tooltip */
     public static class Tooltip {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
@@ -43,6 +43,7 @@ public class SimpleSettingsPanel extends JPanel {
     private static final ColorSettings.ColorProperty COLOR_ERROR =
         ColorSettings.define("SETTINGS_TEXTFIELD_ERROR",
             "Color for marking errornous textfields in settings dialog", new Color(200, 100, 100));
+    public static final String SAVED_BACKGROUND_COLOR = "saved_background_color";
 
     protected final Box pNorth = new Box(BoxLayout.Y_AXIS);
     protected final JPanel pCenter = new JPanel();
@@ -53,7 +54,7 @@ public class SimpleSettingsPanel extends JPanel {
         setLayout(new BorderLayout());
 
         pNorth.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        pNorth.setBackground(Color.WHITE);
+        //pNorth.setBackground(Color.WHITE);
         pNorth.setOpaque(true);
 
         lblHead.setFont(lblHead.getFont().deriveFont(16f).deriveFont(Font.BOLD));
@@ -76,14 +77,14 @@ public class SimpleSettingsPanel extends JPanel {
     }
 
     protected void demarkComponentAsErrornous(JComponent component) {
-        Object col = component.getClientProperty("saved_background_color");
+        Object col = component.getClientProperty(SAVED_BACKGROUND_COLOR);
         if (col instanceof Color) {
             component.setBackground((Color) col);
         }
     }
 
     protected void markComponentAsErrornous(JComponent component, String error) {
-        component.putClientProperty("saved_background_color", component.getBackground());
+        component.putClientProperty(SAVED_BACKGROUND_COLOR, component.getBackground());
         component.setBackground(COLOR_ERROR.get());
         component.setToolTipText(error);
     }
@@ -170,7 +171,7 @@ public class SimpleSettingsPanel extends JPanel {
                 return editor.getTextField().getBackground();
             }
         };
-        spinner.setBackground(Color.WHITE); // without this, the background would be gray ...
+        // spinner.setBackground(Color.WHITE); // without this, the background would be gray ...
         spinner.addChangeListener(new ValidatorSpinnerAdapter<>(spinner, validator));
         return spinner;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/SimpleSettingsPanel.java
@@ -15,7 +15,8 @@ import javax.swing.text.JTextComponent;
 
 import de.uka.ilkd.key.gui.colors.ColorSettings;
 import de.uka.ilkd.key.gui.fonticons.FontAwesomeSolid;
-import de.uka.ilkd.key.gui.fonticons.IconFontSwing;
+import de.uka.ilkd.key.gui.fonticons.IconFontProvider;
+import de.uka.ilkd.key.gui.fonticons.IconProvider;
 
 import org.key_project.util.java.StringUtil;
 
@@ -44,6 +45,8 @@ public class SimpleSettingsPanel extends JPanel {
         ColorSettings.define("SETTINGS_TEXTFIELD_ERROR",
             "Color for marking errornous textfields in settings dialog", new Color(200, 100, 100));
     public static final String SAVED_BACKGROUND_COLOR = "saved_background_color";
+    private static final IconProvider HELP_ICON =
+        new IconFontProvider(FontAwesomeSolid.QUESTION_CIRCLE, Color.black, Color.white);
 
     protected final Box pNorth = new Box(BoxLayout.Y_AXIS);
     protected final JPanel pCenter = new JPanel();
@@ -54,7 +57,7 @@ public class SimpleSettingsPanel extends JPanel {
         setLayout(new BorderLayout());
 
         pNorth.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        //pNorth.setBackground(Color.WHITE);
+        // pNorth.setBackground(Color.WHITE);
         pNorth.setOpaque(true);
 
         lblHead.setFont(lblHead.getFont().deriveFont(16f).deriveFont(Font.BOLD));
@@ -185,8 +188,7 @@ public class SimpleSettingsPanel extends JPanel {
                 + brokenLines.replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>");
         }
 
-        JLabel infoButton =
-            new JLabel(IconFontSwing.buildIcon(FontAwesomeSolid.QUESTION_CIRCLE, 16f));
+        JLabel infoButton = new JLabel(HELP_ICON.get(16f));
         infoButton.setToolTipText(s);
         return infoButton;
     }
@@ -206,8 +208,7 @@ public class SimpleSettingsPanel extends JPanel {
     }
 
     public static JButton createHelpButton(Runnable callback) {
-        var infoButton =
-            new JButton(IconFontSwing.buildIcon(FontAwesomeSolid.QUESTION_CIRCLE, 16f));
+        var infoButton = new JButton(HELP_ICON.get(16f));
         infoButton.setToolTipText("Open online help...");
         infoButton.addActionListener(e -> callback.run());
         return infoButton;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/settings/StandardUISettings.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.settings;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.swing.*;
@@ -15,12 +14,18 @@ import de.uka.ilkd.key.settings.GeneralSettings;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.settings.ViewSettings;
 
+import com.formdev.flatlaf.FlatDarculaLaf;
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatIntelliJLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
+
 /**
  * @author Alexander Weigl
  * @version 1 (10.05.19)
  */
 public class StandardUISettings extends SettingsPanel implements SettingsProvider {
-    private static final long serialVersionUID = -7484169054465984605L;
     private static final String INFO_CLUTTER_RULESET =
         "Comma separated list of rule set names, containing clutter rules.";
     private static final String INFO_CLUTTER_RULE = "Comma separated listof clutter rules, \n"
@@ -29,15 +34,31 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
             Look and feel used by KeY.
             'System' tries to mimic the default looks, 'Metal' is the Java default.
             KeY must be restarted to apply changes.""";
+
+    static {
+        FlatLightLaf.installLafInfo();
+        FlatIntelliJLaf.installLafInfo();
+        FlatMacLightLaf.installLafInfo();
+        FlatDarkLaf.installLafInfo();
+        FlatDarculaLaf.installLafInfo();
+        FlatMacDarkLaf.installLafInfo();
+    }
+
+
     /**
      * Labels for the selectable look and feels. Must be kept in sync with {@link #LAF_CLASSES}.
      */
-    private static final List<String> LAF_LABELS = new ArrayList<>(List.of("Metal"));
+    private static final List<String> LAF_LABELS =
+        Arrays.stream(UIManager.getInstalledLookAndFeels()).map(UIManager.LookAndFeelInfo::getName)
+                .toList();
+
+
     /**
      * Classnames corresponding to the labels in {@link #LAF_LABELS}.
      */
     private static final List<String> LAF_CLASSES =
-        new ArrayList<>(List.of(UIManager.getCrossPlatformLookAndFeelClassName()));
+        Arrays.stream(UIManager.getInstalledLookAndFeels())
+                .map(UIManager.LookAndFeelInfo::getClassName).toList();
 
     private final JComboBox<String> lookAndFeel;
     private final JSpinner spFontSizeGlobal;
@@ -61,16 +82,6 @@ public class StandardUISettings extends SettingsPanel implements SettingsProvide
 
     public StandardUISettings() {
         setHeaderText(getDescription());
-
-        // load all available look and feels
-        if (LAF_LABELS.size() == 1) {
-            for (UIManager.LookAndFeelInfo it : UIManager.getInstalledLookAndFeels()) {
-                if (!LAF_LABELS.contains(it.getName())) {
-                    LAF_LABELS.add(it.getName());
-                    LAF_CLASSES.add(it.getClassName());
-                }
-            }
-        }
 
         addSeparator("General");
         lookAndFeel = createSelection(LAF_LABELS.toArray(new String[0]), emptyValidator());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaDocument.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaDocument.java
@@ -32,25 +32,25 @@ public class JavaDocument extends DefaultStyledDocument {
 
     /** highight color for Java keywords (dark red/violet) */
     private static final ColorSettings.ColorProperty JAVA_KEYWORD_COLOR =
-        ColorSettings.define("[java]keyword", "", new Color(0x7f0055));
-
-    // private static final Color JAVA_STRING_COLOR = new Color(0x000000);
+        ColorSettings.define("[java]keyword", "", new Color(0x7f0055), new Color(0xCf50A5));
 
     /** highight color for comments (dull green) */
     private static final ColorSettings.ColorProperty COMMENT_COLOR =
-        ColorSettings.define("[java]comment", "", new Color(0x3f7f5f));
+        ColorSettings.define("[java]comment", "", new Color(0x3f7f5f),new Color(0x9fBf9f));
 
     /** highight color for JavaDoc (dull green) */
     private static final ColorSettings.ColorProperty JAVADOC_COLOR =
-        ColorSettings.define("[java]javadoc", "", new Color(0x3f7f5f));
+        ColorSettings.define("[java]javadoc", "", new Color(0x3f7f5f), new Color(0x9fBf9f));
 
     /** highight color for JML (dark blue) */
     private static final ColorSettings.ColorProperty JML_COLOR =
-        ColorSettings.define("[java]jml", "", new Color(0x0000c0));
+        ColorSettings.define("[java]jml", "",
+                new Color(0x0000c0),
+                new Color(0x8888cf));
 
     /** highight color for JML keywords (blue) */
     private static final ColorSettings.ColorProperty JML_KEYWORD_COLOR =
-        ColorSettings.define("[java]jmlKeyword", "", new Color(0x0000f0));
+        ColorSettings.define("[java]jmlKeyword", "", new Color(0x0000f0), new Color(0x8888cf));
 
     /**
      * Enum to indicate the current mode (environment) of the parser. Examples are STRING ("..."),

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaDocument.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaDocument.java
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.sourceview;
 
-import java.awt.Color;
+import java.awt.*;
 import java.beans.PropertyChangeListener;
-import java.io.Serial;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.swing.text.*;
 
@@ -24,32 +25,27 @@ import de.uka.ilkd.key.speclang.njml.JmlMarkerDecision;
  * @author Wolfram Pfeifer
  */
 public class JavaDocument extends DefaultStyledDocument {
-
-    @Serial
-    private static final long serialVersionUID = -1856296532743892931L;
-
     // highlighting colors (same as in HTMLSyntaxHighlighter of SequentView for consistency)
-
-    /** highight color for Java keywords (dark red/violet) */
-    private static final ColorSettings.ColorProperty JAVA_KEYWORD_COLOR =
+    /** highlight color for Java keywords (dark red/violet) */
+    public static final ColorSettings.ColorProperty JAVA_KEYWORD_COLOR =
         ColorSettings.define("[java]keyword", "", new Color(0x7f0055), new Color(0xCf50A5));
 
-    /** highight color for comments (dull green) */
-    private static final ColorSettings.ColorProperty COMMENT_COLOR =
-        ColorSettings.define("[java]comment", "", new Color(0x3f7f5f),new Color(0x9fBf9f));
+    /** highlight color for comments (dull green) */
+    public static final ColorSettings.ColorProperty COMMENT_COLOR =
+        ColorSettings.define("[java]comment", "", new Color(0x3f7f5f), new Color(0x9fBf9f));
 
-    /** highight color for JavaDoc (dull green) */
-    private static final ColorSettings.ColorProperty JAVADOC_COLOR =
+    /** highlight color for JavaDoc (dull green) */
+    public static final ColorSettings.ColorProperty JAVADOC_COLOR =
         ColorSettings.define("[java]javadoc", "", new Color(0x3f7f5f), new Color(0x9fBf9f));
 
-    /** highight color for JML (dark blue) */
-    private static final ColorSettings.ColorProperty JML_COLOR =
+    /** highlight color for JML (dark blue) */
+    public static final ColorSettings.ColorProperty JML_COLOR =
         ColorSettings.define("[java]jml", "",
-                new Color(0x0000c0),
-                new Color(0x8888cf));
+            new Color(0x0000c0),
+            new Color(0x8888cf));
 
-    /** highight color for JML keywords (blue) */
-    private static final ColorSettings.ColorProperty JML_KEYWORD_COLOR =
+    /** highlight color for JML keywords (blue) */
+    public static final ColorSettings.ColorProperty JML_KEYWORD_COLOR =
         ColorSettings.define("[java]jmlKeyword", "", new Color(0x0000f0), new Color(0x8888cf));
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaJMLEditorLexer.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/JavaJMLEditorLexer.java
@@ -5,7 +5,6 @@ package de.uka.ilkd.key.gui.sourceview;
 
 import java.awt.*;
 import java.beans.PropertyChangeListener;
-import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -17,6 +16,8 @@ import javax.swing.text.*;
 import de.uka.ilkd.key.gui.colors.ColorSettings;
 import de.uka.ilkd.key.speclang.njml.JmlMarkerDecision;
 
+import static de.uka.ilkd.key.gui.sourceview.JavaDocument.*;
+
 /**
  * This lexer splits a text into tokens with coloured attributes.
  * <p>
@@ -26,34 +27,6 @@ import de.uka.ilkd.key.speclang.njml.JmlMarkerDecision;
  * @author Wolfram Pfeifer, Mattias Ulbrich
  */
 public class JavaJMLEditorLexer implements SourceHighlightDocument.EditorLexer {
-
-    @Serial
-    private static final long serialVersionUID = -1856296532743892931L;
-
-    // highlighting colors (same as in HTMLSyntaxHighlighter of SequentView for consistency)
-
-    /** highight color for Java keywords (dark red/violet) */
-    private static final ColorSettings.ColorProperty JAVA_KEYWORD_COLOR =
-        ColorSettings.define("[java]keyword", "", new Color(0x7f0055));
-
-    // private static final Color JAVA_STRING_COLOR = new Color(0x000000);
-
-    /** highight color for comments (dull green) */
-    private static final ColorSettings.ColorProperty COMMENT_COLOR =
-        ColorSettings.define("[java]comment", "", new Color(0x3f7f5f));
-
-    /** highight color for JavaDoc (dull green) */
-    private static final ColorSettings.ColorProperty JAVADOC_COLOR =
-        ColorSettings.define("[java]javadoc", "", new Color(0x3f7f5f));
-
-    /** highight color for JML (dark blue) */
-    private static final ColorSettings.ColorProperty JML_COLOR =
-        ColorSettings.define("[java]jml", "", new Color(0x0000c0));
-
-    /** highight color for JML keywords (blue) */
-    private static final ColorSettings.ColorProperty JML_KEYWORD_COLOR =
-        ColorSettings.define("[java]jmlKeyword", "", new Color(0x0000f0));
-
     /**
      * Enum to indicate the current mode (environment) of the parser. Examples are STRING ("..."),
      * COMMENT (&#47;&#42; ... &#42;&#47;), JML (&#47;&#42;&#64; ... &#42;&#47; ), ...

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceView.java
@@ -77,8 +77,6 @@ import org.slf4j.LoggerFactory;
 public final class SourceView extends JComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceView.class);
 
-    private static final long serialVersionUID = -94424677425561025L;
-
     /**
      * the only instance of this singleton
      */

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceViewFrame.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/sourceview/SourceViewFrame.java
@@ -20,9 +20,6 @@ import de.uka.ilkd.key.gui.utilities.ClosableTabComponent;
  * @author lanzinger
  */
 public class SourceViewFrame extends JSplitPane {
-
-    private static final long serialVersionUID = 382427737154314400L;
-
     /** The source view contained in this frame. */
     private final SourceView sourceView;
 


### PR DESCRIPTION
This PR brings FlatLAF as the default LaF for KeY, supporting both light/dark modes.  

To make this works, it required cleaning in the current UI code. 

New (old) rules for UI code: 

1. No stupid default colors like `Color.white` or `Color.black` for foreground/background of UI components. Instead, you should use: `UIManager.getColor(...)` to get the appropriate current color. 
2. Every developer-picked color should exist in a dark/light mode variant. 
3. UI code needs to be reactive for LaF changes. Either by listening with a `PropertyChangeListener` on the `ViewSettings` or by overriding `Component#updateUI()`. Later, one is triggered after the LaF is set. 
4. LaF-dependent objects (like colors, icons) should not be final or static.

![image](https://github.com/user-attachments/assets/ad210f46-73a1-4adc-acbd-e563fdad2d1d)

![image](https://github.com/user-attachments/assets/2ad9501b-7564-4121-a36d-f3d2b3234395)

## Plan

* [x] use `SwingUtillities.updateComponentTreeUi` to update the UI after laf switch
* [x] overwrite `Component.updateUI()` if necessary to update the icons. 

* [x] fix settings menu in dark mode:
  
  ![image](https://github.com/user-attachments/assets/cf95aa25-85a4-49ff-9d76-9ddb393da86f)

* [x] Tooltip settings dialog
  
  ![image](https://github.com/user-attachments/assets/3718a929-4a0e-4305-9200-622f7493f898)

* [x] Proof Tree renderer
  
  ![image](https://github.com/user-attachments/assets/33bb3d56-60ef-49d9-8b1a-17755f0f2ab2)


* [x] Testgen window
  
  ![image](https://github.com/user-attachments/assets/a51a093c-992a-49fc-9fd4-3dbb3df35da1)

* [x] Color for syn. highlighting in Source / Sequent view

  ![image](https://github.com/user-attachments/assets/fda49cf0-ea05-40a2-b3f3-c6c8dc695b70)


* [x] Color settings support for light and dark colors.

* Not happened: Detecting the current light/dark mode settings from OS. 
  * This requires: CLI calls for Linux, registry access on Windows using JNA, or native libs on macOS using JFA. There is a library that encapsulates everything but the deps are too strong. 
  

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
  - removal of hard coded colors in some components 
- New feature (non-breaking change which adds functionality)
  - support for dark/light switches (two icon colors, etc.)

## Ensuring quality
- Looking at the UI for a long time.
