### PR TITLE
fix #3721, getParent().toUri() requires absolute paths

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
@@ -220,7 +220,7 @@ public class KeYFile implements EnvInput {
             try {
                 KeyAst.File ctx = getParseContext();
                 // weigl: fix #3721, absolute path is required to solve relative filenames.
-                var absPath = file.file().toAbsolutePath().getParent();
+                Path absPath = file.file().toAbsolutePath().getParent();
                 includes = ctx.getIncludes(absPath.toUri().toURL());
             } catch (ParseCancellationException e) {
                 throw new ParseCancellationException(e);
@@ -242,7 +242,7 @@ public class KeYFile implements EnvInput {
         Path bootClassPathFile = Paths.get(bootClassPath);
         if (!bootClassPathFile.isAbsolute()) {
             // convert to absolute by resolving against the parent path of the parsed file
-            var parentDirectory = file.file().getParent();
+            Path parentDirectory = file.file().getParent();
             bootClassPathFile = parentDirectory.resolve(bootClassPath);
         }
 
@@ -261,7 +261,7 @@ public class KeYFile implements EnvInput {
     @Override
     public @NonNull List<Path> readClassPath() {
         ProblemInformation pi = getProblemInformation();
-        var parentDirectory = file.file().getParent();
+        Path parentDirectory = file.file().getParent();
         List<Path> fileList = new ArrayList<>();
         for (String cp : pi.getClasspath()) {
             if (cp == null) {
@@ -282,10 +282,10 @@ public class KeYFile implements EnvInput {
         ProblemInformation pi = getProblemInformation();
         String javaPath = pi.getJavaSource();
         if (javaPath != null) {
-            var absFile = Paths.get(javaPath);
+            Path absFile = Paths.get(javaPath);
             if (!absFile.isAbsolute()) {
                 // convert to absolute by resolving against the parent path of the parsed file
-                var parent = file.file().getParent();
+                Path parent = file.file().getParent();
                 absFile = parent.resolve(javaPath);
             }
             if (!Files.exists(absFile)) {


### PR DESCRIPTION
## Related Issue

Fix #3721: Error in `KeYFile.readIncludes()` as Uri for `java.nio.Path` can not be found. Java NIO requires an absolute for `getParent()` and `toUri()` to be called successfully. 

It seems that `"getParent().toUri()"` is nowhere else present in the code base. 

## Type of pull request


- Bug fix (non-breaking change which fixes an issue)
 

## Ensuring quality

Hand tested: 

<img width="797" height="337" alt="image" src="https://github.com/user-attachments/assets/6b993cad-6980-4e28-9a3c-a2fd9f649285" />

