### PR TITLE
Fix graphviz configuration of slicing extension

### DIFF
--- a/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettings.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/SlicingSettings.java
@@ -46,7 +46,7 @@ public class SlicingSettings extends AbstractPropertiesSettings {
      * Path to dot executable config key.
      */
     private final PropertyEntry<String> dotExecutable =
-        createStringProperty(KEY_DOT_EXECUTABLE, null);
+        createStringProperty(KEY_DOT_EXECUTABLE, "");
 
     /**
      * Override map for aggressive deduplication config.
@@ -100,7 +100,7 @@ public class SlicingSettings extends AbstractPropertiesSettings {
      */
     public String getDotExecutable() {
         String path = dotExecutable.get();
-        if (path != null) {
+        if (path != null && !path.isBlank()) {
             return path;
         }
         if (System.getProperty("os.name").startsWith("Windows")) {

--- a/keyext.slicing/src/main/java/org/key_project/slicing/ui/SlicingLeftPanel.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/ui/SlicingLeftPanel.java
@@ -588,8 +588,10 @@ public class SlicingLeftPanel extends JPanel implements TabPanel, KeYSelectionLi
         } else {
             dotExport.setEnabled(true);
             dotExport.setToolTipText(null);
-            showGraphRendering.setEnabled(true);
-            showGraphRendering.setToolTipText(null);
+            if (GraphvizDotExecutor.isDotInstalled()) {
+                showGraphRendering.setEnabled(true);
+                showGraphRendering.setToolTipText(null);
+            }
             boolean algoSelectionSane = doDependencyAnalysis.isSelected()
                     || doDeduplicateRuleApps.isSelected();
             runAnalysis.setEnabled(algoSelectionSane);

--- a/keyext.slicing/src/main/java/org/key_project/slicing/util/GraphvizDotExecutor.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/util/GraphvizDotExecutor.java
@@ -74,6 +74,9 @@ public class GraphvizDotExecutor extends SwingWorker<GraphvizResult, Void> {
     }
 
     private static boolean checkDotExecutable(String executableName) {
+        if (executableName.isBlank()) {
+            return false;
+        }
         try {
             Process process = new ProcessBuilder(executableName, "-V").start();
             if (process.waitFor() == 0) {


### PR DESCRIPTION
Multiple issues had to be fixed:

1. Avoid using null as default value for the path setting. This no longer works properly.
2. Only enable render button if graphviz is installed.

## Related Issue

did not bother to open an issue

## Intended Change

See above.
Note this change doesn't fix existing broken configurations that now have "null" configured as dot executable..

## Type of pull request

Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

I have tested the feature as follows: the graphviz renderer now works as expected.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.