### PR TITLE
Fix deprecations in build files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ subprojects {
         }
     }
 
-    task testFast(type: Test) {
+    tasks.register('testFast', Test) {
         group = "verification"
         useJUnitPlatform {
             excludeTags "slow", "performance", "interactive"
@@ -196,14 +196,14 @@ subprojects {
     // The following two tasks can be used to execute main methods from the project
     // The main class is set via "gradle -DmainClass=... execute --args ..."
     // see https://stackoverflow.com/questions/21358466/gradle-to-execute-java-class-without-modifying-build-gradle
-    task execute(type: JavaExec) {
+    tasks.register('execute', JavaExec) {
         description = 'Execute main method from the project. Set main class via "gradle -DmainClass=... execute --args ..."'
         group = "application"
         mainClass.set(System.getProperty('mainClass'))
         classpath = sourceSets.main.runtimeClasspath
     }
 
-    task executeInTests(type: JavaExec) {
+    tasks.register('executeInTests', JavaExec) {
         description = 'Execute main method from the project (tests loaded). Set main class via "gradle -DmainClass=... execute --args ..."'
         group = "application"
         mainClass.set(System.getProperty('mainClass'))
@@ -220,7 +220,7 @@ subprojects {
         ruleSets = ["category/java/errorprone.xml", "category/java/bestpractices.xml"]
     }
 
-    task pmdMainChanged(type: Pmd) {
+    tasks.register('pmdMainChanged', Pmd) {
         // Specify all files that should be checked
         def changedFiles = getChangedFiles()
         source pmdMain.source.filter { f -> f.getAbsoluteFile().toString() in changedFiles }
@@ -246,7 +246,7 @@ subprojects {
     }
 
 
-    task checkstyleMainChanged(type: Checkstyle) {
+    tasks.register('checkstyleMainChanged', Checkstyle) {
         // Specify all files that should be checked
         def changedFiles = getChangedFiles()
         source checkstyleMain.source.filter { f -> f.getAbsoluteFile().toString() in changedFiles }
@@ -281,13 +281,13 @@ subprojects {
         }
     }
 
-    task sourcesJar(type: Jar) {
+    tasks.register('sourcesJar', Jar) {
         description = 'Create a jar file with the sources from this project'
         from sourceSets.main.allJava
         archiveClassifier = 'sources'
     }
 
-    task javadocJar(type: Jar) {
+    tasks.register('javadocJar', Jar) {
         description = 'Create a jar file with the javadocs from this project'
         from javadoc
         archiveClassifier = 'javadoc'
@@ -480,7 +480,7 @@ subprojects {
     }
 }
 
-task start {
+tasks.register('start'){
     description = "Use :key.ui:run instead"
     doFirst {
         println "Use :key.ui:run instead"
@@ -488,7 +488,7 @@ task start {
 }
 
 // Generation of a JavaDoc across sub projects.
-task alldoc(type: Javadoc) {
+tasks.register('alldoc', Javadoc){
     group = "documentation"
     description = "Generate a JavaDoc across sub projects"
     def projects = subprojects
@@ -520,7 +520,7 @@ task alldoc(type: Javadoc) {
 }
 
 // Creates a jar file with the javadoc over all sub projects.
-task alldocJar(type: Zip) {
+tasks.register('alldocJar', Zip){
     dependsOn alldoc
     description = 'Create a jar file with the javadoc over all sub projects'
     from alldoc

--- a/build.gradle
+++ b/build.gradle
@@ -126,11 +126,15 @@ subprojects {
     }
 
     tasks.withType(Test) {//Configure all tests
+
+        def examplesDir = rootProject.layout.projectDirectory.dir("key.ui/examples").getAsFile()
+        def runAllProofsReportDir = layout.buildDirectory.dir("report/runallproves/").get().getAsFile()
+
         systemProperty "test-resources", "src/test/resources"
         systemProperty "testcases", "src/test/resources/testcase"
         systemProperty "TACLET_PROOFS", "tacletProofs"
-        systemProperty "EXAMPLES_DIR", file("$rootProject/key.ui/examples")
-        systemProperty "RUNALLPROOFS_DIR", "$buildDir/report/runallproves"
+        systemProperty "EXAMPLES_DIR", "$examplesDir"
+        systemProperty "RUNALLPROOFS_DIR", "$runAllProofsReportDir"
 
         systemProperty "key.disregardSettings", "true"
         maxHeapSize = "4g"
@@ -491,7 +495,7 @@ task alldoc(type: Javadoc) {
     //key.ui javadoc is broken
     source projects.collect { it.sourceSets.main.allJava }
     classpath = files(projects.collect { it.sourceSets.main.compileClasspath })
-    destinationDir = file("${buildDir}/docs/javadoc")
+    destinationDir = layout.buildDirectory.dir("docs/javadoc").getOrNull().getAsFile()
 
     if (JavaVersion.current().isJava9Compatible()) {
         //notworking on jenkins
@@ -521,7 +525,7 @@ task alldocJar(type: Zip) {
     description = 'Create a jar file with the javadoc over all sub projects'
     from alldoc
     archiveFileName = "key-api-doc-${project.version}.zip"
-    destinationDirectory = file("$buildDir/distribution")
+    destinationDirectory = layout.buildDirectory.dir("distribution").getOrNull()
 }
 
 //conditionally enable jacoco coverage when `-DjacocoEnabled=true` is given on CLI.

--- a/key.core/build.gradle
+++ b/key.core/build.gradle
@@ -52,7 +52,7 @@ compileJavacc {
     }
 }
 
-task generateSMTListings {
+tasks.register('generateSMTListings') {
     def pack = "de/uka/ilkd/key/smt/newsmt2"
     def resourcesDir = "${project.projectDir}/src/main/resources"
     def outputDir = resourcesDir // in the future that should be "${project.buildDir}/resources/main"
@@ -77,7 +77,7 @@ task generateSMTListings {
     }
 }
 
-task generateSolverPropsList {
+tasks.register('generateSolverPropsList') {
     def pack = "de/uka/ilkd/key/smt/solvertypes"
     def resourcesDir = "${project.projectDir}/src/main/resources"
     def outputDir = resourcesDir // in the future that should be "${project.buildDir}/resources/main"
@@ -114,14 +114,14 @@ tasks.withType(Test) {
 }
 
 
-task testProveRules(type: Test) {
+tasks.register('testProveRules', Test) {
     description = 'Proves KeY taclet rules tagged as lemma'
     group = "verification"
     filter { includeTestsMatching "ProveRulesTest" }
     //useJUnitPlatform() {includeTags "testProveRules"    }
 }
 
-task testRunAllFunProofs(type: Test) {
+tasks.register('testRunAllFunProofs', Test) {
     description = 'Prove/reload all keyfiles tagged for regression testing'
     group = "verification"
     filter {
@@ -129,7 +129,7 @@ task testRunAllFunProofs(type: Test) {
     }
 }
 
-task testRunAllInfProofs(type: Test) {
+tasks.register('testRunAllInfProofs', Test) {
     description = 'Prove/reload all keyfiles tagged for regression testing'
     group = "verification"
     filter {
@@ -138,7 +138,7 @@ task testRunAllInfProofs(type: Test) {
 }
 
 
-task testProveSMTLemmas(type: Test) {
+tasks.register('testProveSMTLemmas', Test) {
     description = 'Prove (or load proofs for) lemmas used in the SMT translation'
     group = "verification"
     filter {
@@ -148,7 +148,7 @@ task testProveSMTLemmas(type: Test) {
 
 // Run the tests for the new smt translation in strict mode
 // where "unknown" is less accepted
-task testStrictSMT(type: Test) {
+tasks.register('testStrictSMT', Test) {
     description = 'Run the tests for the new smt translation in strict mode'
     group = 'verification'
     systemProperty("key.newsmt2.stricttests", "true")
@@ -158,7 +158,7 @@ task testStrictSMT(type: Test) {
 }
 
 //Generation of the three version files within the resources by executing `git'.
-task generateVersionFiles() {
+tasks.register('generateVersionFiles') {
     def outputFolder = file("build/resources/main/de/uka/ilkd/key/util")
     def sha1 = new File(outputFolder, "sha1")
     def branch = new File(outputFolder, "branch")
@@ -191,7 +191,7 @@ static def gitRevParse(String args) {
 processResources.dependsOn generateVersionFiles, generateSolverPropsList, generateSMTListings
 
 def antlr4OutputKey = "$projectDir/build/generated-src/antlr4/main/de/uka/ilkd/key/nparser"
-task runAntlr4Key(type: JavaExec) {
+tasks.register('runAntlr4Key', JavaExec) {
     //see incremental task api, prevents rerun if nothing has changed.
     inputs.files "src/main/antlr4/KeYLexer.g4", "src/main/antlr4/KeYParser.g4"
     outputs.dir antlr4OutputKey
@@ -208,7 +208,7 @@ task runAntlr4Key(type: JavaExec) {
 }
 compileJava.dependsOn runAntlr4Key
 
-task debugKeyLexer(type: JavaExec) {
+tasks.register('debugKeyLexer', JavaExec) {
     mainClass.set("de.uka.ilkd.key.nparser.DebugKeyLexer")
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -218,7 +218,7 @@ task debugKeyLexer(type: JavaExec) {
 processResources.dependsOn generateVersionFiles
 
 def antlr4OutputJml = "$projectDir/build/generated-src/antlr4/main/de/uka/ilkd/key/speclang/njml"
-task runAntlr4Jml(type: JavaExec) {
+tasks.register('runAntlr4Jml', JavaExec) {
     //see incremental task api, prevents rerun if nothing has changed.
     inputs.files "src/main/antlr4/JmlLexer.g4", "src/main/antlr4/JmlParser.g4"
     outputs.dir antlr4OutputJml
@@ -235,17 +235,17 @@ task runAntlr4Jml(type: JavaExec) {
 }
 compileJava.dependsOn runAntlr4Jml
 
-task debugJmlLexer(type: JavaExec) {
+tasks.register('debugJmlLexer', JavaExec) {
     mainClass.set("de.uka.ilkd.key.speclang.njml.DebugJmlLexer")
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
 }
 
-task ptest(type: Test) { group = "verification" }
+tasks.register('ptest', Test) { group = "verification" }
 
 def rapDir = layout.buildDirectory.dir("generated-src/rap/").getOrNull()
 
-task generateRAPUnitTests(type: JavaExec) {
+tasks.register('generateRAPUnitTests', JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     mainClass.set("de.uka.ilkd.key.proof.runallproofs.GenerateUnitTests")
     args(rapDir)

--- a/key.core/build.gradle
+++ b/key.core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 }
 
 // The target directory for JavaCC (parser generation)
-def javaCCOutputDir = file("${buildDir}/generated-src/javacc")
+def javaCCOutputDir = layout.buildDirectory.dir("generated-src/javacc").getOrNull()
 def javaCCOutputDirMain = file("$javaCCOutputDir/main")
 
 sourceSets.main.java.srcDirs(javaCCOutputDirMain, "$projectDir/build/generated-src/antlr4/main/")
@@ -243,11 +243,14 @@ task debugJmlLexer(type: JavaExec) {
 
 task ptest(type: Test) { group = "verification" }
 
+def rapDir = layout.buildDirectory.dir("generated-src/rap/").getOrNull()
+
 task generateRAPUnitTests(type: JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     mainClass.set("de.uka.ilkd.key.proof.runallproofs.GenerateUnitTests")
-    args("$buildDir/generated-src/rap/")
+    args(rapDir)
 }
-sourceSets.test.java.srcDirs("$buildDir/generated-src/rap/")
+
+sourceSets.test.java.srcDirs(rapDir)
 
 sourcesJar.dependsOn(runAntlr4Jml, runAntlr4Key, compileJavacc)

--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
 task createExamplesZip(type: Zip) {
     description = 'Create "examples.zip" containing all KeY examples'
-    destinationDirectory = file("$buildDir/resources/main/")
+    destinationDirectory = layout.buildDirectory.dir("resources/main/").getOrNull()
     archiveFileName = "examples.zip"
     from "examples"
     include scanReadmeFiles()  // see end of file

--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     runtimeOnly project(":keyext.isabelletranslation")
 }
 
-task createExamplesZip(type: Zip) {
+tasks.register('createExamplesZip', Zip) {
     description = 'Create "examples.zip" containing all KeY examples'
     destinationDirectory = layout.buildDirectory.dir("resources/main/").getOrNull()
     archiveFileName = "examples.zip"
@@ -74,7 +74,7 @@ run {
     jvmArgs += "-Dsun.awt.disablegrab=true"
 }
 
-task runWithProfiler(type: JavaExec) {
+tasks.register('runWithProfiler', JavaExec) {
     group = "application"
     description = """Run key.ui with flight recoder enabled. 
                    See https://www.baeldung.com/java-flight-recorder-monitoring for a how to."""

--- a/scripts/jacocokey.gradle
+++ b/scripts/jacocokey.gradle
@@ -23,7 +23,7 @@ subprojects {
     testFast {
         finalizedBy jacocoTestReport
         jacoco {
-            destinationFile = file("$buildDir/jacoco/test.exec")
+            destinationFile = layout.buildDirectory.dir("jacoco/test.exec").get().getAsFile()
         }
     }
 }


### PR DESCRIPTION
- **Remove deprecated use of $buildDir**
- **fix depracted use of task**

## Intended Change

Remove usage of deprecated API from gradle build files

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- There are changes to the deployment/CI infrastructure (gradle, github, ...)

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: build key, rap and docs with gradle successfully; could not test jacoco 


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
