### PR TITLE
Fix for a performance regression

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
@@ -126,9 +126,9 @@ public class TacletInstantiationModel {
 
         if (size > 0) {
             ImmutableArray<AssumesFormulaInstantiation> antecCand =
-                AssumesFormulaInstSeq.createList(seq, true);
+                AssumesFormulaInstSeq.createList(seq, true, services);
             ImmutableArray<AssumesFormulaInstantiation> succCand =
-                AssumesFormulaInstSeq.createList(seq, false);
+                AssumesFormulaInstSeq.createList(seq, false, services);
 
             Iterator<SequentFormula> it = ifseq.iterator();
             Term ifFma;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.proof.PrefixTermTacletAppIndexCacheImpl.CacheKey;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.TermTacletAppIndex;
 import de.uka.ilkd.key.proof.TermTacletAppIndexCacheSet;
-import de.uka.ilkd.key.rule.AssumesFormulaInstantiationCache;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Polynomial;
 import de.uka.ilkd.key.strategy.IfInstantiationCachePool;
@@ -24,6 +23,8 @@ import de.uka.ilkd.key.strategy.quantifierHeuristics.TriggersSet;
 
 import org.key_project.logic.op.Operator;
 import org.key_project.logic.sort.Sort;
+import org.key_project.prover.proof.SessionCaches;
+import org.key_project.prover.rules.instantiation.caches.AssumesFormulaInstantiationCache;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.RuleAppCost;
 import org.key_project.util.LRUCache;
@@ -69,7 +70,7 @@ import org.key_project.util.collection.Pair;
  *
  * @author Martin Hentschel
  */
-public class ServiceCaches {
+public class ServiceCaches implements SessionCaches {
     /**
      * The maximal number of index entries in {@link #getTermTacletAppIndexCache()}.
      */
@@ -221,7 +222,7 @@ public class ServiceCaches {
         return ifInstantiationCache;
     }
 
-    public final AssumesFormulaInstantiationCache getIfFormulaInstantiationCache() {
+    public final AssumesFormulaInstantiationCache getAssumesFormulaInstantiationCache() {
         return assumesFormulaInstantiationCache;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -21,6 +21,7 @@ import de.uka.ilkd.key.util.KeYRecoderExcHandler;
 
 import org.key_project.logic.LogicServices;
 import org.key_project.logic.Name;
+import org.key_project.prover.proof.ProofServices;
 import org.key_project.util.lookup.Lookup;
 
 /**
@@ -28,7 +29,7 @@ import org.key_project.util.lookup.Lookup;
  * underlying Java model and a converter to transform Java program elements to logic (where
  * possible) and back.
  */
-public class Services implements TermServices, LogicServices {
+public class Services implements TermServices, LogicServices, ProofServices {
     /**
      * the proof
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -859,8 +859,8 @@ public abstract class TacletApp implements RuleApp {
         return findIfFormulaInstantiationsHelp(
             createSemisequentList(taclet().assumesSequent().succedent()),
             createSemisequentList(taclet().assumesSequent().antecedent()),
-            AssumesFormulaInstSeq.createList(seq, false),
-            AssumesFormulaInstSeq.createList(seq, true),
+            AssumesFormulaInstSeq.createList(seq, false, services),
+            AssumesFormulaInstSeq.createList(seq, true, services),
             ImmutableSLList.nil(), matchConditions(), services);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/AssumesInstantiator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/AssumesInstantiator.java
@@ -73,8 +73,8 @@ public class AssumesInstantiator {
             addResult(tacletAppContainer.getTacletApp());
         } else {
             final Services services = getServices();
-            allAntecFormulas = AssumesFormulaInstSeq.createList(p_seq, true);
-            allSuccFormulas = AssumesFormulaInstSeq.createList(p_seq, false);
+            allAntecFormulas = AssumesFormulaInstSeq.createList(p_seq, true, services);
+            allSuccFormulas = AssumesFormulaInstSeq.createList(p_seq, false, services);
             findIfFormulaInstantiationsHelp(ifSequent.succedent().asList().reverse(), //// Matching
                                                                                       //// with the
                                                                                       //// last

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/proof/ProofServices.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/proof/ProofServices.java
@@ -1,0 +1,16 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.prover.proof;
+
+/**
+ * provides access to services related to proof search
+ */
+public interface ProofServices {
+    /**
+     * provides access to the caching infrastructure of a proof session
+     *
+     * @return the caches used during proof search
+     */
+    SessionCaches getCaches();
+}

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/proof/SessionCaches.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/proof/SessionCaches.java
@@ -1,0 +1,18 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.prover.proof;
+
+import org.key_project.prover.rules.instantiation.caches.AssumesFormulaInstantiationCache;
+
+/**
+ * Provides access to caches used during proof search
+ */
+public interface SessionCaches {
+    /**
+     * returns the cache relevant for matching assumes formulas
+     *
+     * @return the cache relevant for matching assumes formulas
+     */
+    AssumesFormulaInstantiationCache getAssumesFormulaInstantiationCache();
+}

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/rules/instantiation/AssumesFormulaInstSeq.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/rules/instantiation/AssumesFormulaInstSeq.java
@@ -5,6 +5,8 @@ package org.key_project.prover.rules.instantiation;
 
 import org.key_project.logic.LogicServices;
 import org.key_project.logic.PosInTerm;
+import org.key_project.prover.proof.ProofServices;
+import org.key_project.prover.rules.instantiation.caches.AssumesFormulaInstantiationCache;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.Sequent;
@@ -58,15 +60,9 @@ public class AssumesFormulaInstSeq
     /**
      * Create a list with all formulas of a given semi-sequent
      */
-    public static ImmutableArray<AssumesFormulaInstantiation> createList(Sequent p_s,
+    private static ImmutableArray<AssumesFormulaInstantiation> createListHelp(Sequent p_s,
+            Semisequent semi,
             boolean inAntecedent) {
-        Semisequent semi;
-        if (inAntecedent) {
-            semi = p_s.antecedent();
-        } else {
-            semi = p_s.succedent();
-        }
-
         final AssumesFormulaInstSeq[] assumesInstFromSeq =
             new AssumesFormulaInstSeq[semi.size()];
         int i = assumesInstFromSeq.length - 1;
@@ -77,6 +73,26 @@ public class AssumesFormulaInstSeq
         }
 
         return new ImmutableArray<>(assumesInstFromSeq);
+    }
+
+    /**
+     * Retrieves a list with all formulas of a given semi-sequent
+     */
+    public static ImmutableArray<AssumesFormulaInstantiation> createList(Sequent p_s,
+            boolean inAntecedent,
+            ProofServices services) {
+        final AssumesFormulaInstantiationCache cache =
+            services.getCaches().getAssumesFormulaInstantiationCache();
+        final Semisequent semi = inAntecedent ? p_s.antecedent() : p_s.succedent();
+
+        ImmutableArray<AssumesFormulaInstantiation> val = cache.get(inAntecedent, semi);
+
+        if (val == null) {
+            val = createListHelp(p_s, semi, inAntecedent);
+            cache.put(inAntecedent, semi, val);
+        }
+
+        return val;
     }
 
     @Override

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/rules/instantiation/caches/AssumesFormulaInstantiationCache.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/rules/instantiation/caches/AssumesFormulaInstantiationCache.java
@@ -1,7 +1,7 @@
 /* This file is part of KeY - https://key-project.org
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
-package de.uka.ilkd.key.rule;
+package org.key_project.prover.rules.instantiation.caches;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;


### PR DESCRIPTION
When merging the ncore refactoring for generalizing the taclet and prover core structure, we lost access to a cache which speeds up matching of assumes sequents.

In numbers:
Problem PUZ047p1.key (without cache: ca. 1700s)
Problem PUZ047p1.key (with cache: ca. 630s)

<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Fixes a performance regression introduced when generalizing the prover engine and taclet infrastructure

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the Java Code

## Ensuring quality

    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: run test with PUZ047p1 to ensure that performance is back to previous levels
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
