### PR TITLE
Improve error message in headless mode

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -394,8 +394,11 @@ public final class MainWindow extends JFrame {
     public static MainWindow getInstance(boolean ensureIsVisible) {
         if (GraphicsEnvironment.isHeadless()) {
             LOGGER.error(
-                "Error: KeY started in graphical mode, " + "but no graphical environment present.");
-            LOGGER.error("Please use the --auto option to start KeY in batch mode.");
+                "Error: KeY started in graphical mode, but no graphical environment present or supported.");
+            LOGGER.error(
+                "If this is unexpected, ensure that you are not using a headless version of Java " +
+                    "(or force windowed mode with java parameter -Djava.awt.headless=false).");
+            LOGGER.error("Otherwise, please use the --auto option to start KeY in batch mode.");
             LOGGER.error("Use the --help option for more command line options.");
             System.exit(-1);
         }


### PR DESCRIPTION

## Intended Change

A fellow student was using KeY on a system where headless java was installed, and was thus confused why the proram would not launch normally. It seems that [`java.awt.GraphicsEnvironment.isHeadless()`](https://docs.oracle.com/javase/8/docs/api/java/awt/GraphicsEnvironment.html#isHeadless--) also returns `false` if `libawt` is not available, i.e. a headless version of Java is installed. In this case it helped us to debug to set the java runtime flag `-Djava.awt.headless=false`, thus exposing the actual problem (in the form of a crash because `libawt` is not installed).

For this reason, we found it would be nice to provide a bit more details about possible causes in case the program terminates with error when launched normally in headless mode.


## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- There are changes to the (Java) code
- Other: error message improvement

## Ensuring quality
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
