### PR TITLE
Remove unnecessary (and harmful) license plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,6 @@ plugins {
     //https://docs.gradle.org/current/userguide/eclipse_plugin.html
     id("eclipse")  //support for Eclipse
 
-    //Checks and adds the license header of the source files:
-    // Task: `licenseMain' and `licenseFormatMain'
-    //https://github.com/hierynomus/license-gradle-plugin
-    id "com.github.hierynomus.license-base" version "0.16.1"
-    //Generates reports on the license of used packages: Task `downloadLicenses'
-    //Some Licenses requires an entry in the credits (MIT, BSD)
-    id "com.github.hierynomus.license-report" version "0.16.1"
-
     // Gives `gradle dependencyUpdate` to show which dependency has a newer version
     // id "com.github.ben-manes.versions" version "0.39.0"
 
@@ -295,18 +287,6 @@ subprojects {
         description = 'Create a jar file with the javadocs from this project'
         from javadoc
         archiveClassifier = 'javadoc'
-    }
-
-    license {//configures the license file header
-        header = file("$rootDir/gradle/header")
-
-        mapping {
-            //find styles here:
-            // http://code.mycila.com/license-maven-plugin/#supported-comment-types
-            java = "SLASHSTAR_STYLE" // DOUBLESLASH_STYLE
-            javascript = "SLASHSTAR_STYLE"
-        }
-        mapping("key", "SLASHSTAR_STYLE")
     }
 
     eclipse { //configures the generated .project and .classpath files.


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->
Currently, we have a `license-gradle-plugin`, which can add license headers to files and report licenses of our dependencies.

However, it is also the source of a large chunk of our security issues and does nothing for us. Headers are added by spotless and the reports are always empty on my machine. So this PR removes it.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- There are changes to the deployment/CI infrastructure (gradle)

## Ensuring quality

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
