### PR TITLE
Send Feedback using Github issues

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -1046,6 +1046,7 @@ public final class MainWindow extends JFrame {
         help.add(new KeYProjectHomepageAction(this));
         // help.add(new SystemInfoAction(this));
         help.add(new MenuSendFeedackAction(this));
+        help.add(new CreateGithubIssueAction(this));
         help.add(new LicenseAction(this));
         return help;
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
@@ -1,0 +1,113 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.actions;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.fonticons.FontAwesomeBrands;
+import de.uka.ilkd.key.gui.fonticons.IconFontProvider;
+import de.uka.ilkd.key.gui.fonticons.IconProvider;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.io.OutputStreamProofSaver;
+import de.uka.ilkd.key.util.KeYConstants;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This action allows the creation of Github issues with more ease.
+ * <p>
+ * It follows the current bug template and adds Java source and KeY version automatically.
+ *
+ * @author weigl
+ */
+public class CreateGithubIssueAction extends MainWindowAction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateGithubIssueAction.class);
+    private static final String URL = "https://github.com/keyproject/key/issues/new";
+
+    public static final IconProvider ICON_GITHUB =
+        new IconFontProvider(FontAwesomeBrands.GITHUB);
+
+    public CreateGithubIssueAction(MainWindow mainWindow) {
+        super(mainWindow);
+        setName("Create Github Issue");
+        setIcon(ICON_GITHUB.get());
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent event) {
+        var body = """
+                ## Description
+                > Please describe your concern in detail!
+
+                %JAVA%
+
+                ## Reproducible
+
+                > Is the issue reproducible?
+                > Select one of: always, sometimes, random, have not tried, n/a
+
+                ### Steps to reproduce
+                > Describe the steps needed to reproduce the issue.
+
+                1. ...
+                2. ...
+                3. ...
+                > What is your expected behavior and what was the actual behavior?
+
+                ### Additional information
+
+                > Add more details here. In particular: if you have a stacktrace, put it here.
+                ---
+                * Commit: %CHECKSUM%
+                """;
+
+        String java = "";
+        Proof proof = MainWindow.getInstance().getMediator().getSelectedProof();
+        if (proof != null) {
+            File javaSourceLocation = OutputStreamProofSaver.getJavaSourceLocation(proof);
+            if (javaSourceLocation != null) {
+                Path path = javaSourceLocation.toPath();
+                try (final var walker = Files.walk(path)) {
+                    java = walker.map(it -> {
+                        try {
+                            if (it.getFileName().toString().endsWith(".java")) {
+                                return "* " + it.getFileName() + "\n```\n" + Files.readString(it)
+                                    + "```\n";
+                            }
+                        } catch (IOException e) {
+                        }
+                        return null;
+                    }).filter(Objects::nonNull)
+                            .collect(Collectors.joining("\n"));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        body = body.replace("%CHECKSUM%", KeYConstants.INTERNAL_VERSION)
+                .replace("%JAVA%", java);
+
+        URI uri = URI.create(URL + "?body=" + URLEncoder.encode(body, Charset.defaultCharset()));
+        LOGGER.info("Opening URI: {}", uri);
+        try {
+            Desktop.getDesktop().browse(uri);
+        } catch (IOException e) {
+            LOGGER.error("Could not open browser for URI {}.", uri, e);
+        }
+
+    }
+}


### PR DESCRIPTION
## Intended Change

This PR adds a new menu item to create issues on GitHub directly from this repository. 

This functionality uses the [Github URL API](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue#creating-an-issue-from-a-url-query); no API key is required, and the user's account is used. (It just prefills the issues form.)

**Note: the length of URLs is limited.**

It automatically inserts all Java files findable in the current `JavaModel#modelDir`, and the current `KeYConstant.INTERNAL_VERSION`. 

## Plan

* [x] Implement it
* [x] Test it by clicking on it 
* [x] Discussion

## Type of pull request

- New feature (non-breaking change which adds functionality)

## Ensuring quality
   
- I **will** made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: manually clicking the button.
