### PR TITLE
Update Gradle version to 9.5 and deprecated method replacements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,8 +149,17 @@ subprojects {
             excludeTags "owntest", "interactive", "performance"
         }
 
-        afterTest { desc, result -> logger.error "${result.resultType}: ${desc.className}#${desc.name}" }
-        beforeTest { desc -> logger.error "> ${desc.className}#${desc.name}" }
+        addTestListener(new TestListener() {
+                void afterTest(TestDescriptor desc, TestResult result) {
+                    logger.error("${result.getResultType()}: ${desc.getClassName()}#${desc.getName()}")
+                }
+            })
+
+        addTestListener(new TestListener() {
+            void beforeTest(TestDescriptor descriptor) {
+                logger.error("> ${descriptor.getClassName()}#${descriptor.getName()}")
+            }
+        })
 
         testLogging {
             outputs.upToDateWhen { false }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Intended Change

Update gradle version to 9.5.0 and replace deprecated before/afterTest usages

## Type of pull request

- There are changes to the deployment/CI infrastructure (gradle, github, ...)

## Ensuring quality

- I have tested the feature as follows: let's see if the build goes through :-)

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
