### PR TITLE
Fix exception in javac extension

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavaCompilerCheckFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavaCompilerCheckFacade.java
@@ -126,8 +126,10 @@ public class JavaCompilerCheckFacade {
                     it.getMessage(Locale.ENGLISH),
                     new Location(
                         fileManager.asPath(it.getSource()).toFile().toPath().toUri(),
-                        Position.newOneBased((int) it.getLineNumber(),
-                            (int) it.getColumnNumber())),
+                        it.getPosition() != Diagnostic.NOPOS
+                                ? Position.newOneBased((int) it.getLineNumber(),
+                                    (int) it.getColumnNumber())
+                                : Position.UNDEFINED),
                     it.getCode() + " " + it.getKind()))
                     .collect(Collectors.toList());
         });


### PR DESCRIPTION
This issue caused the UI to not update when loading a new Java file that causes warnings like
"Some input files use unchecked or unsafe operations."

```
Caused by: java.lang.IllegalArgumentException: -1, -1
        at de.uka.ilkd.key.java.Position.<init>(Position.java:48)
        at de.uka.ilkd.key.java.Position.newOneBased(Position.java:61)
        at de.uka.ilkd.key.gui.plugins.javac.JavaCompilerCheckFacade.lambda$check$2(JavaCompilerCheckFacade.java:129)
        ...
        at de.uka.ilkd.key.gui.plugins.javac.JavaCompilerCheckFacade.lambda$check$3(JavaCompilerCheckFacade.java:132)
```

## Related Issue

did not bother to open issue

## Intended Change

Fixes javac extension behavior when loading files that use generic types in unsafe ways. This is actually extremely common when using KeY.

## Type of pull request

Bugfix

## Ensuring quality

I have tested the feature as follows: loaded Java file that uses unchecked generics.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.