### PR TITLE
Fix Information Flow Proof Loading for KeY Jar File

### DIFF
--- a/key.core.symbolic_execution/src/main/resources/META-INF/services/de.uka.ilkd.key.proof.init.loader.ProofObligationLoader
+++ b/key.core.symbolic_execution/src/main/resources/META-INF/services/de.uka.ilkd.key.proof.init.loader.ProofObligationLoader
@@ -1,9 +1,2 @@
-de.uka.ilkd.key.proof.init.loader.DependencyContractPOLoader
-de.uka.ilkd.key.proof.init.loader.FunctionalLoopContractPOLoader
-de.uka.ilkd.key.proof.init.loader.FunctionalBlockContractPOLoader
-de.uka.ilkd.key.proof.init.loader.FunctionOperationContractPOLoader
-de.uka.ilkd.key.informationflow.po.InfFlowContractPOLoader
-de.uka.ilkd.key.taclettranslation.lemma.TacletProofObligationInputLoader
-de.uka.ilkd.key.proof.init.WellDefinednessPOLoader
 de.uka.ilkd.key.symbolic_execution.po.ProgramMethodPOLoader
 de.uka.ilkd.key.symbolic_execution.po.ProgramMethodSubsetPOLoader

--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -55,6 +55,9 @@ processResources.dependsOn << createExamplesZip
 shadowJar {
     archiveClassifier.set("exe")
     archiveBaseName.set("key")
+    filesMatching("META-INF/services/**") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE // needed for mergeServices
+    }
     mergeServiceFiles()
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Currently, loading a proof obligation for, e.g., information flow, fails if you are using the generated shadow JAR, because no proof obligation loader can be found.

The problem is (apparently), that the symbolic execution module overwrites the list of proof obligation loaders in the META-INF folder.

This PR fixes the issue by simply adding all relevant loaders to the file in `key.core.symbolic_execution` as well.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code
- Other: 

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: Loading and closing a few Inf Flow proofs

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
