### PR TITLE
Avoid cost computation for rules in rule sets like concrete, simplify_prog etc.

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -23,6 +23,7 @@ import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.TacletApp;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import de.uka.ilkd.key.rule.merge.MergeRule;
+import de.uka.ilkd.key.strategy.DelegatingRuleAppManager;
 import de.uka.ilkd.key.strategy.QueueRuleApplicationManager;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.util.properties.MapProperties;
@@ -140,7 +141,7 @@ public final class Goal implements ProofGoal<Goal> {
         this.goalStrategy = null;
         this.strategyInfos = new MapProperties();
         this.tagManager = new FormulaTagManager(this);
-        setRuleAppManager(new QueueRuleApplicationManager());
+        setRuleAppManager(new DelegatingRuleAppManager(new QueueRuleApplicationManager()));
         this.localNamespaces =
             node.proof().getServices().getNamespaces().copyWithParent().copyWithParent();
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
@@ -20,7 +20,8 @@ public class DelegatingRuleAppManager implements RuleApplicationManager<Goal> {
 
     private static String[] ruleSetNames =
         { "alpha", "concrete", "simplify", "simplify_prog", "simplify_prog_subset",
-            "simplify_expression" };
+            "simplify_expression", "update_elim", "update_apply_on_update", "update_apply",
+            "update_join", "elimQuantifier" };
 
     private HashSet<String> ruleSets = new HashSet<>();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
@@ -1,0 +1,94 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.strategy;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.rule.NoPosTacletApp;
+
+import org.key_project.prover.rules.RuleApp;
+import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.strategy.RuleApplicationManager;
+import org.key_project.prover.strategy.costbased.NumberRuleAppCost;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSLList;
+
+public class DelegatingRuleAppManager implements RuleApplicationManager<Goal> {
+
+    private static String[] ruleSetNames =
+        { "alpha", "concrete", "simplify", "simplify_prog", "simplify_expression" };
+
+    private HashSet<String> ruleSets = new HashSet<>();
+
+    private final RuleApplicationManager<Goal> costBasedAppManager;
+    private ImmutableList<RuleAppContainer> queue;
+    private Goal goal;
+    private RuleApp nextApp;
+
+    public DelegatingRuleAppManager(RuleApplicationManager<Goal> costRuleAppMgr) {
+        this.costBasedAppManager = costRuleAppMgr;
+        queue = ImmutableSLList.nil();
+        ruleSets.addAll(Arrays.asList(ruleSetNames));
+    }
+
+    @Override
+    public void clearCache() {
+        costBasedAppManager.clearCache();
+    }
+
+    @Override
+    public RuleApp peekNext() {
+        RuleApp next = nextApp;
+        if (next == null && !queue.isEmpty()) {
+            var myQueue = queue;
+            while (next == null && !myQueue.isEmpty()) {
+                next = myQueue.head().completeRuleApp(goal);
+                myQueue = myQueue.tail();
+            }
+            queue = myQueue;
+        }
+        nextApp = next == null ? costBasedAppManager.peekNext() : next;
+        return nextApp;
+    }
+
+    @Override
+    public RuleApp next() {
+        final RuleApp next = peekNext();
+        nextApp = null;
+        return next;
+    }
+
+    @Override
+    public RuleApplicationManager<Goal> copy() {
+        DelegatingRuleAppManager copy = new DelegatingRuleAppManager(costBasedAppManager.copy());
+        copy.queue = queue;
+        return copy;
+    }
+
+    @Override
+    public void setGoal(Goal p_goal) {
+        this.goal = p_goal;
+        costBasedAppManager.setGoal(p_goal);
+    }
+
+    @Override
+    public void ruleAdded(RuleApp rule, PosInOccurrence pos) {
+        if (rule instanceof NoPosTacletApp tapp && tapp.taclet().getRuleSets().size() == 1 &&
+                tapp.taclet().getRuleSets().exists(rs -> ruleSets.contains(rs.name().toString()))) {
+            queue = queue.prepend(new FindTacletAppContainer(tapp, pos,
+                NumberRuleAppCost.getZeroCost(), goal, goal.getTime()));
+        } else {
+            costBasedAppManager.ruleAdded(rule, pos);
+        }
+    }
+
+    @Override
+    public void rulesAdded(ImmutableList<? extends RuleApp> rule, PosInOccurrence pos) {
+        for (RuleApp ruleApp : rule) {
+            ruleAdded(ruleApp, pos);
+        }
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
@@ -19,7 +19,8 @@ import org.key_project.util.collection.ImmutableSLList;
 public class DelegatingRuleAppManager implements RuleApplicationManager<Goal> {
 
     private static String[] ruleSetNames =
-        { "alpha", "concrete", "simplify", "simplify_prog", "simplify_expression" };
+        { "alpha", "concrete", "simplify", "simplify_prog", "simplify_prog_subset",
+            "simplify_expression" };
 
     private HashSet<String> ruleSets = new HashSet<>();
 
@@ -76,8 +77,9 @@ public class DelegatingRuleAppManager implements RuleApplicationManager<Goal> {
 
     @Override
     public void ruleAdded(RuleApp rule, PosInOccurrence pos) {
-        if (rule instanceof NoPosTacletApp tapp && tapp.taclet().getRuleSets().size() == 1 &&
-                tapp.taclet().getRuleSets().exists(rs -> ruleSets.contains(rs.name().toString()))) {
+        if (rule instanceof NoPosTacletApp tapp &&
+                tapp.taclet().getRuleSets().stream()
+                        .allMatch(rs -> ruleSets.contains(rs.name().toString()))) {
             queue = queue.prepend(new FindTacletAppContainer(tapp, pos,
                 NumberRuleAppCost.getZeroCost(), goal, goal.getTime()));
         } else {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/DelegatingRuleAppManager.java
@@ -19,9 +19,10 @@ import org.key_project.util.collection.ImmutableSLList;
 public class DelegatingRuleAppManager implements RuleApplicationManager<Goal> {
 
     private static String[] ruleSetNames =
-        { "alpha", "concrete", "simplify", "simplify_prog", "simplify_prog_subset",
-            "simplify_expression", "update_elim", "update_apply_on_update", "update_apply",
-            "update_join", "elimQuantifier" };
+        { "alpha", "concrete", "simplify_prog", "simplify_prog_subset",
+            "simplify_expression", "simplify_literals",
+            "update_elim", "update_apply_on_update", "update_apply", "update_join",
+            "elimQuantifier" };
 
     private HashSet<String> ruleSets = new HashSet<>();
 

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/loopRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/loopRules.key
@@ -49,7 +49,7 @@
         \find(\modality{#allmodal}{.. #forloop ...}\endmodality (post))
         \varcond(\newLabel(#innerLabel), \newLabel(#outerLabel))
         \replacewith(\modality{#allmodal}{.. #for-to-while(#innerLabel, #outerLabel, #forloop) ...}\endmodality (post))
-        \heuristics(simplify_prog)
+        \heuristics(simplify_prog, loop_rewrite)
     };
 
     arrayInitialisation {

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/ruleSetsDeclarations.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/ruleSetsDeclarations.key
@@ -54,6 +54,7 @@
     loop_expand;
     loop_scope_inv_taclet;
     loop_scope_expand;
+    loop_rewrite;
 
     javaIntegerSemantics;
     executeIntegerAssignment;


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

Possible alternative to one step simplifier. 
This PR evaluates an option to bypass cost computation for specific rules.
Experimental. Maybe a possibility to adapt macros to work by replacing the rule app manager

## Plan

<!-- If this pull request is not yet finished, but has open jobs,
     please list them here. It helps others to estimate the state of this
     PR. This list can and should be adapted as the PR develops.
     Items should be crossed out when finished, not deleted.
     
     Remove the section if the PR was finished at submission time.
     The following items are examples:
-->
* [x] Implement delegate rule app manager
* [ ] Optimize behavior of delegate rule app manager
  * use different queues for concrete, simplify etc. 
  * sort some queues (prefer higher positions for concrete or simplify) etc. 
* [ ] Code cleanup
* [ ] Document the changes

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- [ ] I made sure that introduced/changed code is well documented (javadoc and inline comments).
- [ ] I have tested the feature as follows: ...
- [ ] I have checked that runtime performance has not deteriorated.


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
