### PR TITLE
fix testMakeFilenameRelativeWindows

### DIFF
--- a/key.core/src/test/java/de/uka/ilkd/key/util/TestMiscTools.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/TestMiscTools.java
@@ -70,14 +70,9 @@ public class TestMiscTools {
         String u = MiscTools.makeFilenameRelative(s, t);
         assertEquals("Windows", u);
         // do stupid things
-        try {
-            t = File.separator + "home" + File.separator + "daniel";
-            u = MiscTools.makeFilenameRelative(s, t);
-            fail();
-        } catch (RuntimeException e) {
-            assertTrue(true);
-        }
-
+        t = File.separator + "home" + File.separator + "daniel";
+        u = MiscTools.makeFilenameRelative(s, t);
+        assertEquals("..\\..\\Windows", u);
     }
 
     @Test


### PR DESCRIPTION
Fixes the wrong test case `testMakeFilenameRelativeWindows`. 

The path `/home/daniel/` is valid on Windows, but the old implementation failed. 
