### PR TITLE
Disable relative path test on Windows 

### DIFF
--- a/key.core/src/test/java/de/uka/ilkd/key/util/TestMiscTools.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/TestMiscTools.java
@@ -23,6 +23,7 @@ import de.uka.ilkd.key.java.recoderext.URLDataLocation;
 
 import org.key_project.util.java.IOUtil;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import recoder.io.ArchiveDataLocation;
 import recoder.io.DataFileLocation;
@@ -58,6 +59,8 @@ public class TestMiscTools {
     }
 
     @Test
+    @Disabled("weigl: Disabled b/c failing on Windows Server (Github Action). " +
+        "Failing is not  reproducible on Windows.")
     public void testMakeFilenameRelativeWindows() {
         // run only on Windows systems
         if (File.separatorChar != '\\') {


### PR DESCRIPTION
Disables `#testMakeFilenameRelativeWindows` because it is failing on Windows Server (GitHub Action). Failing is not  reproducible on Windows.

