### PR TITLE
(Re-)activating an ancient rule for the treatment of exactInstance of null

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/javaRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/javaRules.key
@@ -387,7 +387,7 @@
     // MU: ... uncommented more than 18 years later
     dynamic_type_for_null {
         \find (G::exactInstance(null))
-        \varcond(\not\same(G,Null)) 
+        \varcond(\not\same(G,Null))
         \replacewith(FALSE)
         \heuristics(concrete)
     };


### PR DESCRIPTION
## Related Issue

`int[]::exactInstance(null) = TRUE -> false`

cannot be proved.
This was triggered by a failing testcase that was commented out

## Intended Change

Reactivating a rule deactivated by Woiciech before 2007.

## Type of pull request

- There are changes to the taclet rule base

## Ensuring quality

- We extensively discussed the issue during an onsite KeY meeting.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
