### PR TITLE
Test if matrix over modules are a good thing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -59,6 +59,8 @@ This pull request resolves #.
 - I added new test case(s) for new functionality.
 - I have tested the feature as follows: ...
 - I have checked that runtime performance has not deteriorated.
+- For new Gradle modules: I added the Gradle module to the test matrix in
+  `.github/workflows/tests.yml`
 
 ## Additional information and contact(s)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         modules: [
           keyext.exploration, keyext.slicing, key.ncore, key.ui, key.core, key.core.rifl,
           key.core.testgen, keyext.isabelletranslation,  keyext.ui.testgen,  key.ncore.calculus,
-          key.util, key.core.example,  key.core.symbolic_execution, keyext.caching,
+          key.util, key.core.example, keyext.caching,
           keyext.proofmanagement, key.removegenerics ]
     continue-on-error: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - "main"
       - "KeY-*"
   merge_group:
-  
+
 permissions:
   contents: write
   issues: write
@@ -22,8 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        java: [21]
+        os: [ ubuntu-latest, windows-latest ]
+        java: [ 21 ]
+        modules: [
+          keyext.exploration, keyext.slicing, key.ncore, key.ui, key.core, key.core.rifl,
+          key.core.testgen, keyext.isabelletranslation,  keyext.ui.testgen,  key.ncore.calculus,
+          key.util, key.core.example,  key.core.symbolic_execution, keyext.caching,
+          keyext.proofmanagement, key.removegenerics ]
     continue-on-error: true
     runs-on: ${{ matrix.os }}
     env:
@@ -53,18 +58,18 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Test with Gradle
-        run: ./gradlew --continue -DjacocoEnabled=true -x :key.core.symbolic_execution:test -x :key.core.proof_references:test test
+        run: ./gradlew --continue -DjacocoEnabled=true :${{ matrix.modules }}:test
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results-${{ matrix.os }}
+          name: test-results-${{ matrix.os }}-${{ matrix.modules }}
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/
             !**/jacocoTestReport.xml
-          
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
 
@@ -75,9 +80,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [testProveRules, testRunAllFunProofs, testRunAllInfProofs]
-        os: [ubuntu-latest]
-        java: [21]
+        test: [ testProveRules, testRunAllFunProofs, testRunAllInfProofs ]
+        os: [ ubuntu-latest ]
+        java: [ 21 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Related Issue

None

## Intended Change

Small change to the GitHub workflow for unit testing. Now, the test matrix is also over each individual module. Therefore, each module is tested separately. 

### Advantages: 

* Easier to spot individual failing modules
* More things in parallel lead to faster failures
* Fine-grained download of individual reports for each module. 

### Disadvantages: 

* Higher CPU usage: KeY is compiled more often 
  (Note: artefact sharing between jobs (upload+download) was slower.)

**Do we want this?** 

## Plan

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the deployment/CI infrastructure: Github test matrix

## Ensuring quality  
- I have tested the feature as follows using the CI.
