### PR TITLE
Improve behavior in case of not found methods

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/reference/MethodReference.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/reference/MethodReference.java
@@ -374,7 +374,8 @@ public class MethodReference extends JavaNonTerminalProgramElement
     public KeYJavaType getKeYJavaType(Services services, ExecutionContext ec) {
         IProgramMethod meth = method(services, determineStaticPrefixType(services, ec), ec);
         if (meth == null) {
-            return ec.getTypeReference().getKeYJavaType();
+            throw new IllegalStateException(
+                "Could not determine type for method " + name.toString());
         }
         return meth.getReturnType();
 

--- a/key.core/src/main/resources/de/uka/ilkd/key/java/JavaRedux/java/lang/Math.java
+++ b/key.core/src/main/resources/de/uka/ilkd/key/java/JavaRedux/java/lang/Math.java
@@ -1,7 +1,7 @@
 package java.lang;
 
 public final class Math {
-    
+
     private Math() {}
     
     /*@ public normal_behavior
@@ -92,4 +92,6 @@ public final class Math {
     public static double pow(double a , double b);
     public static double exp(double a);
     public static double atan(double a);
+
+    public static double random();
 }


### PR DESCRIPTION
## Intended Change

 When resolving a method call of an unknown method, the type resolution returned the container type as result type of the method if the method was not found. This led to not understandable error messages later on.

This fix now throws an exception informing the user that a method call could not be resolved.



## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality
- I have tested the feature as follows: standard KeY tests

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
