### PR TITLE
Make user-defined sorts accessible in "\dl_" escapes

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeYConverter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Recoder2KeYConverter.java
@@ -747,6 +747,7 @@ public class Recoder2KeYConverter {
     /**
      * Resolve the function symbol with the given name. Also supports sort-dependent functions
      * (where the name contains "::").
+     *
      * @param name
      * @param e
      * @return

--- a/key.core/src/main/java/de/uka/ilkd/key/java/expression/operator/DLEmbeddedExpression.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/expression/operator/DLEmbeddedExpression.java
@@ -106,7 +106,9 @@ public class DLEmbeddedExpression extends Operator {
         String qualifier =
             name.lastIndexOf('.') != -1 ? name.substring(0, name.lastIndexOf('.')) : "";
         name = name.substring(name.lastIndexOf('.') + 1);
-        TypeRef tr = new TypeRef(new ProgramElementName(name, qualifier), 0, null, containingClass);
+        ProgramElementName pen = qualifier.isEmpty() ? new ProgramElementName(name)
+            : new ProgramElementName(name, qualifier);
+        TypeRef tr = new TypeRef(pen, 0, null, containingClass);
         ExecutionContext ec = new ExecutionContext(tr, null, null);
 
         for (int i = 0; i < actual; i++) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/expression/operator/DLEmbeddedExpression.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/expression/operator/DLEmbeddedExpression.java
@@ -107,7 +107,7 @@ public class DLEmbeddedExpression extends Operator {
             name.lastIndexOf('.') != -1 ? name.substring(0, name.lastIndexOf('.')) : "";
         name = name.substring(name.lastIndexOf('.') + 1);
         ProgramElementName pen = qualifier.isEmpty() ? new ProgramElementName(name)
-            : new ProgramElementName(name, qualifier);
+                : new ProgramElementName(name, qualifier);
         TypeRef tr = new TypeRef(pen, 0, null, containingClass);
         ExecutionContext ec = new ExecutionContext(tr, null, null);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/RecoderModelTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/recoderext/RecoderModelTransformer.java
@@ -84,10 +84,9 @@ public abstract class RecoderModelTransformer extends TwoPassTransformation {
                 default -> {
                     if (type.getName().startsWith("\\dl_")) {
                         // The default value of a type is resolved later, then we know the Sort of
-                        // the
-                        // type
+                        // the type
                         yield new DLEmbeddedExpression(
-                            "\\dl_DEFAULT_VALUE_" + type.getName().substring(4),
+                            type.getName().substring(4) + "::defaultValue",
                             Collections.emptyList());
                     }
                     Debug.fail("makeImplicitMembersExplicit: unknown primitive type" + type);

--- a/key.core/src/main/java/de/uka/ilkd/key/ldt/JavaDLTheory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/ldt/JavaDLTheory.java
@@ -151,7 +151,6 @@ public class JavaDLTheory extends LDT {
     @Override
     public boolean isResponsible(Operator op, JTerm[] subs, Services services,
             ExecutionContext ec) {
-        assert false;
         return false;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -102,7 +102,8 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
         ImmutableSet<PositionedString> warnings = DefaultImmutableSet.nil();
 
         // read key file itself (except contracts)
-        warnings = warnings.union(super.readExtendedSignature());
+        // should have been read earlier (TODO: find a clean solution)
+        //warnings = warnings.union(super.readExtendedSignature());
 
         // read in-code specifications
         SLEnvInput slEnvInput = new SLEnvInput(readJavaPath(), readClassPath(), readBootClassPath(),

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -103,7 +103,7 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
 
         // read key file itself (except contracts)
         // should have been read earlier (TODO: find a clean solution)
-        //warnings = warnings.union(super.readExtendedSignature());
+        // warnings = warnings.union(super.readExtendedSignature());
 
         // read in-code specifications
         SLEnvInput slEnvInput = new SLEnvInput(readJavaPath(), readClassPath(), readBootClassPath(),

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -526,7 +526,7 @@ public final class ProblemInitializer {
         // hacky, but allows to use sorts and functions from user .key files in JML via \dl_ escape
         if (envInput instanceof KeYUserProblemFile kf) {
             envInput.setInitConfig(initConfig);
-            //warnings.add(kf.readSorts());
+            // warnings.add(kf.readSorts());
             warnings.add(kf.readExtendedSignature());
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -523,6 +523,13 @@ public final class ProblemInitializer {
 
         configureTermLabelSupport(initConfig);
 
+        // hacky, but allows to use sorts and functions from user .key files in JML via \dl_ escape
+        if (envInput instanceof KeYFile kf) {
+            envInput.setInitConfig(initConfig);
+            //warnings.add(kf.readSorts());
+            warnings.add(kf.readExtendedSignature());
+        }
+
         // read Java
         readJava(envInput, initConfig);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProblemInitializer.java
@@ -524,7 +524,7 @@ public final class ProblemInitializer {
         configureTermLabelSupport(initConfig);
 
         // hacky, but allows to use sorts and functions from user .key files in JML via \dl_ escape
-        if (envInput instanceof KeYFile kf) {
+        if (envInput instanceof KeYUserProblemFile kf) {
             envInput.setInitConfig(initConfig);
             //warnings.add(kf.readSorts());
             warnings.add(kf.readExtendedSignature());

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
@@ -1,4 +1,10 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.njml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
 import de.uka.ilkd.key.proof.Proof;
@@ -7,12 +13,10 @@ import de.uka.ilkd.key.proof.init.ProofInputException;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.speclang.Contract;
 import de.uka.ilkd.key.util.HelperClassForTests;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public class DLEscapeParsingTest {
     @Test

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
@@ -1,7 +1,6 @@
 package de.uka.ilkd.key.speclang.njml;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.ContractPO;
 import de.uka.ilkd.key.proof.init.ProofInputException;
@@ -11,10 +10,7 @@ import de.uka.ilkd.key.util.HelperClassForTests;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -25,10 +21,16 @@ public class DLEscapeParsingTest {
                 .resolve("speclang/dlEscapeParsing/dlEscapeTest.key");
         Assumptions.assumeTrue(Files.exists(keyFile));
         KeYEnvironment<?> env = KeYEnvironment.load(keyFile);
+        // both contracts are provable automatically within a few steps
         Contract contr = env.getProofContracts().getFirst();
-        ContractPO po = contr.createProofObl(env.getInitConfig());
-        Proof proof = env.createProof(po);
-        env.getProofControl().startAndWaitForAutoMode(proof);
-        Assertions.assertTrue(proof.closed());
+        ContractPO po1 = contr.createProofObl(env.getInitConfig());
+        Proof proof1 = env.createProof(po1);
+        env.getProofControl().startAndWaitForAutoMode(proof1);
+        Assertions.assertTrue(proof1.closed());
+
+        ContractPO po2 = contr.createProofObl(env.getInitConfig());
+        Proof proof2 = env.createProof(po2);
+        env.getProofControl().startAndWaitForAutoMode(proof2);
+        Assertions.assertTrue(proof2.closed());
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/DLEscapeParsingTest.java
@@ -1,0 +1,34 @@
+package de.uka.ilkd.key.speclang.njml;
+
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.init.ContractPO;
+import de.uka.ilkd.key.proof.init.ProofInputException;
+import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+import de.uka.ilkd.key.speclang.Contract;
+import de.uka.ilkd.key.util.HelperClassForTests;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class DLEscapeParsingTest {
+    @Test
+    public void dlEscapeParsingTest() throws ProblemLoaderException, ProofInputException {
+        final Path keyFile = HelperClassForTests.TESTCASE_DIRECTORY
+                .resolve("speclang/dlEscapeParsing/dlEscapeTest.key");
+        Assumptions.assumeTrue(Files.exists(keyFile));
+        KeYEnvironment<?> env = KeYEnvironment.load(keyFile);
+        Contract contr = env.getProofContracts().getFirst();
+        ContractPO po = contr.createProofObl(env.getInitConfig());
+        Proof proof = env.createProof(po);
+        env.getProofControl().startAndWaitForAutoMode(proof);
+        Assertions.assertTrue(proof.closed());
+    }
+}

--- a/key.core/src/test/resources/testcase/speclang/dlEscapeParsing/IntTriple.java
+++ b/key.core/src/test/resources/testcase/speclang/dlEscapeParsing/IntTriple.java
@@ -1,0 +1,23 @@
+class IntTriple {
+    // abstract state
+    //@ ghost int x;
+    //@ ghost \dl_IntPair yz;                     // default value is needed here!
+    int a, b, c;        // concrete state
+
+
+    // coupling invariant
+    //@ invariant a == x && \dl_fst(yz) == b && \dl_snd(yz) == c;
+
+    //@ ensures yz == \dl_ip(0,0);      // (auto) provable
+    IntTriple() {
+    }
+
+    /*@ normal_behavior
+      @  requires true;
+      @  ensures \result == \dl_fst(yz);   // (auto) provable
+      @  assignable \nothing;
+      @*/
+    int getSecond() {
+        return b;
+    }
+}

--- a/key.core/src/test/resources/testcase/speclang/dlEscapeParsing/dlEscapeTest.key
+++ b/key.core/src/test/resources/testcase/speclang/dlEscapeParsing/dlEscapeTest.key
@@ -1,0 +1,37 @@
+\sorts {
+    /*  ! @defaultValue(emptyPair) */    // <-- not needed anymore with this PR
+    IntPair;
+}
+
+\functions {
+    // IntPair emptyPair;              // <-- not needed anymore with this PR
+    \unique IntPair ip(int, int);   // constructor
+    int fst(IntPair);               // selector function
+    int snd(IntPair);               // selector function
+}
+
+\rules {
+    defaultValueOfIntPair {
+        \find (IntPair::defaultValue)
+        \replacewith (ip(0,0))
+        \heuristics(simplify)
+    };
+
+    fstOfIp {
+        \schemaVar \term int a, b;
+        \find (fst(ip(a, b)))
+        \replacewith (a)
+        \heuristics(simplify)
+    };
+
+    sndOfIp {
+        \schemaVar \term int a, b;
+        \find (snd(ip(a, b)))
+        \replacewith (b)
+        \heuristics(simplify)
+    };
+}
+
+\javaSource ".";
+
+\chooseContract


### PR DESCRIPTION
As described in #3402, user-defined sorts (from a .key file) cannot be used inside "\dl_" escapes. This PR changes this by reading the sorts and function/predicate definitions of the .key file before parsing JML. Note that the PR should also work for datatypes, since they are pretransformed into sorts and rules before reading the file. However, this is still untested.

In addition, this PR changes the handling of default values (relevant when declaring a ghost field of a user-defined sort).
Earlier, the default value was read from a doc comment `/*! @defaultValue(x) */` attached to the sort declaration. However, this has drawbacks:
* The semantics depend on comments, changing the comments might change the semantics of the specification.
* `x` was only allowed to be a constant, which is quite restrictive
With this PR, the existing sort-depending constant `x::defaultValue` (from heap.key) is used as default. A concrete value can be assigned with a taclet.

Here is a small example with the sort IntPair:
```latex
\sorts {
    /*! @defaultValue(emptyPair) */    // <-- not needed anymore with this PR
    IntPair;
}

\functions {
    // IntPair emptyPair;              // <-- not needed anymore with this PR
    \unique IntPair ip(int, int);   // constructor
    int fst(IntPair);               // selector function
    int snd(IntPair);               // selector function
}

\rules {
    defaultValueOfIntPair {
        \find (IntPair::defaultValue)
        \replacewith (ip(0,0))
        \heuristics(simplify)
    };

    fstOfIp {
        \schemaVar \term int a, b;
        \find (fst(ip(a, b)))
        \replacewith (a)
        \heuristics(simplify)
    };

    sndOfIp {
        \schemaVar \term int a, b;
        \find (snd(ip(a, b)))
        \replacewith (b)
        \heuristics(simplify)
    };
}

\javaSource ".";

\chooseContract
```
Java File:
```java
class IntTriple {
                        // abstract state
    //@ ghost int x;
    //@ ghost \dl_IntPair yz;                     // default value is needed here!

    int a, b, c;        // concrete state

                        // coupling invariant
    //@ invariant a == x && \dl_fst(yz) == b && \dl_snd(yz) == c;

    //@ ensures yz == \dl_ip(0,0);      // (auto) provable
    IntTriple() {
    }

    /*@ normal_behavior
      @  requires true;
      @  ensures \result == \dl_fst(yz);   // (auto) provable
      @  assignable \nothing;
      @*/
    int getSecond() {
        return b;
    }
}
```

The PR is still a draft because I want to see if the tests succeed first. Also, the `x instanceof KeYFile` seems a bit hacky, I don't know if it works for other cases ...

## Related Issue

This pull request resolves #3402.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: Manually with the example given above.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
