### PR TITLE
Refixing #3721: Starting KeY UI with local files

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/core/Main.java
@@ -546,6 +546,9 @@ public final class Main implements Callable<Integer> {
                 workingDir = f;
             } else {
                 workingDir = f.getParent();
+                if (workingDir == null) {
+                    workingDir = IOUtil.getCurrentDirectory();
+                }
             }
         } else {
             workingDir = IOUtil.getCurrentDirectory();


### PR DESCRIPTION
## Related Issue

This pull request resolves #3721. Again.

## Intended Change

This was broken by migration to `java.nio.Path`. When starting KeY for UI mode, one would get an exception
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.toFile()" because the return value of "de.uka.ilkd.key.core.Main.getWorkingDir()" is null
	at de.uka.ilkd.key.gui.actions.OpenFileAction.<init>(OpenFileAction.java:26)
	at de.uka.ilkd.key.gui.MainWindow.layoutMain(MainWindow.java:544)
```

The plan is to allow local calls like explained in #3721 and #3722 which fixed half of it.


## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I added new test case(s) for new functionality.

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
