### PR TITLE
Higher Order Proof Scripts

### DIFF
--- a/key.core/src/main/antlr4/KeYParser.g4
+++ b/key.core/src/main/antlr4/KeYParser.g4
@@ -5,7 +5,6 @@ parser grammar KeYParser;
 }
 
 @members {
-private boolean lastPosArgWasCodeBlock=false;
 private SyntaxErrorReporter errorReporter = new SyntaxErrorReporter(getClass());
 public SyntaxErrorReporter getErrorReporter() { return errorReporter;}
 }
@@ -864,8 +863,6 @@ proofScriptEntry
 proofScriptEOF: proofScript EOF;
 proofScript: proofScriptCommand+;
 proofScriptCommand: cmd=IDENT proofScriptParameters? SEMI;
-//	( {lastPosArgWasCodeBlock}? SEMI?
-//	| SEMI);
 
 proofScriptParameters: proofScriptParameter+;
 proofScriptParameter :  ((pname=proofScriptParameterName (COLON|EQUALS))? expr=proofScriptExpression);

--- a/key.core/src/main/antlr4/KeYParser.g4
+++ b/key.core/src/main/antlr4/KeYParser.g4
@@ -5,6 +5,7 @@ parser grammar KeYParser;
 }
 
 @members {
+private boolean lastPosArgWasCodeBlock=false;
 private SyntaxErrorReporter errorReporter = new SyntaxErrorReporter(getClass());
 public SyntaxErrorReporter getErrorReporter() { return errorReporter;}
 }
@@ -859,16 +860,18 @@ proofScriptEntry
     | LBRACE proofScript RBRACE
     )
 ;
+
 proofScriptEOF: proofScript EOF;
 proofScript: proofScriptCommand+;
-proofScriptCommand: cmd=IDENT proofScriptParameters?
-	( LBRACE sub=proofScript RBRACE SEMI?
-	| SEMI);
+proofScriptCommand: cmd=IDENT proofScriptParameters? SEMI;
+//	( {lastPosArgWasCodeBlock}? SEMI?
+//	| SEMI);
 
 proofScriptParameters: proofScriptParameter+;
 proofScriptParameter :  ((pname=proofScriptParameterName (COLON|EQUALS))? expr=proofScriptExpression);
 proofScriptParameterName: AT? IDENT; // someone thought, that the let-command parameters should have a leading "@"
 proofScriptExpression:
+//  {lastPosArgWasCodeBlock=false;}
     boolean_literal
   | char_literal
   | integer
@@ -878,8 +881,10 @@ proofScriptExpression:
   | simple_ident
   | abbreviation
   | literals
+  | proofScriptCodeBlock
   ;
 
+proofScriptCodeBlock: LBRACE proofScript RBRACE;
 
 // PROOF
 proof: PROOF EOF;

--- a/key.core/src/main/antlr4/KeYParser.g4
+++ b/key.core/src/main/antlr4/KeYParser.g4
@@ -861,14 +861,13 @@ proofScriptEntry
 ;
 
 proofScriptEOF: proofScript EOF;
-proofScript: proofScriptCommand+;
-proofScriptCommand: cmd=IDENT proofScriptParameters? SEMI;
+proofScript: proofScriptCommand*;
+proofScriptCommand: cmd=IDENT proofScriptParameters SEMI;
 
-proofScriptParameters: proofScriptParameter+;
+proofScriptParameters: proofScriptParameter*;
 proofScriptParameter :  ((pname=proofScriptParameterName (COLON|EQUALS))? expr=proofScriptExpression);
 proofScriptParameterName: AT? IDENT; // someone thought, that the let-command parameters should have a leading "@"
 proofScriptExpression:
-//  {lastPosArgWasCodeBlock=false;}
     boolean_literal
   | char_literal
   | integer

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -17,6 +17,7 @@ import de.uka.ilkd.key.nparser.builder.FindProblemInformation;
 import de.uka.ilkd.key.nparser.builder.IncludeFinder;
 import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.init.Includes;
+import de.uka.ilkd.key.scripts.ScriptBlock;
 import de.uka.ilkd.key.scripts.ScriptCommandAst;
 import de.uka.ilkd.key.settings.Configuration;
 import de.uka.ilkd.key.settings.ProofSettings;
@@ -253,7 +254,11 @@ public abstract class KeyAst<T extends ParserRuleContext> {
         }
 
         public URI getUri() {
-            final var sourceName = ctx.start.getTokenSource().getSourceName();
+            return getUri(ctx.start);
+        }
+
+        public static URI getUri(Token token) {
+            final var sourceName = token.getTokenSource().getSourceName();
             try {
                 if (sourceName.startsWith("file:") || sourceName.startsWith("http:")
                         || sourceName.startsWith("jar:"))
@@ -273,31 +278,41 @@ public abstract class KeyAst<T extends ParserRuleContext> {
             return asAst(fileUri, ctx.proofScriptCommand());
         }
 
-        private List<ScriptCommandAst> asAst(URI file,
+        private static List<ScriptCommandAst> asAst(URI file,
                 List<KeYParser.ProofScriptCommandContext> cmds) {
             return cmds.stream().map(it -> asAst(file, it)).toList();
         }
 
-        private @NonNull ScriptCommandAst asAst(URI file, KeYParser.ProofScriptCommandContext it) {
-            var loc = new Location(file, Position.fromToken(it.start));
-            var sub = it.sub != null
-                    ? asAst(file, it.sub.proofScriptCommand())
-                    : null;
+        public static @NonNull ScriptBlock asAst(URI file, KeYParser.ProofScriptCodeBlockContext ctx) {
+            var loc = new Location(file, Position.fromToken(ctx.start));
+            return new ScriptBlock(
+                    ctx.proofScript().proofScriptCommand().stream()
+                    .map(it -> asAst(file, it))
+                    .toList(), loc);
+        }
 
+        private static @NonNull ScriptCommandAst asAst(URI file, KeYParser.ProofScriptCommandContext it) {
+            var loc = new Location(file, Position.fromToken(it.start));
             var nargs = new HashMap<String, Object>();
             var pargs = new ArrayList<>();
 
             if (it.proofScriptParameters() != null) {
                 for (var param : it.proofScriptParameters().proofScriptParameter()) {
+                    var expr = param.expr;
+                    Object value = expr;
+                    if(expr.proofScriptCodeBlock() != null) {
+                        value = asAst(file, expr.proofScriptCodeBlock());
+                    }
+
                     if (param.pname != null) {
-                        nargs.put(param.pname.getText(), param.expr);
+                        nargs.put(param.pname.getText(), value);
                     } else {
-                        pargs.add(param.expr);
+                        pargs.add(value);
                     }
                 }
             }
 
-            return new ScriptCommandAst(it.cmd.getText(), nargs, pargs, sub, loc);
+            return new ScriptCommandAst(it.cmd.getText(), nargs, pargs, loc);
         }
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -286,11 +286,12 @@ public abstract class KeyAst<T extends ParserRuleContext> {
         public static @NonNull ScriptBlock asAst(URI file,
                 KeYParser.ProofScriptCodeBlockContext ctx) {
             var loc = new Location(file, Position.fromToken(ctx.start));
-            return new ScriptBlock(
-                ctx.proofScript().proofScriptCommand().stream()
+            final var proofScriptCommandContexts = ctx.proofScript().proofScriptCommand();
+            final List<ScriptCommandAst> list =
+                proofScriptCommandContexts.stream()
                         .map(it -> asAst(file, it))
-                        .toList(),
-                loc);
+                        .toList();
+            return new ScriptBlock(list, loc);
         }
 
         private static @NonNull ScriptCommandAst asAst(URI file,

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -283,15 +283,18 @@ public abstract class KeyAst<T extends ParserRuleContext> {
             return cmds.stream().map(it -> asAst(file, it)).toList();
         }
 
-        public static @NonNull ScriptBlock asAst(URI file, KeYParser.ProofScriptCodeBlockContext ctx) {
+        public static @NonNull ScriptBlock asAst(URI file,
+                KeYParser.ProofScriptCodeBlockContext ctx) {
             var loc = new Location(file, Position.fromToken(ctx.start));
             return new ScriptBlock(
-                    ctx.proofScript().proofScriptCommand().stream()
-                    .map(it -> asAst(file, it))
-                    .toList(), loc);
+                ctx.proofScript().proofScriptCommand().stream()
+                        .map(it -> asAst(file, it))
+                        .toList(),
+                loc);
         }
 
-        private static @NonNull ScriptCommandAst asAst(URI file, KeYParser.ProofScriptCommandContext it) {
+        private static @NonNull ScriptCommandAst asAst(URI file,
+                KeYParser.ProofScriptCommandContext it) {
             var loc = new Location(file, Position.fromToken(it.start));
             var nargs = new HashMap<String, Object>();
             var pargs = new ArrayList<>();
@@ -300,7 +303,7 @@ public abstract class KeyAst<T extends ParserRuleContext> {
                 for (var param : it.proofScriptParameters().proofScriptParameter()) {
                     var expr = param.expr;
                     Object value = expr;
-                    if(expr.proofScriptCodeBlock() != null) {
+                    if (expr.proofScriptCodeBlock() != null) {
                         value = asAst(file, expr.proofScriptCodeBlock());
                     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/AllCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/AllCommand.java
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.scripts;
 
+import java.util.List;
+
 import de.uka.ilkd.key.control.AbstractUserInterfaceControl;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.scripts.meta.ProofScriptArgument;
-
-import java.util.List;
 
 public class AllCommand implements ProofScriptCommand {
     @Override
@@ -17,15 +17,16 @@ public class AllCommand implements ProofScriptCommand {
 
     @Override
     public void execute(AbstractUserInterfaceControl uiControl, ScriptCommandAst args,
-                        EngineState stateMap) throws ScriptException, InterruptedException {
+            EngineState stateMap) throws ScriptException, InterruptedException {
         if (args.positionalArgs().size() != 1) {
-            throw new ScriptException("Invalid number of positional arguments to 'onAll'. Pos. arguments: "
+            throw new ScriptException(
+                "Invalid number of positional arguments to 'onAll'. Pos. arguments: "
                     + args.positionalArgs().size());
         }
 
         var block = stateMap.getValueInjector().convert(
-                args.positionalArgs().getFirst(),
-                ScriptBlock.class);
+            args.positionalArgs().getFirst(),
+            ScriptBlock.class);
 
         var proof = stateMap.getProof();
         for (Goal g : proof.openGoals()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/AllCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/AllCommand.java
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.scripts;
 
-import java.util.List;
-
 import de.uka.ilkd.key.control.AbstractUserInterfaceControl;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.scripts.meta.ProofScriptArgument;
 
-public class AllCommand implements ProofScriptCommand {
-    private String documentation;
+import java.util.List;
 
+public class AllCommand implements ProofScriptCommand {
     @Override
     public List<ProofScriptArgument> getArguments() {
         return List.of();
@@ -19,22 +17,21 @@ public class AllCommand implements ProofScriptCommand {
 
     @Override
     public void execute(AbstractUserInterfaceControl uiControl, ScriptCommandAst args,
-            EngineState stateMap) throws ScriptException, InterruptedException {
-        var block = args.commands();
-
-        if (block == null) {
-            throw new ScriptException("Missing command to apply onAll to");
+                        EngineState stateMap) throws ScriptException, InterruptedException {
+        if (args.positionalArgs().size() != 1) {
+            throw new ScriptException("Invalid number of positional arguments to 'onAll'. Pos. arguments: "
+                    + args.positionalArgs().size());
         }
+
+        var block = stateMap.getValueInjector().convert(
+                args.positionalArgs().getFirst(),
+                ScriptBlock.class);
 
         var proof = stateMap.getProof();
-        // Node selectedNode = state.getSelectedNode();
         for (Goal g : proof.openGoals()) {
-            // if (isBelow(g, selectedNode)) {
             stateMap.setGoal(g);
             stateMap.getEngine().execute(uiControl, block);
-            // }
         }
-        // state.setGoal(selectedNode);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/EngineState.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/EngineState.java
@@ -100,6 +100,7 @@ public class EngineState {
         addContextTranslator(v, JTerm.class);
         addContextTranslator(v, Sequent.class);
         addContextTranslator(v, Semisequent.class);
+        addContextTranslator(v, ScriptBlock.class);
         return v;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ExprEvaluator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ExprEvaluator.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.scripts;
 import de.uka.ilkd.key.nparser.KeYParser;
 import de.uka.ilkd.key.nparser.KeYParser.*;
 import de.uka.ilkd.key.nparser.KeYParserBaseVisitor;
+import de.uka.ilkd.key.nparser.KeyAst;
 import de.uka.ilkd.key.nparser.builder.ExpressionBuilder;
 
 import org.key_project.prover.sequent.Sequent;
@@ -13,6 +14,8 @@ import org.key_project.prover.sequent.Sequent;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URI;
 
 import static org.key_project.util.java.StringUtil.trim;
 
@@ -34,6 +37,12 @@ class ExprEvaluator extends KeYParserBaseVisitor<Object> {
 
     ExprEvaluator(EngineState engineState) {
         this.state = engineState;
+    }
+
+    @Override
+    public Object visitProofScriptCodeBlock(ProofScriptCodeBlockContext ctx) {
+        URI uri = KeyAst.ProofScript.getUri(ctx.start);
+        return KeyAst.ProofScript.asAst(uri, ctx);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ExprEvaluator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ExprEvaluator.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.scripts;
 
+import java.net.URI;
+
 import de.uka.ilkd.key.nparser.KeYParser;
 import de.uka.ilkd.key.nparser.KeYParser.*;
 import de.uka.ilkd.key.nparser.KeYParserBaseVisitor;
@@ -14,8 +16,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.URI;
 
 import static org.key_project.util.java.StringUtil.trim;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ProofScriptEngine.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ProofScriptEngine.java
@@ -22,7 +22,6 @@ import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 
 import org.antlr.v4.runtime.RuleContext;
-import org.antlr.v4.runtime.misc.Interval;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +31,6 @@ import org.slf4j.LoggerFactory;
  * @author Alexander Weigl
  */
 public class ProofScriptEngine {
-    public static final int KEY_START_INDEX_PARAMETER = 2;
-    public static final String KEY_SUB_SCRIPT = "#block";
-    private static final int MAX_CHARS_PER_COMMAND = 80;
     private static final Map<String, ProofScriptCommand> COMMANDS = loadCommands();
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofScriptEngine.class);
 
@@ -117,6 +113,11 @@ public class ProofScriptEngine {
         execute(uiControl, script);
     }
 
+    public void execute(AbstractUserInterfaceControl uiControl, ScriptBlock block)
+            throws ScriptException, InterruptedException {
+        execute(uiControl, block.commands());
+    }
+
     public void execute(AbstractUserInterfaceControl uiControl, List<ScriptCommandAst> commands)
             throws InterruptedException, ScriptException {
         if (script.isEmpty()) { // no commands given, no work to do
@@ -196,29 +197,6 @@ public class ProofScriptEngine {
                             .collect(Collectors.joining(" "))
                     : "")
             + ";";
-    }
-
-
-    private Map<String, Object> getArguments(KeYParser.ProofScriptCommandContext commandContext) {
-        var map = new TreeMap<String, Object>();
-        int i = KEY_START_INDEX_PARAMETER;
-
-        if (commandContext.proofScriptParameters() != null) {
-            for (var pc : commandContext.proofScriptParameters().proofScriptParameter()) {
-                String key = pc.pname != null ? pc.pname.getText() : "#" + (i++);
-                map.put(key, pc.expr);
-            }
-        }
-
-        if (commandContext.sub != null) {
-            map.put(KEY_SUB_SCRIPT, commandContext.sub);
-        }
-
-        var in = commandContext.start.getTokenSource().getInputStream();
-        var txt = in.getText(
-            Interval.of(commandContext.start.getStartIndex(), commandContext.stop.getStopIndex()));
-        map.put(ScriptLineParser.LITERAL_KEY, txt);
-        return map;
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
@@ -1,0 +1,25 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.scripts;
+
+import de.uka.ilkd.key.parser.Location;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+/// This class represents is the AST of a proof script command.
+@NullMarked
+public record ScriptBlock(
+        List<ScriptCommandAst> commands,
+        @Nullable Location location) {
+
+    public String asCommandLine() {
+        return " {"
+                + commands.stream().map(ScriptCommandAst::asCommandLine).collect(joining("\n"))
+                + "\n}";
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
@@ -3,23 +3,36 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.scripts;
 
+import java.util.List;
+
 import de.uka.ilkd.key.parser.Location;
+
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import java.util.List;
-
 import static java.util.stream.Collectors.joining;
 
-/// This class represents is the AST of a proof script command.
+/// This class represents a block `{ c1; c2; ... ck; }` of proof scripts.
 @NullMarked
 public record ScriptBlock(
         List<ScriptCommandAst> commands,
         @Nullable Location location) {
 
+    /// Renders this command a parsable string representation. The order of the arguments is as
+    /// follows:
+    /// key-value arguments, positional arguments and the additional script block.
+    ///
+    /// @see de.uka.ilkd.key.nparser.ParsingFacade#parseScript(org.antlr.v4.runtime.CharStream)
     public String asCommandLine() {
-        return " {"
-                + commands.stream().map(ScriptCommandAst::asCommandLine).collect(joining("\n"))
-                + "\n}";
+        if (commands.isEmpty()) {
+            return " {}";
+        }
+        if (commands.size() == 1) {
+            return " {" + commands.getFirst().asCommandLine() + "}";
+        }
+
+        return " {\n"
+            + commands.stream().map(ScriptCommandAst::asCommandLine).collect(joining("\n"))
+            + "\n}";
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptCommandAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptCommandAst.java
@@ -21,17 +21,24 @@ import static java.util.stream.Collectors.joining;
 ///
 /// It is an abstraction to the commands of following structure:
 /// ```
-/// <commandName> key_1:value_1 ... key_m:value_m positionalArgs_1 ... positionalArgs_n {
-/// commands_0; ...; commands_k;
-///}
-///```
+/// integer-split
+/// "<0" : { auto; }
+/// "=0" : { instantiate; }
+/// ">0" : { tryclose; }
+/// ;
+/// ```
+/// or
+/// ```
+/// <commandName> key_1:value_1 ... key_m:value_m positionalArgs_1 ... positionalArgs_n;
+/// ```
+/// where `value_X` and `positionalArgs_X` can also be scripts.
 ///
-/// @param commandName    the name of the command, e.g., "macro" for `macro auto;`
-/// @param namedArgs      a map of the given named arguments and values.
-///                       If a named argument is not given, the entry should be missing in the map. Null-values are not
-///                       allowed.
+/// @param commandName the name of the command, e.g., "macro" for `macro auto;`
+/// @param namedArgs a map of the given named arguments and values.
+/// If a named argument is not given, the entry should be missing in the map. Null-values are not
+/// allowed.
 /// @param positionalArgs the list of given positional arguments
-/// @param location       the location of this command for error reporting. **excluded from equality**
+/// @param location the location of this command for error reporting. **excluded from equality**
 /// @author Alexander Weigl
 /// @version 1 (14.03.25)
 @NullMarked
@@ -42,7 +49,7 @@ public record ScriptCommandAst(
         @Nullable Location location) {
 
     public ScriptCommandAst(String commandName, Map<String, Object> namedArgs,
-                            List<Object> positionalArgs) {
+            List<Object> positionalArgs) {
         this(commandName, namedArgs, positionalArgs, null);
     }
 
@@ -53,13 +60,13 @@ public record ScriptCommandAst(
     /// @see de.uka.ilkd.key.nparser.ParsingFacade#parseScript(CharStream)
     public String asCommandLine() {
         return commandName + ' ' +
-                namedArgs.entrySet().stream()
-                        .map(it -> it.getKey() + ": " + asReadableString(it.getValue()))
-                        .collect(joining(" "))
-                + ' '
-                + positionalArgs.stream().map(ScriptCommandAst::asReadableString)
-                        .collect(joining(" "))
-                + ";";
+            namedArgs.entrySet().stream()
+                    .map(it -> it.getKey() + ": " + asReadableString(it.getValue()))
+                    .collect(joining(" "))
+            + ' '
+            + positionalArgs.stream().map(ScriptCommandAst::asReadableString)
+                    .collect(joining(" "))
+            + ";";
     }
 
     public static String asReadableString(Object value) {
@@ -83,8 +90,12 @@ public record ScriptCommandAst(
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) { return true; }
-        if(obj == null || getClass() != obj.getClass()) { return false; }
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
         ScriptCommandAst other = (ScriptCommandAst) obj;
         return Objects.equals(commandName, other.commandName)
                 && Objects.equals(positionalArgs, other.positionalArgs)

--- a/key.core/src/test/java/de/uka/ilkd/key/scripts/ProofScriptParserTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/scripts/ProofScriptParserTest.java
@@ -5,10 +5,7 @@ package de.uka.ilkd.key.scripts;
 
 import de.uka.ilkd.key.nparser.ParsingFacade;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/scripts/ProofScriptParserTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/scripts/ProofScriptParserTest.java
@@ -5,17 +5,18 @@ package de.uka.ilkd.key.scripts;
 
 import de.uka.ilkd.key.nparser.ParsingFacade;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Alexander Weigl
  * @version 1 (7/25/21)
  */
-public class ScriptLineParserTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ScriptLineParserTest.class);
-
+public class ProofScriptParserTest {
     @Test
     public void test() throws Exception {
         String arg = """
@@ -35,5 +36,34 @@ public class ScriptLineParserTest {
         for (var scriptCommandAst : ast) {
             System.out.println(scriptCommandAst);
         }
+    }
+
+    @Test
+    void higherOrder() {
+        String arg = """
+                cmd key1: { cmd1; }\s
+                    key2: { cmd2; };\s
+                cmd { cmd; } { cmd; };
+                cmd { cmd; } { cmd; };
+                """;
+
+        var script = ParsingFacade.parseScript(arg);
+        var ast = script.asAst();
+        for (var scriptCommandAst : ast) {
+            System.out.println(scriptCommandAst);
+        }
+
+        assertThat(ast).hasSize(3);
+
+        var cmd1 = ast.get(0);
+        var cmd2 = ast.get(1);
+        var cmd3 = ast.get(2);
+
+        assertThat(cmd1.commandName()).isEqualTo("cmd");
+        assertThat(cmd1.namedArgs()).containsKey("key1");
+        assertThat(cmd1.namedArgs()).containsKey("key2");
+
+        assertThat(cmd2.positionalArgs()).hasSize(2);
+        assertThat(cmd3.positionalArgs()).hasSize(2);
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/scripts/meta/ValueInjectorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/scripts/meta/ValueInjectorTest.java
@@ -29,7 +29,7 @@ public class ValueInjectorTest {
         PP pp = new PP();
         Map<String, Object> args = new HashMap<>();
         ScriptCommandAst ast = new ScriptCommandAst("pp", args, new LinkedList<>(),
-            null, null);
+                null);
         args.put("b", true);
         args.put("i", 42);
 
@@ -51,7 +51,7 @@ public class ValueInjectorTest {
         PP pp = new PP();
         Map<String, Object> args = new HashMap<>();
         ScriptCommandAst ast = new ScriptCommandAst("pp", args, new LinkedList<>(),
-            null, null);
+                null);
         args.put("b", "true");
         args.put("s", "blubb");
         assertThrows(ArgumentRequiredException.class,

--- a/key.core/src/test/java/de/uka/ilkd/key/scripts/meta/ValueInjectorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/scripts/meta/ValueInjectorTest.java
@@ -29,7 +29,7 @@ public class ValueInjectorTest {
         PP pp = new PP();
         Map<String, Object> args = new HashMap<>();
         ScriptCommandAst ast = new ScriptCommandAst("pp", args, new LinkedList<>(),
-                null);
+            null);
         args.put("b", true);
         args.put("i", 42);
 
@@ -51,7 +51,7 @@ public class ValueInjectorTest {
         PP pp = new PP();
         Map<String, Object> args = new HashMap<>();
         ScriptCommandAst ast = new ScriptCommandAst("pp", args, new LinkedList<>(),
-                null);
+            null);
         args.put("b", "true");
         args.put("s", "blubb");
         assertThrows(ArgumentRequiredException.class,


### PR DESCRIPTION
## Intended Change

This PR generalizes the usage of proof script blocks further. 

**Currently,** you are allowed to have *one* proof script block at the end of a command:
```
onAll { auto;}
```

With this PR, proof script blocks can appear as a regular argument anywhere (positional and keyworded):
```
integer-split 
  "<0" : { auto;  }
  "=0" : { instantiate; } 
  ">0" : { tryclose; }
```

This allows for various constructs, e.g., 

```
if "cond" { .. then ..} {.. else ..}
```



## Plan

* [x] Do it
* [x] Test it

## Type of pull request

- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
