### PR TITLE
small fixes to datatype handling

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -68,17 +68,18 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
                 args[i] = argSort;
                 var argName = argNames.get(i).getText();
                 SortedOperator alreadyDefinedFn = dtNamespace.lookup(argName);
-                if(alreadyDefinedFn == null) {
+                if (alreadyDefinedFn == null) {
                     alreadyDefinedFn = namespaces().functions().lookup(argName);
                 }
-                if(alreadyDefinedFn == null) {
+                if (alreadyDefinedFn == null) {
                     alreadyDefinedFn = namespaces().programVariables().lookup(argName);
                 }
                 if (alreadyDefinedFn != null
                         && (!alreadyDefinedFn.sort().equals(argSort)
                                 || !alreadyDefinedFn.argSorts().equals(ImmutableList.of(sort)))) {
-                    semanticError( argNames.get(i), "Name already in namespace: %s" +
-                            ". Identifiers in datatype definitions must be unique (also wrt. global functions).", argName);
+                    semanticError(argNames.get(i), "Name already in namespace: %s" +
+                        ". Identifiers in datatype definitions must be unique (also wrt. global functions).",
+                        argName);
                 }
                 Function fn = new JFunction(new Name(argName), argSort, new Sort[] { sort }, null,
                     false, false);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -78,8 +78,10 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
                         && (!alreadyDefinedFn.sort().equals(argSort)
                                 || !alreadyDefinedFn.argSorts().equals(ImmutableList.of(sort)))) {
                     // The condition checks whether there is already a function with the same name
-                    // but different signature. This is necessarily true if there is a globally defined function
-                    // of the same name and may or may not be true if there is another constructor argument of the
+                    // but different signature. This is necessarily true if there is a globally
+                    // defined function
+                    // of the same name and may or may not be true if there is another constructor
+                    // argument of the
                     // same name.
                     semanticError(argNames.get(i), "Name already in namespace: %s" +
                         ". Identifiers in datatype definitions must be unique (also wrt. global functions).",

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -77,6 +77,10 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
                 if (alreadyDefinedFn != null
                         && (!alreadyDefinedFn.sort().equals(argSort)
                                 || !alreadyDefinedFn.argSorts().equals(ImmutableList.of(sort)))) {
+                    // The condition checks whether there is already a function with the same name
+                    // but different signature. This is necessarily true if there is a globally defined function
+                    // of the same name and may or may not be true if there is another constructor argument of the
+                    // same name.
                     semanticError(argNames.get(i), "Name already in namespace: %s" +
                         ". Identifiers in datatype definitions must be unique (also wrt. global functions).",
                         argName);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/FunctionPredicateBuilder.java
@@ -17,8 +17,10 @@ import de.uka.ilkd.key.nparser.KeYParser;
 import org.key_project.logic.Name;
 import org.key_project.logic.Namespace;
 import org.key_project.logic.op.Function;
+import org.key_project.logic.op.SortedOperator;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
+import org.key_project.util.collection.ImmutableList;
 
 
 /**
@@ -65,11 +67,18 @@ public class FunctionPredicateBuilder extends DefaultBuilder {
                 Sort argSort = accept(constructorContext.sortId(i));
                 args[i] = argSort;
                 var argName = argNames.get(i).getText();
-                var alreadyDefinedFn = dtNamespace.lookup(argName);
+                SortedOperator alreadyDefinedFn = dtNamespace.lookup(argName);
+                if(alreadyDefinedFn == null) {
+                    alreadyDefinedFn = namespaces().functions().lookup(argName);
+                }
+                if(alreadyDefinedFn == null) {
+                    alreadyDefinedFn = namespaces().programVariables().lookup(argName);
+                }
                 if (alreadyDefinedFn != null
                         && (!alreadyDefinedFn.sort().equals(argSort)
-                                || !alreadyDefinedFn.argSort(0).equals(sort))) {
-                    throw new RuntimeException("Name already in namespace: " + argName);
+                                || !alreadyDefinedFn.argSorts().equals(ImmutableList.of(sort)))) {
+                    semanticError( argNames.get(i), "Name already in namespace: %s" +
+                            ". Identifiers in datatype definitions must be unique (also wrt. global functions).", argName);
                 }
                 Function fn = new JFunction(new Name(argName), argSort, new Sort[] { sort }, null,
                     false, false);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -275,12 +275,15 @@ public class TacletPBuilder extends ExpressionBuilder {
     }
 
     private TacletBuilder<? extends Taclet> createDeconstructorTaclet(
-            KeYParser.Datatype_constructorContext constructor, String argName, int argIndex, Sort dtSort) {
+            KeYParser.Datatype_constructorContext constructor, String argName, int argIndex,
+            Sort dtSort) {
         var tacletBuilder = new RewriteTacletBuilder<>();
         tacletBuilder
-                .setName(new Name(String.format("DT_%s#Dec_%s#%s", dtSort.name(), argName, constructor.name.getText())));
+                .setName(new Name(String.format("DT_%s#Dec_%s#%s", dtSort.name(), argName,
+                    constructor.name.getText())));
         tacletBuilder.setDisplayName(
-            String.format("DT %s Deconstructor %s (for %s)", dtSort.name(), argName, constructor.name.getText()));
+            String.format("DT %s Deconstructor %s (for %s)", dtSort.name(), argName,
+                constructor.name.getText()));
 
         var schemaVariables = new JOperatorSV[constructor.argName.size()];
         var args = new JTerm[constructor.argName.size()];
@@ -315,9 +318,11 @@ public class TacletPBuilder extends ExpressionBuilder {
             Sort dtSort) {
         var tacletBuilder = new RewriteTacletBuilder<>();
         tacletBuilder.setName(
-            new Name(String.format("DT_%s#Dec_%s#%s#EQ", dtSort.name(), argName, constructor.name.getText())));
+            new Name(String.format("DT_%s#Dec_%s#%s#EQ", dtSort.name(), argName,
+                constructor.name.getText())));
         tacletBuilder.setDisplayName(
-            String.format("DT %s Deconstructor %s (for %s)", dtSort.name(), argName, constructor.name.getText()));
+            String.format("DT %s Deconstructor %s (for %s)", dtSort.name(), argName,
+                constructor.name.getText()));
 
         var schemaVariables = new JOperatorSV[constructor.argName.size()];
         var args = new JTerm[constructor.argName.size()];

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/RuleJustificationInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/RuleJustificationInfo.java
@@ -29,7 +29,7 @@ public class RuleJustificationInfo {
             for (RuleKey key : rule2Justification.keySet()) {
                 if (key.equals(ruleKey) && r != key.r) {
                     throw new IllegalArgumentException(
-                        "A rule named " + r.name() + "has already been registered.");
+                        "A rule named " + r.name() + " has already been registered.");
                 }
             }
         } else {

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.nparser;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
 
@@ -51,6 +53,27 @@ public class AdtTests {
         Assertions.assertEquals(EXPECTED_PRED_DECEQ_SUCC, predDecEqSucc.toString());
 
     }
+
+    /*
+     * Test for a non-recursive constructor. The generated taclet must not contain an induction
+     * hypothesis.
+     * See #3661
+     */
+    @Test
+    public void nonRecursiveConstructorTest() throws ProblemLoaderException, IOException {
+        var path = Paths.get("../key.ui/examples/standard_key/adt/dt_nonrec.key");
+        var env = KeYEnvironment.load(path);
+        var taclets = env.getInitConfig().activatedTaclets();
+        String expected = Files.lines(path)
+                .filter(l -> l.startsWith("//!"))
+                .map(l -> l.substring(4))
+                .collect(java.util.stream.Collectors.joining("\n"));
+
+        var consTaclet = get("DT_NonRec#Dec_nonrecarg#b", taclets);
+        // There are spaces before linebreaks. Better remove them for the comparison.
+        Assertions.assertEquals(expected, consTaclet.toString().replaceAll(" +\n", "\n"));
+    }
+
 
     private Taclet get(String name, Collection<Taclet> taclets) {
         var n = new Name(name);

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
@@ -20,17 +20,17 @@ import org.junit.jupiter.api.Test;
  */
 public class AdtTests {
     private static final String EXPECTED_PRED_DEC_SUCC = """
-            pred_Dec_succ {
+            DT_Nat#Dec_pred#succ {
             \\find(pred(succ(pred_sv)))
             \\sameUpdateLevel\\replacewith(pred_sv)\s
-
+            \\heuristics(simplify)
             Choices: true}""";
     private static final String EXPECTED_PRED_DECEQ_SUCC = """
-            pred_DecEQ_succ {
-            \\assumes ([equals(pred_x,succ(pred_sv))]==>[])\s
+            DT_Nat#Dec_pred#succ#EQ {
+            \\assumes ([equals(succ(pred_sv),pred_x)]==>[])\s
             \\find(pred(pred_x))
             \\sameUpdateLevel\\replacewith(pred_sv)\s
-
+            \\heuristics(simplify)
             Choices: true}""";
 
     @Test
@@ -44,8 +44,8 @@ public class AdtTests {
                 System.out.println(taclet.name());
         }
 
-        var predDecsucc = get("pred_Dec_succ", taclets);
-        var predDecEqSucc = get("pred_DecEQ_succ", taclets);
+        var predDecsucc = get("DT_Nat#Dec_pred#succ", taclets);
+        var predDecEqSucc = get("DT_Nat#Dec_pred#succ#EQ", taclets);
 
         Assertions.assertEquals(EXPECTED_PRED_DEC_SUCC, predDecsucc.toString());
         Assertions.assertEquals(EXPECTED_PRED_DECEQ_SUCC, predDecEqSucc.toString());

--- a/key.ui/examples/standard_key/adt/dt_color.proof
+++ b/key.ui/examples/standard_key/adt/dt_color.proof
@@ -56,7 +56,7 @@
 
 (branch "dummy ID"
 (rule "allRight" (formula "1") (inst "sk=l_0") (userinteraction))
-(rule "Color_ctor_split" (formula "1") (term "0,0,0") (userinteraction))
+(rule "DT_Color_ctor_split" (formula "1") (term "0,0,0") (userinteraction))
 (branch "l_0 = Red"
    (rule "orRight" (formula "2"))
    (rule "orRight" (formula "2"))

--- a/key.ui/examples/standard_key/adt/dt_list_appnil.proof
+++ b/key.ui/examples/standard_key/adt/dt_list_appnil.proof
@@ -95,7 +95,7 @@
 (autoModeTime "105")
 
 (branch "dummy ID"
-(rule "List_Ind" (inst "phi=(app(l, Nil) = l)<<origin(\"User_Interaction @ node 0 (Induction_for_List)\",\"[]\")>>") (inst "x=l") (userinteraction))
+(rule "DT_List_Induction" (inst "phi=(app(l, Nil) = l)<<origin(\"User_Interaction @ node 0 (Induction_for_List)\",\"[]\")>>") (inst "x=l") (userinteraction))
 (branch "Nil"
    (rule "concat_base" (formula "1") (term "0") (userinteraction))
     (builtin "One Step Simplification" (formula "1"))

--- a/key.ui/examples/standard_key/adt/dt_list_deconstruct.key
+++ b/key.ui/examples/standard_key/adt/dt_list_deconstruct.key
@@ -1,5 +1,5 @@
 \datatypes {
-	List = Nil | Cons(any head, List tail) | Cons2(any head2, List tail);
+	List = Nil | Cons(any head, List tail) | Cons2(any head2, List tail2);
 }
 
 \functions {
@@ -7,5 +7,5 @@
 }
 
 \problem {
-	Nil = tail(Cons(0, Nil)) & Nil = tail(Cons2(0, Nil)) & (x = Cons(0, Cons(1, Nil)) -> head(x) = 0)
+	Nil = tail(Cons(0, Nil)) & Nil = tail2(Cons2(0, Nil)) & (Cons(0, Cons(1, Nil)) = x -> head(x) = 0)
 }

--- a/key.ui/examples/standard_key/adt/dt_list_deconstruct.proof
+++ b/key.ui/examples/standard_key/adt/dt_list_deconstruct.proof
@@ -73,7 +73,7 @@
  } 
 
 \datatypes {
-	List = Nil | Cons(any head, List tail) | Cons2(any head2, List tail);
+	List = Nil | Cons(any head, List tail) | Cons2(any head2, List tail2);
 }
 
 \functions {
@@ -81,8 +81,8 @@
 }
 \problem {
   Nil = tail(Cons(Z(0(#)), Nil))
-& Nil = tail(Cons2(Z(0(#)), Nil))
-& (   x = Cons(Z(0(#)), Cons(Z(1(#)), Nil))
+& Nil = tail2(Cons2(Z(0(#)), Nil))
+& (   Cons(Z(0(#)), Cons(Z(1(#)), Nil)) = x
    -> head(x) = Z(0(#)))
 }
 
@@ -96,19 +96,19 @@
 (branch "Case 1"
    (rule "andRight" (formula "1") (userinteraction))
    (branch "Case 1"
-      (rule "tail_Dec_Cons" (formula "1") (term "1") (userinteraction))
+      (rule "DT_List#Dec_tail#Cons" (formula "1") (term "1") (userinteraction))
       (rule "equalUnique" (formula "1") (userinteraction))
       (rule "closeTrue" (formula "1") (userinteraction))
    )
    (branch "Case 2"
-      (rule "tail_Dec_Cons2" (formula "1") (term "1") (userinteraction))
+      (rule "DT_List#Dec_tail2#Cons2" (formula "1") (term "1") (userinteraction))
       (rule "equalUnique" (formula "1") (userinteraction))
       (rule "closeTrue" (formula "1") (userinteraction))
    )
 )
 (branch "Case 2"
    (rule "impRight" (formula "1") (userinteraction))
-   (rule "head_DecEQ_Cons" (formula "2") (term "0") (ifseqformula "1") (userinteraction))
+   (rule "DT_List#Dec_head#Cons#EQ" (formula "2") (term "0") (ifseqformula "1") (userinteraction))
    (rule "equal_literals" (formula "2") (userinteraction))
    (rule "closeTrue" (formula "2") (userinteraction))
 )

--- a/key.ui/examples/standard_key/adt/dt_list_revrev.proof
+++ b/key.ui/examples/standard_key/adt/dt_list_revrev.proof
@@ -110,7 +110,7 @@
 (autoModeTime "22638")
 
 (branch "dummy ID"
-(rule "List_Ind" (inst "phi=(rev(rev(l)) = l)<<origin(\"User_Interaction @ node 0 (InductionforList)\",\"[]\")>>") (inst "x=l") (userinteraction))
+(rule "DT_List_Induction" (inst "phi=(rev(rev(l)) = l)<<origin(\"User_Interaction @ node 0 (InductionforList)\",\"[]\")>>") (inst "x=l") (userinteraction))
 (branch "Nil"
    (rule "allRight" (formula "2") (inst "sk=l_0"))
    (rule "revert_base" (formula "1") (term "0,0") (userinteraction))

--- a/key.ui/examples/standard_key/adt/dt_nonrec.key
+++ b/key.ui/examples/standard_key/adt/dt_nonrec.key
@@ -1,0 +1,17 @@
+/*
+  There was a bug in the handling of datatypes with constructors that have no recursive arguments. #3661
+*/
+
+//  Expected selector taclet is as follows:
+//! DT_NonRec#Dec_nonrecarg#b {
+//! \find(nonrecarg(b(nonrecarg_sv)))
+//! \sameUpdateLevel\replacewith(nonrecarg_sv)
+//! \heuristics(simplify)
+//! Choices: true}
+
+\datatypes {
+        NonRec = a | b(int nonrecarg);
+}
+
+\problem { true }
+        


### PR DESCRIPTION
## Related Issue

#3662 Parsing problem in \datatypes with no 'self' selectors

## Intended Change

Small changes in data type treatment:
- error messaging improved
- consistent naming scheme
- *corrected EQ taclet in correct order (a=b became b=a at one point)*
- *fixed bug in the Axiom taclet for datatypes* which crashed KeY while loading.
- added generated deconstructor rules to "simplify" ruleset 

## Plan

Small fixes: done.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code
- There are changes to the taclet rule base [only to taclets created at load time for datatype declarations]

## Ensuring quality

- Pair programming
- I added new test case(s) for new functionality. Manually.

## Additional information and contact(s)

Co-authored by @WolframPfeifer 

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.