### PR TITLE
Enable assertion for :key.ui:run

### DIFF
--- a/key.ui/build.gradle
+++ b/key.ui/build.gradle
@@ -75,6 +75,9 @@ run {
     //systemProperties["KeyDebugFlag"] = "on"
     //args "--experimental"
 
+    // enable assertion
+    jvmArgs += "-ea"
+
     // this can be used to solve a problem where the OS hangs during debugging of popup menus
     // (see https://docs.oracle.com/javase/10/troubleshoot/awt.htm#JSTGD425)
     jvmArgs += "-Dsun.awt.disablegrab=true"

--- a/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
@@ -239,6 +239,15 @@ public final class Main implements Callable<Integer> {
     public Integer call() throws Exception {
         Debug.ENABLE_DEBUG = debug;
 
+        try {
+            // weigl: You can set assertion status via the system class loader,
+            // but can not get its current status. Here a workaround.
+            assert false;
+            LOGGER.info("Assertion evaluation is disabled.");
+        } catch (AssertionError e) {
+            LOGGER.info("Assertion evaluation is enabled.");
+        }
+
         if (tacletDir != null) {
             System.setProperty(RuleSourceFactory.STD_TACLET_DIR_PROP_KEY,
                 tacletDir.toAbsolutePath().toString());
@@ -301,11 +310,7 @@ public final class Main implements Callable<Integer> {
             LOGGER.info("Running in debug mode");
         }
 
-        if (Debug.ENABLE_ASSERTION) {
-            LOGGER.info("Using assertions");
-        } else {
-            LOGGER.info("Not using assertions");
-        }
+        LOGGER.info("Debug.ENABLE_ASSERTION = {}", Debug.ENABLE_ASSERTION);
 
         if (riflFileName != null) {
             LOGGER.info("Loading RIFL specification from {}", riflFileName);
@@ -350,11 +355,6 @@ public final class Main implements Callable<Integer> {
         }
 
         AbstractMediatorUserInterfaceControl ui = createUserInterface(inputFiles);
-
-        System.out.println(inputFiles.isEmpty());
-        System.out.println(examplesFolder);
-        System.out.println(ui);
-        System.out.println(showExampleChooserIfExamplesDirIsDefined);
 
         if (inputFiles.isEmpty()) {
             if (examplesFolder != null


### PR DESCRIPTION
## Related Issue

Assertions are not enabled when KeY is run by Gradle. Hence, assertions are not checked during the quality assurance of releases. 

## Intended Change

1. `-ea` set as JVM argument for `:key.ui:run`
2. Report whether `assert` is enabled on console.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: Manually inspection.

