### PR TITLE
Fix NPE in dependency contract feature (caused by pulled out expression)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
@@ -30,9 +30,9 @@ public final class DependencyContractFeature extends BinaryFeature {
     private void removePreviouslyUsedSteps(JTerm focus, Goal goal,
             List<PosInOccurrence> steps) {
         for (RuleApp app : goal.appliedRuleApps()) {
-            JTerm term = (JTerm) app.posInOccurrence().subTerm();
             if (app.rule() instanceof UseDependencyContractRule
-                    && RENAMING_TERM_PROPERTY.equalsModThisProperty(term, focus)) {
+                    && RENAMING_TERM_PROPERTY.equalsModThisProperty(app.posInOccurrence().subTerm(),
+                        focus)) {
                 final IBuiltInRuleApp bapp = (IBuiltInRuleApp) app;
                 for (PosInOccurrence ifInst : bapp.assumesInsts()) {
                     steps.remove(ifInst);


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Related Issue

This pull request resolves #3674.

## Intended Change

The feature for dependency contracts should not throw an exception if a no-find taclet was applied on the branch

## Type of pull request


- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: Reproduced the reported error on the unmodified version, fixed the issue, tested the fix and no exception is thrown

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
