### PR TITLE
Fix deadlock when showing JML warnings dialog

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
@@ -592,7 +592,7 @@ public class WindowUserInterfaceControl extends AbstractMediatorUserInterfaceCon
 
     @Override
     public void reportWarnings(ImmutableSet<PositionedString> warnings) {
-        IssueDialog.showWarningsIfNecessary(mainWindow, warnings);
+        SwingUtilities.invokeLater(() -> IssueDialog.showWarningsIfNecessary(mainWindow, warnings));
     }
 
     /**


### PR DESCRIPTION
## Intended Change

It seems this method is called on the worker thread, which may lead to a deadlock when creating the dialog.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: loaded a file with JML warnings (specifically, missing decreases). Now works fine, previously it got stuck on "Reading project.key".

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.