### PR TITLE
Fix bug in ProofManagementDialog

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofManagementDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofManagementDialog.java
@@ -132,7 +132,10 @@ public final class ProofManagementDialog extends JDialog {
                     } else if (ps.getProofClosedByCache()) {
                         label.setIcon(KEY_CACHED_CLOSED);
                     } else {
-                        assert ps.getProofOpen();
+                        if (!ps.getProofOpen()) {
+                            LOGGER.warn("Unknown proof status " + ps
+                                + " in ProofManagementDialog. Displaying open icon.");
+                        }
                         label.setIcon(KEY_OPEN);
                     }
                 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofManagementDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofManagementDialog.java
@@ -513,6 +513,8 @@ public final class ProofManagementDialog extends JDialog {
                     startButton.setIcon(KEY_OPEN);
                 } else if (status.getProofClosedButLemmasLeft()) {
                     startButton.setIcon(KEY_ALMOST_CLOSED);
+                } else if (status.getProofClosedByCache()) {
+                    startButton.setIcon(KEY_CACHED_CLOSED);
                 } else {
                     assert status.getProofClosed();
                     startButton.setIcon(KEY_CLOSED);


### PR DESCRIPTION
## Intended Change

Fixes a bug in the proof obligation browser.

When a proof is closed, the PO browser displays the corresponding closed icon inside the "Goto Proof" button. It happened that when selecting a PO, where the goal was closed by caching, the corresponding icon was not found causing an assertion failure. This renderes the browser unusable as it did not go to the corresponding proof and one could not open the dialog again.

This PR fixes this bug.


## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
## Ensuring quality

- I have tested the feature as follows: Closed a proof by caching, open the dialog, selected the closed PO: no exception thrown, Goto Proof worked and PO browser could be used again afterwards

## Additional information and contact(s)

Maybe we should also replace the assertion with simple logging? In the worst case the button would display the wrong close icon.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
