### PR TITLE
fixes #3660

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -1662,11 +1662,9 @@ class Translator extends JmlParserBaseVisitor<Object> {
         SLExpression e2 = accept(ctx.expression(1));
         SLExpression e3 = accept(ctx.expression(2));
         // short for "e1[0..e2-1]+e3+e1[e2+1..e1.length-1]"
-        final JTerm minusOne = tb.zTerm("-1");
         assert e2 != null;
         assert e1 != null;
-        JTerm updated = tb.seqUpd(e1.getTerm(), e2.getTerm(), e3.getTerm());
-        return new SLExpression(updated);
+        return termFactory.seqUpd(e1.getTerm(), e2.getTerm(), e3.getTerm());
     }
 
     @Override

--- a/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/speclang/njml/exprs.txt
@@ -14,3 +14,10 @@ this
 1.f + 2.d
 \seq()
 \locset()
+\seq_upd(\seq(), 2, true) // There were issues with true in expressions ... #3660
+\seq(true)
+\seq(true, true)
+(\seq_def int i; 0; 10; true)
+\seq_indexOf(\seq(true), true)
+true == true
+(\exists int i; true)


### PR DESCRIPTION
## Related Issue

This pull request resolves #3660.

## Intended Change

See #3660 for details.

This fix allows `true` to be used as expression in more places in JML.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality
  
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality. [to existing exprs.txt]

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
