### PR TITLE
Better ImmutableList 

### DIFF
--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/ProofObligationVars.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/ProofObligationVars.java
@@ -18,7 +18,6 @@ import org.key_project.logic.Namespace;
 import org.key_project.logic.op.Function;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -135,7 +134,7 @@ public class ProofObligationVars {
      */
     private ImmutableList<JTerm> buildFormalParamVars(Services services)
             throws IllegalArgumentException {
-        ImmutableList<JTerm> formalParamVars = ImmutableSLList.nil();
+        ImmutableList<JTerm> formalParamVars = ImmutableList.nil();
         for (JTerm param : pre.localVars) {
             ProgramVariable paramVar = param.op(ProgramVariable.class);
             ProgramElementName pen = new ProgramElementName("_" + paramVar.name());

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/macros/ExhaustiveProofMacro.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/macros/ExhaustiveProofMacro.java
@@ -23,7 +23,6 @@ import org.key_project.prover.engine.TaskStartedInfo.TaskKind;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * The abstract class ExhaustiveProofMacro can be used to create compound macros which either apply
@@ -40,7 +39,7 @@ public abstract class ExhaustiveProofMacro extends AbstractProofMacro {
             ProofMacro macro) {
         if (posInOcc == null || posInOcc.subTerm() == null) {
             return null;
-        } else if (macro.canApplyTo(proof, ImmutableSLList.<Goal>nil().prepend(goal), posInOcc)) {
+        } else if (macro.canApplyTo(proof, ImmutableList.<Goal>nil().prepend(goal), posInOcc)) {
             return posInOcc;
         } else {
             final var subTerm = posInOcc.subTerm();
@@ -124,7 +123,7 @@ public abstract class ExhaustiveProofMacro extends AbstractProofMacro {
                 if (!isCached) {
                     // node has not been checked before, so do it
                     boolean canBeApplied =
-                        canApplyTo(proof, ImmutableSLList.<Goal>nil().prepend(goal), posInOcc);
+                        canApplyTo(proof, ImmutableList.<Goal>nil().prepend(goal), posInOcc);
                     if (!canBeApplied) {
                         // canApplyTo checks all open goals. thus, if it returns
                         // false, then this macro is not applicable at all and
@@ -143,7 +142,7 @@ public abstract class ExhaustiveProofMacro extends AbstractProofMacro {
                     pml.taskStarted(new DefaultTaskStartedInfo(TaskKind.Macro, getName(), 0));
                     synchronized (macro) {
                         // wait for macro to terminate
-                        info = macro.applyTo(uic, proof, ImmutableSLList.<Goal>nil().prepend(goal),
+                        info = macro.applyTo(uic, proof, ImmutableList.<Goal>nil().prepend(goal),
                             applicableAt, pml);
                     }
                     pml.taskFinished(info);

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicBlockExecutionSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicBlockExecutionSnippet.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.speclang.AuxiliaryContract;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -33,7 +32,7 @@ class BasicBlockExecutionSnippet extends ReplaceAndRegisterMethod implements Fac
     @Override
     public JTerm produce(BasicSnippetData d, ProofObligationVars poVars)
             throws UnsupportedOperationException {
-        ImmutableList<JTerm> posts = ImmutableSLList.nil();
+        ImmutableList<JTerm> posts = ImmutableList.nil();
         if (poVars.post.self != null) {
             posts = posts.append(d.tb.equals(poVars.post.self, poVars.pre.self));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicLoopExecutionSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicLoopExecutionSnippet.java
@@ -20,7 +20,6 @@ import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.speclang.LoopSpecification;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 public class BasicLoopExecutionSnippet extends ReplaceAndRegisterMethod implements FactoryMethod {
@@ -28,7 +27,7 @@ public class BasicLoopExecutionSnippet extends ReplaceAndRegisterMethod implemen
     @Override
     public JTerm produce(BasicSnippetData d, ProofObligationVars poVars)
             throws UnsupportedOperationException {
-        ImmutableList<JTerm> posts = ImmutableSLList.nil();
+        ImmutableList<JTerm> posts = ImmutableList.nil();
         if (poVars.post.self != null) {
             posts = posts.append(d.tb.equals(poVars.post.self, poVars.pre.self));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicSnippetData.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicSnippetData.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.util.InfFlowSpec;
 import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 
@@ -150,7 +149,7 @@ public class BasicSnippetData {
         // add guard term to information flow specs (necessary for soundness)
         // and add the modified specs to the table
         ImmutableList<InfFlowSpec> infFlowSpecs = invariant.getInfFlowSpecs(services);
-        ImmutableList<InfFlowSpec> modifiedSpecs = ImmutableSLList.nil();
+        ImmutableList<InfFlowSpec> modifiedSpecs = ImmutableList.nil();
         for (InfFlowSpec infFlowSpec : infFlowSpecs) {
             ImmutableList<JTerm> modifiedPreExps = infFlowSpec.preExpressions.append(guardTerm);
             ImmutableList<JTerm> modifiedPostExps = infFlowSpec.postExpressions.append(guardTerm);
@@ -234,7 +233,7 @@ public class BasicSnippetData {
 
 
     private ImmutableList<JTerm> toTermList(ImmutableSet<LocationVariable> vars) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (ProgramVariable v : vars) {
             result = result.append(tb.var(v));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicSymbolicExecutionSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/BasicSymbolicExecutionSnippet.java
@@ -33,7 +33,6 @@ import de.uka.ilkd.key.logic.op.ProgramVariable;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  *
@@ -47,7 +46,7 @@ class BasicSymbolicExecutionSnippet extends ReplaceAndRegisterMethod implements 
         assert poVars.exceptionParameter.op() instanceof LocationVariable
                 : "Something is wrong with the catch variable";
 
-        ImmutableList<JTerm> posts = ImmutableSLList.nil();
+        ImmutableList<JTerm> posts = ImmutableList.nil();
         if (poVars.post.self != null) {
             posts = posts.append(d.tb.equals(poVars.post.self, poVars.pre.self));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/InfFlowContractAppInOutRelationSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/InfFlowContractAppInOutRelationSnippet.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.logic.JTerm;
 import de.uka.ilkd.key.util.InfFlowSpec;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  *
@@ -27,7 +26,7 @@ class InfFlowContractAppInOutRelationSnippet extends InfFlowInputOutputRelationS
             InfFlowSpec infFlowSpec2, BasicSnippetData d, ProofObligationVars vs1,
             ProofObligationVars vs2, JTerm eqAtLocsTerm) {
         // build equalities for newObjects terms
-        ImmutableList<JTerm> newObjEqs = ImmutableSLList.nil();
+        ImmutableList<JTerm> newObjEqs = ImmutableList.nil();
         Iterator<JTerm> newObjects1It = infFlowSpec1.newObjects.iterator();
         Iterator<JTerm> newObjects2It = infFlowSpec2.newObjects.iterator();
         for (int i = 0; i < infFlowSpec1.newObjects.size(); i++) {

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/InfFlowInputOutputRelationSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/InfFlowInputOutputRelationSnippet.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.util.InfFlowSpec;
 import org.key_project.logic.Term;
 import org.key_project.logic.op.Function;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Generate term "self != null".
@@ -97,7 +96,7 @@ class InfFlowInputOutputRelationSnippet extends ReplaceAndRegisterMethod
     private JTerm buildOutputRelation(BasicSnippetData d, ProofObligationVars vs1,
             ProofObligationVars vs2, InfFlowSpec infFlowSpec1, InfFlowSpec infFlowSpec2) {
         // build equalities for post expressions
-        ImmutableList<JTerm> eqAtLocs = ImmutableSLList.nil();
+        ImmutableList<JTerm> eqAtLocs = ImmutableList.nil();
 
         Iterator<JTerm> postExp1It = infFlowSpec1.postExpressions.iterator();
         Iterator<JTerm> postExp2It = infFlowSpec2.postExpressions.iterator();
@@ -123,7 +122,7 @@ class InfFlowInputOutputRelationSnippet extends ReplaceAndRegisterMethod
             InfFlowSpec infFlowSpec2, BasicSnippetData d, ProofObligationVars vs1,
             ProofObligationVars vs2, JTerm eqAtLocsTerm) {
         // build equalities for newObjects terms
-        ImmutableList<JTerm> newObjEqs = ImmutableSLList.nil();
+        ImmutableList<JTerm> newObjEqs = ImmutableList.nil();
         Iterator<JTerm> newObjects1It = infFlowSpec1.newObjects.iterator();
         Iterator<JTerm> newObjects2It = infFlowSpec2.newObjects.iterator();
         for (int i = 0; i < infFlowSpec1.newObjects.size(); i++) {

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/ReplaceAndRegisterMethod.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/ReplaceAndRegisterMethod.java
@@ -22,7 +22,6 @@ import org.key_project.logic.Visitor;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -78,15 +77,15 @@ abstract class ReplaceAndRegisterMethod {
 
     final InfFlowSpec replace(InfFlowSpec terms, StateVars origVars, StateVars poVars,
             TermBuilder tb) {
-        ImmutableList<JTerm> resultPreExps = ImmutableSLList.nil();
+        ImmutableList<JTerm> resultPreExps = ImmutableList.nil();
         for (JTerm t : terms.preExpressions) {
             resultPreExps = resultPreExps.append(replace(t, origVars, poVars, tb));
         }
-        ImmutableList<JTerm> resultPostExps = ImmutableSLList.nil();
+        ImmutableList<JTerm> resultPostExps = ImmutableList.nil();
         for (JTerm t : terms.postExpressions) {
             resultPostExps = resultPostExps.append(replace(t, origVars, poVars, tb));
         }
-        ImmutableList<JTerm> resultNewObjecs = ImmutableSLList.nil();
+        ImmutableList<JTerm> resultNewObjecs = ImmutableList.nil();
         for (JTerm t : terms.newObjects) {
             resultNewObjecs = resultNewObjecs.append(replace(t, origVars, poVars, tb));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/TwoStateMethodPredicateSnippet.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/po/snippet/TwoStateMethodPredicateSnippet.java
@@ -21,7 +21,6 @@ import org.key_project.logic.Namespace;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -118,8 +117,8 @@ abstract class TwoStateMethodPredicateSnippet implements FactoryMethod {
      */
     private ImmutableList<JTerm> extractTermListForPredicate(IProgramMethod pm,
             ProofObligationVars poVars, boolean hasMby) {
-        ImmutableList<JTerm> relevantPreVars = ImmutableSLList.nil();
-        ImmutableList<JTerm> relevantPostVars = ImmutableSLList.nil();
+        ImmutableList<JTerm> relevantPreVars = ImmutableList.nil();
+        ImmutableList<JTerm> relevantPostVars = ImmutableList.nil();
 
         if (!pm.isStatic()) {
             // self is relevant in the pre and post state for constructors

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/proof/init/StateVars.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/proof/init/StateVars.java
@@ -22,7 +22,6 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -65,7 +64,7 @@ public class StateVars {
         this.heap = heap;
         this.mbyAtPre = mbyAtPre;
 
-        ImmutableList<JTerm> terms = ImmutableSLList.nil();
+        ImmutableList<JTerm> terms = ImmutableList.nil();
         terms = appendIfNotNull(terms, heap);
         terms = appendIfNotNull(terms, self);
         terms = appendIfNotNull(terms, guard);
@@ -75,7 +74,7 @@ public class StateVars {
         terms = appendIfNotNull(terms, mbyAtPre);
         termList = terms;
 
-        ImmutableList<JTerm> allTerms = ImmutableSLList.nil();
+        ImmutableList<JTerm> allTerms = ImmutableList.nil();
         allTerms = allTerms.append(heap);
         allTerms = allTerms.append(self);
         allTerms = allTerms.append(guard);
@@ -148,7 +147,7 @@ public class StateVars {
 
     private static ImmutableList<JTerm> copyVariables(ImmutableList<JTerm> ts, String postfix,
             Services services) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JTerm t : ts) {
             result = result.append(copyVariable(t, postfix, services));
         }
@@ -284,7 +283,7 @@ public class StateVars {
         JTerm mbyAtPre = (origPreVars.mbyAtPre == origPostVars.mbyAtPre) ? preVars.mbyAtPre
                 : copyVariable(origPostVars.mbyAtPre, postfix, services);
 
-        ImmutableList<JTerm> localPostVars = ImmutableSLList.nil();
+        ImmutableList<JTerm> localPostVars = ImmutableList.nil();
         Iterator<JTerm> origPreVarsIt = origPreVars.localVars.iterator();
         Iterator<JTerm> localPreVarsIt = preVars.localVars.iterator();
         for (JTerm origPostVar : origPostVars.localVars) {
@@ -390,7 +389,7 @@ public class StateVars {
 
     static <T> ImmutableList<T> ops(ImmutableList<JTerm> terms, Class<T> opClass)
             throws IllegalArgumentException {
-        ImmutableList<T> ops = ImmutableSLList.nil();
+        ImmutableList<T> ops = ImmutableList.nil();
         for (JTerm t : terms) {
             ops = ops.append(t.op(opClass));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/InfFlowBlockContractInternalRule.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/InfFlowBlockContractInternalRule.java
@@ -49,7 +49,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.Nullable;
@@ -422,7 +421,7 @@ public class InfFlowBlockContractInternalRule extends BlockContractInternalRule 
             return varTerms;
         }
         final TermBuilder tb = services.getTermBuilder();
-        ImmutableList<JTerm> renamedLocalOuts = ImmutableSLList.nil();
+        ImmutableList<JTerm> renamedLocalOuts = ImmutableList.nil();
         for (JTerm varTerm : varTerms) {
             assert varTerm.op() instanceof LocationVariable;
 
@@ -444,7 +443,7 @@ public class InfFlowBlockContractInternalRule extends BlockContractInternalRule 
             return varTerms;
         }
         final TermBuilder tb = services.getTermBuilder();
-        ImmutableList<JTerm> renamedLocalOuts = ImmutableSLList.nil();
+        ImmutableList<JTerm> renamedLocalOuts = ImmutableList.nil();
         for (JTerm varTerm : varTerms) {
             assert varTerm.op() instanceof LocationVariable;
 

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/InfFlowWhileInvariantRule.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/InfFlowWhileInvariantRule.java
@@ -40,7 +40,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -298,7 +297,7 @@ public class InfFlowWhileInvariantRule extends WhileInvariantRule {
             return varTerms;
         }
         final TermBuilder tb = services.getTermBuilder();
-        ImmutableList<JTerm> localOuts = ImmutableSLList.nil();
+        ImmutableList<JTerm> localOuts = ImmutableList.nil();
         for (final JTerm varTerm : varTerms) {
             assert varTerm.op() instanceof LocationVariable;
 
@@ -320,7 +319,7 @@ public class InfFlowWhileInvariantRule extends WhileInvariantRule {
             return varTerms;
         }
         final TermBuilder tb = services.getTermBuilder();
-        ImmutableList<JTerm> localOuts = ImmutableSLList.nil();
+        ImmutableList<JTerm> localOuts = ImmutableList.nil();
         for (final JTerm varTerm : varTerms) {
             assert varTerm.op() instanceof LocationVariable;
 

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/executor/InfFlowContractAppTacletExecutor.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/executor/InfFlowContractAppTacletExecutor.java
@@ -20,7 +20,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -92,7 +91,7 @@ public class InfFlowContractAppTacletExecutor extends RewriteTacletExecutor {
     private void updateStrategyInfo(Goal goal, final JTerm applFormula) {
         ImmutableList<JTerm> applFormulas = goal.getStrategyInfo(INF_FLOW_CONTRACT_APPL_PROPERTY);
         if (applFormulas == null) {
-            applFormulas = ImmutableSLList.nil();
+            applFormulas = ImmutableList.nil();
         }
         applFormulas = applFormulas.append(applFormula);
         StrategyInfoUndoMethod undo = strategyInfos -> {

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowContractAppTacletBuilder.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowContractAppTacletBuilder.java
@@ -32,7 +32,6 @@ import org.key_project.prover.rules.TacletApplPart;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Builds the rule which inserts information flow contract applications.
@@ -198,7 +197,7 @@ abstract class AbstractInfFlowContractAppTacletBuilder extends AbstractInfFlowTa
         JTerm selfAtPostSV = (appData.pre.self == appData.post.self ? selfAtPreSV
                 : createTermSV(appData.post.self, schemaPrefix, services));
 
-        ImmutableList<JTerm> localVarsAtPostSVs = ImmutableSLList.nil();
+        ImmutableList<JTerm> localVarsAtPostSVs = ImmutableList.nil();
         Iterator<JTerm> appDataPreLocalVarsIt = appData.pre.localVars.iterator();
         Iterator<JTerm> schemaLocalVarsAtPreIt = localVarsAtPreSVs.iterator();
         for (JTerm appDataPostLocalVar : appData.post.localVars) {
@@ -262,10 +261,10 @@ abstract class AbstractInfFlowContractAppTacletBuilder extends AbstractInfFlowTa
         // create sequents
         Sequent assumesSeq =
             JavaDLSequentKit.createAnteSequent(
-                ImmutableSLList.singleton(new SequentFormula(schemaAssumes)));
+                ImmutableList.singleton(new SequentFormula(schemaAssumes)));
         Sequent replaceWithSeq =
             JavaDLSequentKit.createAnteSequent(
-                ImmutableSLList.singleton(new SequentFormula(replaceWithTerm)));
+                ImmutableList.singleton(new SequentFormula(replaceWithTerm)));
 
         // create taclet
         InfFlowContractAppRewriteTacletBuilder tacletBuilder =
@@ -276,7 +275,7 @@ abstract class AbstractInfFlowContractAppTacletBuilder extends AbstractInfFlowTa
             new ApplicationRestriction(ApplicationRestriction.ANTECEDENT_POLARITY));
         tacletBuilder.setAssumesSequent(assumesSeq);
         RewriteTacletGoalTemplate goalTemplate = new RewriteTacletGoalTemplate(replaceWithSeq,
-            ImmutableSLList.nil(), schemaFind);
+            ImmutableList.nil(), schemaFind);
         tacletBuilder.addTacletGoalTemplate(goalTemplate);
         tacletBuilder.addRuleSet(new RuleSet(new Name(IF_CONTRACT_APPLICATION)));
         tacletBuilder.setSurviveSmbExec(true);

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowTacletBuilder.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowTacletBuilder.java
@@ -23,7 +23,6 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -53,7 +52,7 @@ abstract class AbstractInfFlowTacletBuilder extends TermBuilder {
 
     ImmutableList<JTerm> createTermSV(ImmutableList<JTerm> ts, String schemaPrefix,
             Services services) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JTerm t : ts) {
             result = result.append(createTermSV(t, schemaPrefix, services));
         }

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowUnfoldTacletBuilder.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/AbstractInfFlowUnfoldTacletBuilder.java
@@ -26,7 +26,6 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.prover.rules.ApplicationRestriction;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 
@@ -136,7 +135,7 @@ abstract class AbstractInfFlowUnfoldTacletBuilder extends AbstractInfFlowTacletB
         JTerm selfAtPostSV = (poVars.pre.self == poVars.post.self ? selfAtPreSV
                 : createTermSV(poVars.post.self, schemaPrefix, services));
 
-        ImmutableList<JTerm> localVarsAtPostSVs = ImmutableSLList.nil();
+        ImmutableList<JTerm> localVarsAtPostSVs = ImmutableList.nil();
         Iterator<JTerm> appDataPreLocalVarsIt = poVars.pre.localVars.iterator();
         Iterator<JTerm> schemaLocalVarsAtPreIt = localVarsAtPreSVs.iterator();
         for (JTerm appDataPostLocalVar : poVars.post.localVars) {
@@ -245,7 +244,7 @@ abstract class AbstractInfFlowUnfoldTacletBuilder extends AbstractInfFlowTacletB
         if (origVars.localVars == null) {
             localVars = null;
         } else if (origVars.localVars.isEmpty()) {
-            localVars = ImmutableSLList.nil();
+            localVars = ImmutableList.nil();
         }
         if (origVars.result == null) {
             result = null;

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/InfFlowBlockContractTacletBuilder.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/InfFlowBlockContractTacletBuilder.java
@@ -16,7 +16,6 @@ import de.uka.ilkd.key.util.MiscTools;
 import org.key_project.logic.Name;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 
@@ -80,7 +79,7 @@ public final class InfFlowBlockContractTacletBuilder
         ImmutableSet<BlockContract> ifContracts =
             services.getSpecificationRepository().getBlockContracts(blockContract.getBlock());
         ifContracts = filterContracts(ifContracts);
-        ImmutableList<JTerm> contractsApplications = ImmutableSLList.nil();
+        ImmutableList<JTerm> contractsApplications = ImmutableList.nil();
         for (BlockContract cont : ifContracts) {
             InfFlowPOSnippetFactory f = POSnippetFactory.getInfFlowFactory(cont, contAppData,
                 contAppData2, executionContext, services);

--- a/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/InfFlowMethodContractTacletBuilder.java
+++ b/key.core.infflow/src/main/java/de/uka/ilkd/key/informationflow/rule/tacletbuilder/InfFlowMethodContractTacletBuilder.java
@@ -18,7 +18,6 @@ import de.uka.ilkd.key.util.MiscTools;
 import org.key_project.logic.Name;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 
@@ -76,7 +75,7 @@ public final class InfFlowMethodContractTacletBuilder
             ProofObligationVars contAppData2, Services services) {
         ImmutableSet<InformationFlowContract> ifContracts =
             getInformFlowContracts(methodContract.getTarget(), services);
-        ImmutableList<JTerm> contractsApplications = ImmutableSLList.nil();
+        ImmutableList<JTerm> contractsApplications = ImmutableList.nil();
         for (InformationFlowContract cont : ifContracts) {
             InfFlowPOSnippetFactory f =
                 POSnippetFactory.getInfFlowFactory(cont, contAppData, contAppData2, services);

--- a/key.core.proof_references/src/main/java/de/uka/ilkd/key/proof_references/ProofReferenceUtil.java
+++ b/key.core.proof_references/src/main/java/de/uka/ilkd/key/proof_references/ProofReferenceUtil.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.proof_references.analyst.*;
 import de.uka.ilkd.key.proof_references.reference.IProofReference;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -42,7 +41,7 @@ public final class ProofReferenceUtil {
      * The default {@link IProofReferencesAnalyst}s.
      */
     public static final ImmutableList<IProofReferencesAnalyst> DEFAULT_ANALYSTS =
-        ImmutableSLList.<IProofReferencesAnalyst>nil().append(
+        ImmutableList.<IProofReferencesAnalyst>nil().append(
             new MethodBodyExpandProofReferencesAnalyst(), new MethodCallProofReferencesAnalyst(),
             new ContractProofReferencesAnalyst(), new ProgramVariableReferencesAnalyst(),
             new ClassAxiomAndInvariantProofReferencesAnalyst());

--- a/key.core.proof_references/src/main/java/de/uka/ilkd/key/proof_references/analyst/MethodCallProofReferencesAnalyst.java
+++ b/key.core.proof_references/src/main/java/de/uka/ilkd/key/proof_references/analyst/MethodCallProofReferencesAnalyst.java
@@ -31,7 +31,7 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 /**
  * Extracts called methods.
@@ -136,7 +136,7 @@ public class MethodCallProofReferencesAnalyst implements IProofReferencesAnalyst
                 throw new IllegalArgumentException("Empty argument list expected.");
             }
             IProgramMethod pm = services.getJavaInfo().getProgramMethod(type.getKeYJavaType(),
-                method.toString(), ImmutableSLList.nil(), type.getKeYJavaType());
+                method.toString(), ImmutableList.nil(), type.getKeYJavaType());
             return new DefaultProofReference<>(IProofReference.CALL_METHOD, node, pm);
         }
     }

--- a/key.core.proof_references/src/test/java/de/uka/ilkd/key/proof_references/testcase/AbstractProofReferenceTestCase.java
+++ b/key.core.proof_references/src/test/java/de/uka/ilkd/key/proof_references/testcase/AbstractProofReferenceTestCase.java
@@ -31,7 +31,6 @@ import de.uka.ilkd.key.util.HelperClassForTests;
 import org.key_project.logic.Choice;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.helper.FindResources;
 import org.key_project.util.java.CollectionUtil;
@@ -154,7 +153,7 @@ public abstract class AbstractProofReferenceTestCase {
             final ExpectedProofReferences... expectedReferences) {
         return (environment, proof) -> {
             // Compute proof references
-            ImmutableList<IProofReferencesAnalyst> analysts = ImmutableSLList.nil();
+            ImmutableList<IProofReferencesAnalyst> analysts = ImmutableList.nil();
             if (analyst != null) {
                 analysts = analysts.append(analyst);
             }

--- a/key.core.proof_references/src/test/java/de/uka/ilkd/key/proof_references/testcase/TestProofReferenceUtil.java
+++ b/key.core.proof_references/src/test/java/de/uka/ilkd/key/proof_references/testcase/TestProofReferenceUtil.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.proof_references.analyst.MethodBodyExpandProofReferencesA
 import de.uka.ilkd.key.proof_references.reference.IProofReference;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class TestProofReferenceUtil extends AbstractProofReferenceTestCase {
         doAPITest(TESTCASE_DIRECTORY,
             "/proofReferences/UseOperationContractTest/UseOperationContractTest.java",
             "UseOperationContractTest", "main", true,
-            ImmutableSLList.<IProofReferencesAnalyst>nil().append(
+            ImmutableList.<IProofReferencesAnalyst>nil().append(
                 new MethodBodyExpandProofReferencesAnalyst(), new ContractProofReferencesAnalyst()),
             new ExpectedProofReferences(IProofReference.INLINE_METHOD,
                 "UseOperationContractTest::main"),
@@ -48,7 +47,7 @@ public class TestProofReferenceUtil extends AbstractProofReferenceTestCase {
     @Test
     public void testReferenceComputation_NoAnalysts() throws Exception {
         doAPITest(TESTCASE_DIRECTORY, "/proofReferences/MethodBodyExpand/MethodBodyExpand.java",
-            "MethodBodyExpand", "main", false, ImmutableSLList.nil());
+            "MethodBodyExpand", "main", false, ImmutableList.nil());
     }
 
     /**
@@ -57,7 +56,7 @@ public class TestProofReferenceUtil extends AbstractProofReferenceTestCase {
     @Test
     public void testReferenceComputation_ContractOnly() throws Exception {
         doAPITest(TESTCASE_DIRECTORY, "/proofReferences/MethodBodyExpand/MethodBodyExpand.java",
-            "MethodBodyExpand", "main", false, ImmutableSLList.<IProofReferencesAnalyst>nil()
+            "MethodBodyExpand", "main", false, ImmutableList.<IProofReferencesAnalyst>nil()
                     .append(new ContractProofReferencesAnalyst()));
     }
 
@@ -68,7 +67,7 @@ public class TestProofReferenceUtil extends AbstractProofReferenceTestCase {
     public void testReferenceComputation_ExpandOnly() throws Exception {
         doAPITest(TESTCASE_DIRECTORY, "/proofReferences/MethodBodyExpand/MethodBodyExpand.java",
             "MethodBodyExpand", "main", false,
-            ImmutableSLList.<IProofReferencesAnalyst>nil()
+            ImmutableList.<IProofReferencesAnalyst>nil()
                     .append(new MethodBodyExpandProofReferencesAnalyst()),
             new ExpectedProofReferences(IProofReference.INLINE_METHOD, "MethodBodyExpand::main"),
             new ExpectedProofReferences(IProofReference.INLINE_METHOD,

--- a/key.core.symbolic_execution.example/src/main/java/org/key_project/example/Main.java
+++ b/key.core.symbolic_execution.example/src/main/java/org/key_project/example/Main.java
@@ -31,7 +31,7 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionEnvironment;
 import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 import de.uka.ilkd.key.util.MiscTools;
 
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.java.StringUtil;
 
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class Main {
                 // Find method to symbolically execute
                 KeYJavaType classType = env.getJavaInfo().getKeYJavaType("Number");
                 IProgramMethod pm = env.getJavaInfo().getProgramMethod(classType, "equals",
-                    ImmutableSLList.<KeYJavaType>nil().append(classType), classType);
+                    ImmutableList.<KeYJavaType>nil().append(classType), classType);
                 // Instantiate proof for symbolic execution of the program method (Java semantics)
                 AbstractOperationPO po = new ProgramMethodPO(env.getInitConfig(),
                     "Symbolic Execution of: " + pm, pm, null, // An optional precondition

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/BlockContractValidityTermLabelUpdate.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/BlockContractValidityTermLabelUpdate.java
@@ -19,7 +19,6 @@ import org.key_project.prover.rules.Rule;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -34,7 +33,7 @@ public class BlockContractValidityTermLabelUpdate implements TermLabelUpdate {
      */
     @Override
     public ImmutableList<Name> getSupportedRuleNames() {
-        return ImmutableSLList.singleton(BlockContractInternalRule.INSTANCE.name());
+        return ImmutableList.singleton(BlockContractInternalRule.INSTANCE.name());
     }
 
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/LoopBodyTermLabelUpdate.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/LoopBodyTermLabelUpdate.java
@@ -17,7 +17,6 @@ import org.key_project.prover.rules.Rule;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Makes sure that {@link SymbolicExecutionUtil#LOOP_BODY_LABEL} is introduced when a
@@ -31,7 +30,7 @@ public class LoopBodyTermLabelUpdate implements TermLabelUpdate {
      */
     @Override
     public ImmutableList<Name> getSupportedRuleNames() {
-        return ImmutableSLList.singleton(WhileInvariantRule.INSTANCE.name());
+        return ImmutableList.singleton(WhileInvariantRule.INSTANCE.name());
     }
 
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/LoopInvariantNormalBehaviorTermLabelUpdate.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/LoopInvariantNormalBehaviorTermLabelUpdate.java
@@ -17,7 +17,6 @@ import org.key_project.prover.rules.Rule;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Makes sure that {@link SymbolicExecutionUtil#LOOP_INVARIANT_NORMAL_BEHAVIOR_LABEL} is introduced
@@ -31,7 +30,7 @@ public class LoopInvariantNormalBehaviorTermLabelUpdate implements TermLabelUpda
      */
     @Override
     public ImmutableList<Name> getSupportedRuleNames() {
-        return ImmutableSLList.singleton(WhileInvariantRule.INSTANCE.name());
+        return ImmutableList.singleton(WhileInvariantRule.INSTANCE.name());
     }
 
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/RemoveInCheckBranchesTermLabelRefactoring.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/RemoveInCheckBranchesTermLabelRefactoring.java
@@ -21,7 +21,6 @@ import org.key_project.logic.Name;
 import org.key_project.prover.rules.Rule;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This {@link TermLabelRefactoring} removes the supported {@link TermLabel} in check branches.
@@ -56,7 +55,7 @@ public class RemoveInCheckBranchesTermLabelRefactoring implements TermLabelRefac
      */
     @Override
     public ImmutableList<Name> getSupportedRuleNames() {
-        return ImmutableSLList.singleton(UseOperationContractRule.INSTANCE.name())
+        return ImmutableList.singleton(UseOperationContractRule.INSTANCE.name())
                 .prepend(WhileInvariantRule.INSTANCE.name())
                 .prepend(BlockContractInternalRule.INSTANCE.name())
                 .prepend(BlockContractExternalRule.INSTANCE.name())

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/SymbolicExecutionTermLabelUpdate.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/rule/label/SymbolicExecutionTermLabelUpdate.java
@@ -17,7 +17,6 @@ import org.key_project.prover.rules.Rule;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -32,7 +31,7 @@ public class SymbolicExecutionTermLabelUpdate implements TermLabelUpdate {
      */
     @Override
     public ImmutableList<Name> getSupportedRuleNames() {
-        return ImmutableSLList.<Name>nil().prepend(WhileInvariantRule.INSTANCE.name())
+        return ImmutableList.<Name>nil().prepend(WhileInvariantRule.INSTANCE.name())
                 .prepend(BlockContractInternalRule.INSTANCE.name())
                 .prepend(BlockContractExternalRule.INSTANCE.name())
                 .prepend(LoopContractInternalRule.INSTANCE.name())

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/AbstractUpdateExtractor.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/AbstractUpdateExtractor.java
@@ -33,7 +33,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.Strings;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -1109,7 +1108,7 @@ public abstract class AbstractUpdateExtractor {
         ImmutableList<JTerm> originalUpdates = computeOriginalUpdates(modalityPio, currentLayout);
         // Combine memory layout with original updates
         Map<LocationVariable, JTerm> preUpdateMap = new HashMap<>();
-        ImmutableList<JTerm> additionalUpdates = ImmutableSLList.nil();
+        ImmutableList<JTerm> additionalUpdates = ImmutableList.nil();
         for (ExtractLocationParameter evp : locations) {
             additionalUpdates = additionalUpdates.append(evp.createPreUpdate());
             preUpdateMap.put(evp.getPreVariable(), evp.getPreUpdateTarget());
@@ -1270,7 +1269,7 @@ public abstract class AbstractUpdateExtractor {
             boolean currentLayout) {
         ImmutableList<JTerm> originalUpdates;
         if (!currentLayout) {
-            originalUpdates = ImmutableSLList.nil();
+            originalUpdates = ImmutableList.nil();
         } else {
             if (node.proof().root() == node) {
                 originalUpdates = SymbolicExecutionUtil.computeRootElementaryUpdates(node);
@@ -1460,7 +1459,7 @@ public abstract class AbstractUpdateExtractor {
          * @param goal The current {@link Goal} to start backward iteration at.
          */
         public NodeGoal(Goal goal) {
-            this(goal.node(), ImmutableSLList.<Goal>nil().prepend(goal));
+            this(goal.node(), ImmutableList.<Goal>nil().prepend(goal));
         }
 
         /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/ExecutionNodeReader.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/ExecutionNodeReader.java
@@ -38,7 +38,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.CollectionUtil;
 
@@ -1278,7 +1277,7 @@ public class ExecutionNodeReader {
         /**
          * The completed blocks.
          */
-        private ImmutableList<IExecutionBlockStartNode<?>> completedBlocks = ImmutableSLList.nil();
+        private ImmutableList<IExecutionBlockStartNode<?>> completedBlocks = ImmutableList.nil();
 
         /**
          * The formated conditions under which a block is completed.
@@ -1289,12 +1288,12 @@ public class ExecutionNodeReader {
         /**
          * The contained outgoing links.
          */
-        private ImmutableList<IExecutionLink> outgoingLinks = ImmutableSLList.nil();
+        private ImmutableList<IExecutionLink> outgoingLinks = ImmutableList.nil();
 
         /**
          * The contained incoming links.
          */
-        private ImmutableList<IExecutionLink> incomingLinks = ImmutableSLList.nil();
+        private ImmutableList<IExecutionLink> incomingLinks = ImmutableList.nil();
 
         /**
          * Constructor.
@@ -1580,7 +1579,7 @@ public class ExecutionNodeReader {
         /**
          * The block completions.
          */
-        private ImmutableList<IExecutionNode<?>> blockCompletions = ImmutableSLList.nil();
+        private ImmutableList<IExecutionNode<?>> blockCompletions = ImmutableList.nil();
 
         /**
          * Is a block opened?
@@ -1758,7 +1757,7 @@ public class ExecutionNodeReader {
         /**
          * The up to now discovered {@link IExecutionTermination}s.
          */
-        private ImmutableList<IExecutionTermination> terminations = ImmutableSLList.nil();
+        private ImmutableList<IExecutionTermination> terminations = ImmutableList.nil();
 
         /**
          * Constructor.
@@ -2014,7 +2013,7 @@ public class ExecutionNodeReader {
         /**
          * The up to now discovered {@link IExecutionBaseMethodReturn<?>}s.
          */
-        private ImmutableList<IExecutionBaseMethodReturn<?>> methodReturns = ImmutableSLList.nil();
+        private ImmutableList<IExecutionBaseMethodReturn<?>> methodReturns = ImmutableList.nil();
 
         /**
          * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/ExecutionVariableExtractor.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/ExecutionVariableExtractor.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 /**
@@ -444,7 +443,7 @@ public class ExecutionVariableExtractor extends AbstractUpdateExtractor {
                         firstPair.getProgramVariable(), firstPair.getArrayIndex()));
                 assert variable != null;
                 createValues(variable, pairsList, firstPair, childrenInfo, values,
-                    ImmutableSLList.nil());
+                    ImmutableList.nil());
                 variable.values = values.toArray(new IExecutionValue[0]);
             }
             return values;

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicExecutionTreeBuilder.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicExecutionTreeBuilder.java
@@ -44,7 +44,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.ArrayUtil;
 
@@ -306,7 +305,7 @@ public class SymbolicExecutionTreeBuilder {
                 }
             }.run();
             Map<Node, ImmutableList<Node>> methodCallStack = getMethodCallStack(label);
-            methodCallStack.put(root, ImmutableSLList.<Node>nil().append(initialStack));
+            methodCallStack.put(root, ImmutableList.<Node>nil().append(initialStack));
         }
     }
 
@@ -693,7 +692,7 @@ public class SymbolicExecutionTreeBuilder {
         /**
          * Contains all {@link Node}s which are closed after a join.
          */
-        private ImmutableList<Node> joinNodes = ImmutableSLList.nil();
+        private ImmutableList<Node> joinNodes = ImmutableList.nil();
 
         /**
          * Constructor.
@@ -1083,10 +1082,10 @@ public class SymbolicExecutionTreeBuilder {
             ImmutableList<Node> stack = findMethodCallStack(methodCallStack, node);
             if (stack != null) {
                 while (stack.size() > currentLevel) {
-                    stack = stack.take(1);
+                    stack = stack.tail();
                 }
             } else {
-                stack = ImmutableSLList.nil();
+                stack = ImmutableList.nil();
             }
             // Add new node to call stack.
             stack = stack.prepend(node);
@@ -1229,10 +1228,10 @@ public class SymbolicExecutionTreeBuilder {
                 }
                 afterBlockMaps.put(node, afterBlockMap);
                 JavaPair secondPair = new JavaPair(stackSize,
-                    ImmutableSLList.<SourceElement>nil().append(sourceElements));
+                    ImmutableList.<SourceElement>nil().append(sourceElements));
                 ImmutableList<IExecutionNode<?>> blockStartList = afterBlockMap.get(secondPair);
                 if (blockStartList == null) {
-                    blockStartList = ImmutableSLList.nil();
+                    blockStartList = ImmutableList.nil();
                 }
                 blockStartList = blockStartList.append(blockStartNode);
                 afterBlockMap.put(secondPair, blockStartList);
@@ -1302,7 +1301,7 @@ public class SymbolicExecutionTreeBuilder {
                     JavaTools.getInnermostMethodFrame(currentJavaBlock, proof.getServices());
                 return !isAfterBlockReached(currentStackSize, currentInnerMostMethodFrame,
                     currentActiveStatement, expectedStackSize,
-                    ImmutableSLList.<SourceElement>nil().append(expectedSourceElements).iterator());
+                    ImmutableList.<SourceElement>nil().append(expectedSourceElements).iterator());
             } else {
                 return true; // No single SE node reached, so allow blocks
             }
@@ -1602,7 +1601,7 @@ public class SymbolicExecutionTreeBuilder {
         Map<Node, ImmutableList<Node>> newMethodCallStackMap = getMethodCallStack(label.id());
         ImmutableList<Node> currentMethodCallStack =
             findMethodCallStack(currentMethodCallStackMap, currentNode);
-        ImmutableList<Node> newMethodCallStack = ImmutableSLList.nil();
+        ImmutableList<Node> newMethodCallStack = ImmutableList.nil();
         Set<Node> currentIgnoreSet = getMethodReturnsToIgnore(label.id());
         assert newMethodCallStack.isEmpty() : "Method call stack is not empty.";
         Iterator<Node> currentIter = currentMethodCallStack.iterator();
@@ -1689,7 +1688,7 @@ public class SymbolicExecutionTreeBuilder {
             Map<Node, ImmutableList<Node>> methodCallStack =
                 getMethodCallStack(node.getAppliedRuleApp());
             ImmutableList<Node> stack = findMethodCallStack(methodCallStack, node);
-            stack = stack.take(stack.size() - size);
+            stack = stack.skip(stack.size() - size);
             Iterator<Node> stackIter = stack.iterator();
             for (int i = 0; i < size; i++) {
                 Node stackEntry = stackIter.next();
@@ -1722,7 +1721,7 @@ public class SymbolicExecutionTreeBuilder {
         if (returnStackSize >= 0) {
             Map<Node, ImmutableList<Node>> methodCallStack = getMethodCallStack(ruleApp);
             ImmutableList<Node> stack = findMethodCallStack(methodCallStack, currentNode);
-            return stack.take(stack.size() - returnStackSize).head();
+            return stack.skip(stack.size() - returnStackSize).head();
         } else {
             return null;
         }

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicLayoutExtractor.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicLayoutExtractor.java
@@ -31,7 +31,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.CollectionUtil;
 
@@ -761,7 +760,7 @@ public class SymbolicLayoutExtractor extends AbstractUpdateExtractor {
      */
     protected ImmutableList<ISymbolicEquivalenceClass> lazyComputeEquivalenceClasses(
             ImmutableSet<JTerm> appliedCuts) {
-        ImmutableList<ISymbolicEquivalenceClass> result = ImmutableSLList.nil();
+        ImmutableList<ISymbolicEquivalenceClass> result = ImmutableList.nil();
         for (JTerm term : appliedCuts) {
             if (Junctor.NOT != term.op()) {
                 assert term.op() == Equality.EQUALS;

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicLayoutReader.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/SymbolicLayoutReader.java
@@ -30,7 +30,6 @@ import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicValue;
 
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -451,12 +450,12 @@ public class SymbolicLayoutReader {
         /**
          * The objects.
          */
-        private ImmutableList<ISymbolicObject> objects = ImmutableSLList.nil();
+        private ImmutableList<ISymbolicObject> objects = ImmutableList.nil();
 
         /**
          * The symbolic equivalence classes.
          */
-        private ImmutableList<ISymbolicEquivalenceClass> equivalenceClasses = ImmutableSLList.nil();
+        private ImmutableList<ISymbolicEquivalenceClass> equivalenceClasses = ImmutableList.nil();
 
         /**
          * {@inheritDoc}
@@ -522,12 +521,12 @@ public class SymbolicLayoutReader {
         /**
          * The associations.
          */
-        private ImmutableList<ISymbolicAssociation> associations = ImmutableSLList.nil();
+        private ImmutableList<ISymbolicAssociation> associations = ImmutableList.nil();
 
         /**
          * The values.
          */
-        private ImmutableList<ISymbolicValue> values = ImmutableSLList.nil();
+        private ImmutableList<ISymbolicValue> values = ImmutableList.nil();
 
         /**
          * {@inheritDoc}
@@ -1062,7 +1061,7 @@ public class SymbolicLayoutReader {
          * @param representativeString The representative term.
          */
         public KeYlessEquivalenceClass(String representativeString) {
-            this(ImmutableSLList.nil(), representativeString);
+            this(ImmutableList.nil(), representativeString);
         }
 
         /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/TruthValueTracingUtil.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/TruthValueTracingUtil.java
@@ -246,7 +246,7 @@ public final class TruthValueTracingUtil {
                     if (!isClosingRule(taclet)) { // Not a closing taclet
                         checkPerformed = true;
                         TacletGoalTemplate tacletGoal =
-                            taclet.goalTemplates().reverse().take(childIndexOnParent).head();
+                            taclet.goalTemplates().reverse().get(childIndexOnParent);
                         // Check for new minor ids created by parent rule application
                         updatePredicateResultBasedOnNewMinorIds(child, termLabelName,
                             services.getTermBuilder(), nodeResult);

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/AbstractExecutionBlockStartNode.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/AbstractExecutionBlockStartNode.java
@@ -10,7 +10,6 @@ import de.uka.ilkd.key.symbolic_execution.model.IExecutionNode;
 import de.uka.ilkd.key.symbolic_execution.model.ITreeSettings;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Provides a basic implementation of {@link IExecutionBlockStartNode}.
@@ -22,7 +21,7 @@ public abstract class AbstractExecutionBlockStartNode<S extends SourceElement>
     /**
      * The up to know discovered completing {@link IExecutionNode}s.
      */
-    private ImmutableList<IExecutionNode<?>> blockCompletions = ImmutableSLList.nil();
+    private ImmutableList<IExecutionNode<?>> blockCompletions = ImmutableList.nil();
 
     /**
      * Defines if a block is or might be opened.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/AbstractExecutionNode.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/AbstractExecutionNode.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -78,7 +77,7 @@ public abstract class AbstractExecutionNode<S extends SourceElement>
     /**
      * The up to know discovered completed {@link IExecutionBlockStartNode}s.
      */
-    private ImmutableList<IExecutionBlockStartNode<?>> completedBlocks = ImmutableSLList.nil();
+    private ImmutableList<IExecutionBlockStartNode<?>> completedBlocks = ImmutableList.nil();
 
     /**
      * The already computed block completion conditions.
@@ -95,12 +94,12 @@ public abstract class AbstractExecutionNode<S extends SourceElement>
     /**
      * The up to know discovered outgoing links.
      */
-    private ImmutableList<IExecutionLink> outgoingLinks = ImmutableSLList.nil();
+    private ImmutableList<IExecutionLink> outgoingLinks = ImmutableList.nil();
 
     /**
      * The up to know discovered incoming links.
      */
-    private ImmutableList<IExecutionLink> incomingLinks = ImmutableSLList.nil();
+    private ImmutableList<IExecutionLink> incomingLinks = ImmutableList.nil();
 
     /**
      * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/ExecutionMethodCall.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/ExecutionMethodCall.java
@@ -16,7 +16,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 import de.uka.ilkd.key.util.KeYTypeUtil;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * The default implementation of {@link IExecutionMethodCall}.
@@ -28,7 +27,7 @@ public class ExecutionMethodCall extends AbstractExecutionNode<MethodBodyStateme
     /**
      * The up to know discovered {@link IExecutionBaseMethodReturn}s.
      */
-    private ImmutableList<IExecutionBaseMethodReturn<?>> methodReturns = ImmutableSLList.nil();
+    private ImmutableList<IExecutionBaseMethodReturn<?>> methodReturns = ImmutableList.nil();
 
     /**
      * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/ExecutionStart.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/model/impl/ExecutionStart.java
@@ -16,7 +16,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * The default implementation of {@link IExecutionStart}.
@@ -28,7 +27,7 @@ public class ExecutionStart extends AbstractExecutionNode<SourceElement>
     /**
      * The up to know discovered {@link IExecutionTermination}s.
      */
-    private ImmutableList<IExecutionTermination> terminations = ImmutableSLList.nil();
+    private ImmutableList<IExecutionTermination> terminations = ImmutableList.nil();
 
     /**
      * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/AbstractSymbolicAssociationValueContainer.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/AbstractSymbolicAssociationValueContainer.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicAssociationValue
 import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicValue;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -26,12 +25,12 @@ public abstract class AbstractSymbolicAssociationValueContainer extends Abstract
     /**
      * The contained {@link ISymbolicAssociation}s.
      */
-    private ImmutableList<ISymbolicAssociation> associations = ImmutableSLList.nil();
+    private ImmutableList<ISymbolicAssociation> associations = ImmutableList.nil();
 
     /**
      * The contained {@link ISymbolicValue}s.
      */
-    private ImmutableList<ISymbolicValue> values = ImmutableSLList.nil();
+    private ImmutableList<ISymbolicValue> values = ImmutableList.nil();
 
     /**
      * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/SymbolicEquivalenceClass.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/SymbolicEquivalenceClass.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicEquivalenceClass
 import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicObject;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.CollectionUtil;
 
 /**
@@ -39,7 +38,7 @@ public class SymbolicEquivalenceClass extends AbstractElement implements ISymbol
      * @param settings The {@link IModelSettings} to use.
      */
     public SymbolicEquivalenceClass(Services services, IModelSettings settings) {
-        this(services, ImmutableSLList.nil(), settings);
+        this(services, ImmutableList.nil(), settings);
     }
 
     /**
@@ -86,7 +85,7 @@ public class SymbolicEquivalenceClass extends AbstractElement implements ISymbol
      */
     @Override
     public ImmutableList<String> getTermStrings() {
-        ImmutableList<String> strings = ImmutableSLList.nil();
+        ImmutableList<String> strings = ImmutableList.nil();
         for (JTerm term : terms) {
             strings = strings.append(formatTerm(term, services));
         }

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/SymbolicLayout.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/object_model/impl/SymbolicLayout.java
@@ -10,7 +10,6 @@ import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicObject;
 import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicState;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Default implementation of {@link ISymbolicLayout}.
@@ -31,7 +30,7 @@ public class SymbolicLayout extends AbstractElement implements ISymbolicLayout {
     /**
      * The contained {@link ISymbolicObject}s.
      */
-    private ImmutableList<ISymbolicObject> objects = ImmutableSLList.nil();
+    private ImmutableList<ISymbolicObject> objects = ImmutableList.nil();
 
     /**
      * Constructor.

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodPO.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodPO.java
@@ -33,7 +33,6 @@ import de.uka.ilkd.key.speclang.njml.JmlIO;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * <p>
@@ -150,7 +149,7 @@ public class ProgramMethodPO extends AbstractOperationPO {
             formalParVars.toArray(new ProgramVariable[formalParVars.size()]));
         MethodBodyStatement mbs = new MethodBodyStatement(pm, selfVar, resultVar, args);
         StatementBlock result = new StatementBlock(mbs);
-        return ImmutableSLList.<StatementBlock>nil().prepend(null, result, null, null);
+        return ImmutableList.<StatementBlock>nil().prepend(null, result, null, null);
     }
 
     /**
@@ -346,7 +345,7 @@ public class ProgramMethodPO extends AbstractOperationPO {
         if (type == null) {
             throw new IOException("Can't find type \"" + className + "\".");
         }
-        ImmutableList<KeYJavaType> parameterTypes = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> parameterTypes = ImmutableList.nil();
         for (String s : types) {
             KeYJavaType paramType = javaInfo.getKeYJavaType(s.trim());
             if (paramType == null) {

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodSubsetPO.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodSubsetPO.java
@@ -28,7 +28,6 @@ import de.uka.ilkd.key.settings.Configuration;
 
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.parsing.Position;
 
 // need to switch spotless off for this comment as it replaces @code with &#64;code
@@ -177,7 +176,7 @@ public class ProgramMethodSubsetPO extends ProgramMethodPO {
         for (LocationVariable x : undeclaredVariables) {
             register(x, services);
         }
-        return ImmutableSLList.<StatementBlock>nil().prepend(null, result, null, null);
+        return ImmutableList.<StatementBlock>nil().prepend(null, result, null, null);
     }
 
     /**
@@ -268,7 +267,7 @@ public class ProgramMethodSubsetPO extends ProgramMethodPO {
      * @return The created {@link ImmutableList}.
      */
     protected static ImmutableList<LocationVariable> convert(Collection<LocationVariable> c) {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (LocationVariable var : c) {
             result = result.append(var);
         }

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/profile/SimplifyTermProfile.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/profile/SimplifyTermProfile.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 import org.key_project.logic.Name;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -61,7 +60,7 @@ public class SimplifyTermProfile extends JavaProfile {
     protected ImmutableList<TermLabelConfiguration> computeTermLabelConfiguration() {
         ImmutableList<TermLabelConfiguration> result = super.computeTermLabelConfiguration();
         ImmutableList<TermLabelPolicy> symExcPolicies =
-            ImmutableSLList.<TermLabelPolicy>nil()
+            ImmutableList.<TermLabelPolicy>nil()
                     .prepend((state, services, applicationPosInOccurrence, applicationTerm, rule,
                             goal, hint, tacletTerm,
                             newTerm, label) -> label);

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/profile/SymbolicExecutionJavaProfile.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/profile/SymbolicExecutionJavaProfile.java
@@ -41,7 +41,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 import org.key_project.logic.Name;
 import org.key_project.prover.engine.GoalChooserFactory;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -143,31 +142,31 @@ public class SymbolicExecutionJavaProfile extends JavaProfile {
     public static ImmutableList<TermLabelConfiguration> getSymbolicExecutionTermLabelConfigurations(
             boolean predicateEvaluationEnabled) {
         ImmutableList<TermLabelPolicy> symExcPolicies =
-            ImmutableSLList.<TermLabelPolicy>nil().prepend(new StayOnOperatorTermLabelPolicy());
+            ImmutableList.<TermLabelPolicy>nil().prepend(new StayOnOperatorTermLabelPolicy());
 
-        ImmutableList<TermLabelUpdate> bcUps = ImmutableSLList.<TermLabelUpdate>nil()
+        ImmutableList<TermLabelUpdate> bcUps = ImmutableList.<TermLabelUpdate>nil()
                 .prepend(new BlockContractValidityTermLabelUpdate());
         ImmutableList<TermLabelUpdate> lbUps =
-            ImmutableSLList.<TermLabelUpdate>nil().prepend(new LoopBodyTermLabelUpdate());
-        ImmutableList<TermLabelUpdate> nbUps = ImmutableSLList.<TermLabelUpdate>nil()
+            ImmutableList.<TermLabelUpdate>nil().prepend(new LoopBodyTermLabelUpdate());
+        ImmutableList<TermLabelUpdate> nbUps = ImmutableList.<TermLabelUpdate>nil()
                 .prepend(new LoopInvariantNormalBehaviorTermLabelUpdate());
         ImmutableList<TermLabelUpdate> seUps =
-            ImmutableSLList.<TermLabelUpdate>nil().prepend(new SymbolicExecutionTermLabelUpdate());
+            ImmutableList.<TermLabelUpdate>nil().prepend(new SymbolicExecutionTermLabelUpdate());
 
         ImmutableList<TermLabelRefactoring> bcRefs =
-            ImmutableSLList.<TermLabelRefactoring>nil().prepend(
+            ImmutableList.<TermLabelRefactoring>nil().prepend(
                 new RemoveInCheckBranchesTermLabelRefactoring(BlockContractValidityTermLabel.NAME));
-        ImmutableList<TermLabelRefactoring> lbRefs = ImmutableSLList.<TermLabelRefactoring>nil()
+        ImmutableList<TermLabelRefactoring> lbRefs = ImmutableList.<TermLabelRefactoring>nil()
                 .prepend(new RemoveInCheckBranchesTermLabelRefactoring(
                     SymbolicExecutionUtil.LOOP_BODY_LABEL_NAME));
-        ImmutableList<TermLabelRefactoring> nbRefs = ImmutableSLList.<TermLabelRefactoring>nil()
+        ImmutableList<TermLabelRefactoring> nbRefs = ImmutableList.<TermLabelRefactoring>nil()
                 .prepend(new RemoveInCheckBranchesTermLabelRefactoring(
                     SymbolicExecutionUtil.LOOP_INVARIANT_NORMAL_BEHAVIOR_LABEL_NAME));
         ImmutableList<TermLabelRefactoring> seRefs =
-            ImmutableSLList.<TermLabelRefactoring>nil().prepend(
+            ImmutableList.<TermLabelRefactoring>nil().prepend(
                 new RemoveInCheckBranchesTermLabelRefactoring(SymbolicExecutionTermLabel.NAME));
 
-        ImmutableList<TermLabelConfiguration> result = ImmutableSLList.nil();
+        ImmutableList<TermLabelConfiguration> result = ImmutableList.nil();
         result = result.prepend(new TermLabelConfiguration(BlockContractValidityTermLabel.NAME,
             new BlockContractValidityTermLabelFactory(), null, symExcPolicies, null, null, bcUps,
             bcRefs, null));
@@ -185,10 +184,10 @@ public class SymbolicExecutionJavaProfile extends JavaProfile {
             seRefs, null));
         if (predicateEvaluationEnabled) {
             ImmutableList<TermLabelPolicy> predPolicies =
-                ImmutableSLList.<TermLabelPolicy>nil().prepend(new StayOnFormulaTermLabelPolicy());
+                ImmutableList.<TermLabelPolicy>nil().prepend(new StayOnFormulaTermLabelPolicy());
             ImmutableList<TermLabelUpdate> predUpdates =
-                ImmutableSLList.<TermLabelUpdate>nil().prepend(new FormulaTermLabelUpdate());
-            ImmutableList<TermLabelRefactoring> predRefs = ImmutableSLList
+                ImmutableList.<TermLabelUpdate>nil().prepend(new FormulaTermLabelUpdate());
+            ImmutableList<TermLabelRefactoring> predRefs = ImmutableList
                     .<TermLabelRefactoring>nil().prepend(new FormulaTermLabelRefactoring());
             result = result.prepend(new TermLabelConfiguration(FormulaTermLabel.NAME,
                 new FormulaTermLabelFactory(), null, predPolicies, null, null, predUpdates,

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/AbstractBackwardSlicer.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/AbstractBackwardSlicer.java
@@ -25,7 +25,6 @@ import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicEquivalenceClass
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Provides a basic implementation of backward slicing algorithms.
@@ -165,7 +164,7 @@ public abstract class AbstractBackwardSlicer extends AbstractSlicer {
             if (!newAlternatives.equals(oldAlternatives)) {
                 // Compute old variables
                 ImmutableList<ImmutableList<Access>> newAlternativeVariables =
-                    ImmutableSLList.nil();
+                    ImmutableList.nil();
                 for (Location newALternative : newAlternatives) {
                     newAlternativeVariables =
                         newAlternativeVariables.prepend(newALternative.getAccesses());
@@ -185,7 +184,7 @@ public abstract class AbstractBackwardSlicer extends AbstractSlicer {
                                 newLocations.add(newAlternative);
                             } else {
                                 ImmutableList<Access> oldRemainignVariables =
-                                    oldVariables.take(commonPrefixLength);
+                                    oldVariables.skip(commonPrefixLength);
                                 ImmutableList<Access> newAccesses =
                                     newAlternative.getAccesses().append(oldRemainignVariables);
                                 newLocations.add(new Location(newAccesses));

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/AbstractSlicer.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/AbstractSlicer.java
@@ -39,7 +39,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.CollectionUtil;
 
@@ -736,7 +735,7 @@ public abstract class AbstractSlicer {
      * @return The representative alias.
      */
     protected Location normalizeAlias(Services services, Location location, SequentInfo info) {
-        ImmutableList<Access> normalizedAccesses = ImmutableSLList.nil();
+        ImmutableList<Access> normalizedAccesses = ImmutableList.nil();
         for (Access access : location.getAccesses()) {
             if (access.isArrayIndex()) {
                 access = normalizeArrayIndex(access, info);
@@ -890,7 +889,7 @@ public abstract class AbstractSlicer {
     protected Location toLocation(Services services, ReferencePrefix prefix, ExecutionContext ec,
             ReferencePrefix thisReference) {
         ImmutableList<Access> accesses =
-            toLocationRecursive(services, prefix, ec, thisReference, ImmutableSLList.nil());
+            toLocationRecursive(services, prefix, ec, thisReference, ImmutableList.nil());
         return new Location(accesses);
     }
 

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/Location.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/slicing/Location.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 
 import org.key_project.logic.op.Function;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Represents a location like a local variable, method parameter, static field or an instance field
@@ -43,7 +42,7 @@ public class Location {
      */
     public Location(Access... accesses) {
         assert accesses != null;
-        this.accesses = ImmutableSLList.<Access>nil().append(accesses);
+        this.accesses = ImmutableList.<Access>nil().append(accesses);
     }
 
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionGoalChooser.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/SymbolicExecutionGoalChooser.java
@@ -110,7 +110,7 @@ public class SymbolicExecutionGoalChooser extends DepthFirstGoalChooser {
                             if (goalsWhereStopConditionDoNotAllowNextRule.add(next)) {
                                 // Update selected list to get a new goal in next loop iteration
                                 Goal head = selectedList.head();
-                                selectedList = selectedList.take(1);
+                                selectedList = selectedList.tail();
                                 selectedList = selectedList.append(head);
                             } else {
                                 // Next rule not allowed, but all other goals also don't allow it,
@@ -124,7 +124,7 @@ public class SymbolicExecutionGoalChooser extends DepthFirstGoalChooser {
                     if (goal == null) {
                         // Update selected list to get a new goal in next loop iteration
                         Goal head = selectedList.head();
-                        selectedList = selectedList.take(1);
+                        selectedList = selectedList.tail();
                         selectedList = selectedList.append(head);
                     }
                 }

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/AbstractConditionalBreakpoint.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/AbstractConditionalBreakpoint.java
@@ -36,7 +36,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -298,7 +297,7 @@ public abstract class AbstractConditionalBreakpoint extends AbstractHitCountBrea
         setSelfVar(new LocationVariable(
             new ProgramElementName(getProof().getServices().getTermBuilder().newName("self")),
             containerType, null, false, false));
-        ImmutableList<LocationVariable> varsForCondition = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> varsForCondition = ImmutableList.nil();
         if (getPm() != null) {
             // collect parameter variables
             for (ParameterDeclaration pd : getPm().getParameters()) {
@@ -320,7 +319,7 @@ public abstract class AbstractConditionalBreakpoint extends AbstractHitCountBrea
         }
         JavaInfo info = getProof().getServices().getJavaInfo();
         List<KeYJavaType> kjts = info.getAllSupertypes(containerType);
-        ImmutableList<LocationVariable> globalVars = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> globalVars = ImmutableList.nil();
         for (KeYJavaType kjtloc : kjts) {
             if (kjtloc.getJavaType() instanceof TypeDeclaration) {
                 ImmutableList<Field> fields =

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
@@ -77,7 +77,6 @@ import org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.CollectionUtil;
 import org.key_project.util.parsing.Position;
@@ -213,7 +212,7 @@ public final class SymbolicExecutionUtil {
             if (openGoals.isEmpty()) {
                 return tb.tt();
             } else {
-                ImmutableList<JTerm> goalImplications = ImmutableSLList.nil();
+                ImmutableList<JTerm> goalImplications = ImmutableList.nil();
                 for (Goal goal : openGoals) {
                     JTerm goalImplication =
                         sequentToImplication(goal.sequent(), goal.proof().getServices());
@@ -256,7 +255,7 @@ public final class SymbolicExecutionUtil {
      * @return The list with all contained {@link JTerm}s.
      */
     public static ImmutableList<JTerm> listSemisequentTerms(Semisequent semisequent) {
-        ImmutableList<JTerm> terms = ImmutableSLList.nil();
+        ImmutableList<JTerm> terms = ImmutableList.nil();
         if (semisequent != null) {
             for (SequentFormula sf : semisequent) {
                 terms = terms.append((JTerm) sf.formula());
@@ -1736,7 +1735,7 @@ public final class SymbolicExecutionUtil {
         if (executionElement != null) {
             return collectGoalsInSubtree(executionElement.getProofNode());
         } else {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
     }
 
@@ -2582,11 +2581,11 @@ public final class SymbolicExecutionUtil {
                 goalTemplate = null;
             } else {
                 goalTemplate = app.taclet().goalTemplates()
-                        .take(app.taclet().goalTemplates().size() - childIndex).head();
+                        .get(app.taclet().goalTemplates().size() - childIndex);
             }
         } else {
             goalTemplate = app.taclet().goalTemplates()
-                    .take(app.taclet().goalTemplates().size() - 1 - childIndex).head();
+                    .get(app.taclet().goalTemplates().size() - 1 - childIndex);
         }
         // Instantiate replace object if required
         if (goalTemplate != null) {
@@ -2632,8 +2631,8 @@ public final class SymbolicExecutionUtil {
                             + " term in branch computation but rule \"" + app + "\" was found.");
                     }
                     // Create new lists
-                    ImmutableList<JTerm> tempAntecedents = ImmutableSLList.nil();
-                    ImmutableList<JTerm> tempSuccedents = ImmutableSLList.nil();
+                    ImmutableList<JTerm> tempAntecedents = ImmutableList.nil();
+                    ImmutableList<JTerm> tempSuccedents = ImmutableList.nil();
                     // Apply updates on antecedents and add result to new antecedents list
                     for (JTerm a : newAntecedents) {
                         tempAntecedents = tempAntecedents
@@ -2707,7 +2706,7 @@ public final class SymbolicExecutionUtil {
         for (final SequentFormula sf : parent) {
             parentSFs.add(sf);
         }
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (final SequentFormula sf : child) {
             if (!parentSFs.contains(sf)) {
                 result = result.append((JTerm) sf.formula());
@@ -2834,7 +2833,7 @@ public final class SymbolicExecutionUtil {
                                               // scenarios in which a precondition or null pointer
                                               // check can't be shown
                 splittingOption, false);
-        ImmutableList<JTerm> goalCondtions = ImmutableSLList.nil();
+        ImmutableList<JTerm> goalCondtions = ImmutableList.nil();
         for (Pair<JTerm, Node> pair : resultValuesAndConditions) {
             JTerm goalCondition = pair.first;
             goalCondition = replaceSkolemConstants(pair.second.sequent(),
@@ -3016,7 +3015,7 @@ public final class SymbolicExecutionUtil {
      * @return The found initial {@link ElementaryUpdate}s.
      */
     public static ImmutableList<JTerm> computeRootElementaryUpdates(Node root) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         Sequent sequent = root.sequent();
         for (SequentFormula sf : sequent.succedent()) {
             JTerm term = (JTerm) sf.formula();
@@ -3038,15 +3037,15 @@ public final class SymbolicExecutionUtil {
             JTerm updateTerm = UpdateApplication.getUpdate(term);
             return collectElementaryUpdates(updateTerm);
         } else if (term.op() == UpdateJunctor.PARALLEL_UPDATE) {
-            ImmutableList<JTerm> result = ImmutableSLList.nil();
+            ImmutableList<JTerm> result = ImmutableList.nil();
             for (int i = 0; i < term.arity(); i++) {
                 result = result.prepend(collectElementaryUpdates(term.sub(i)));
             }
             return result;
         } else if (term.op() instanceof ElementaryUpdate) {
-            return ImmutableSLList.<JTerm>nil().prepend(term);
+            return ImmutableList.<JTerm>nil().prepend(term);
         } else {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
     }
 

--- a/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/TestSymbolicLayoutWriterAndReader.java
+++ b/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/TestSymbolicLayoutWriterAndReader.java
@@ -16,7 +16,7 @@ import de.uka.ilkd.key.symbolic_execution.SymbolicLayoutReader.*;
 import de.uka.ilkd.key.symbolic_execution.SymbolicLayoutWriter;
 import de.uka.ilkd.key.symbolic_execution.object_model.ISymbolicLayout;
 
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -73,9 +73,9 @@ public class TestSymbolicLayoutWriterAndReader {
     protected ISymbolicLayout createModel() {
         KeYlessLayout model = new KeYlessLayout();
         model.addEquivalenceClass(
-            new KeYlessEquivalenceClass(ImmutableSLList.<String>nil().append("A", "B", "C"), "A"));
+            new KeYlessEquivalenceClass(ImmutableList.<String>nil().append("A", "B", "C"), "A"));
         model.addEquivalenceClass(
-            new KeYlessEquivalenceClass(ImmutableSLList.<String>nil().append("1", "2", "3"), "63"));
+            new KeYlessEquivalenceClass(ImmutableList.<String>nil().append("1", "2", "3"), "63"));
         // state
         KeYlessState state = new KeYlessState("exampleState");
         state.addValue(new KeYlessValue("v1", "v1", false, "-1", "v1Value", "t1", null));

--- a/key.core.wd/src/main/java/de/uka/ilkd/key/wd/MethodWellDefinedness.java
+++ b/key.core.wd/src/main/java/de/uka/ilkd/key/wd/MethodWellDefinedness.java
@@ -22,7 +22,6 @@ import de.uka.ilkd.key.speclang.jml.JMLInfoExtractor;
 import org.key_project.logic.Name;
 import org.key_project.logic.op.Function;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * A contract for checking the well-definedness of a specification for a method or model field.
@@ -185,7 +184,7 @@ public final class MethodWellDefinedness extends WellDefinednessCheck {
      * @return a list of schema variables
      */
     private ImmutableList<JOperatorSV> paramsSV() {
-        ImmutableList<JOperatorSV> paramsSV = ImmutableSLList.nil();
+        ImmutableList<JOperatorSV> paramsSV = ImmutableList.nil();
         for (var pv : getOrigVars().params) {
             paramsSV = paramsSV.append(
                 SchemaVariableFactory.createTermSV(pv.name(), pv.getKeYJavaType().getSort()));
@@ -216,7 +215,7 @@ public final class MethodWellDefinedness extends WellDefinednessCheck {
         if (hasMby()) {
             final JTerm mbyAtPre = TB.func(mbyAtPreFunc);
             assert params != null;
-            ImmutableList<LocationVariable> paramVars = ImmutableSLList.nil();
+            ImmutableList<LocationVariable> paramVars = ImmutableList.nil();
             for (var pv : params) {
                 paramVars = paramVars.append(pv);
             }

--- a/key.core.wd/src/main/java/de/uka/ilkd/key/wd/SpecificationRepositoryWD.java
+++ b/key.core.wd/src/main/java/de/uka/ilkd/key/wd/SpecificationRepositoryWD.java
@@ -114,7 +114,7 @@ public class SpecificationRepositoryWD extends SpecificationRepository {
      * @return contracts without well-definedness checks
      */
     private static ImmutableSet<Contract> removeWdChecks(ImmutableSet<Contract> contracts) {
-        ImmutableList<Contract> result = ImmutableSLList.nil();
+        ImmutableList<Contract> result = ImmutableList.nil();
         if (contracts == null) {
             return contracts;
         }

--- a/key.core.wd/src/main/java/de/uka/ilkd/key/wd/StatementWellDefinedness.java
+++ b/key.core.wd/src/main/java/de/uka/ilkd/key/wd/StatementWellDefinedness.java
@@ -19,7 +19,6 @@ import de.uka.ilkd.key.wd.po.WellDefinednessPO.Variables;
 import org.key_project.logic.op.Function;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -69,7 +68,7 @@ public abstract class StatementWellDefinedness extends WellDefinednessCheck {
      * @return a list of the parameter variables
      */
     final static ImmutableList<LocationVariable> convertParams(ImmutableSet<LocationVariable> set) {
-        ImmutableList<LocationVariable> list = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> list = ImmutableList.nil();
         for (LocationVariable pv : set) {
             list = list.append(pv);
         }

--- a/key.core.wd/src/main/java/de/uka/ilkd/key/wd/WellDefinednessCheck.java
+++ b/key.core.wd/src/main/java/de/uka/ilkd/key/wd/WellDefinednessCheck.java
@@ -35,7 +35,6 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.op.Operator;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import static de.uka.ilkd.key.logic.equality.IrrelevantTermLabelsProperty.IRRELEVANT_TERM_LABELS_PROPERTY;
@@ -117,8 +116,8 @@ public abstract class WellDefinednessCheck implements Contract {
      */
     private Pair<ImmutableList<JTerm>, ImmutableList<JTerm>> sort(JTerm spec) {
         assert spec != null;
-        ImmutableList<JTerm> implicit = ImmutableSLList.nil();
-        ImmutableList<JTerm> explicit = ImmutableSLList.nil();
+        ImmutableList<JTerm> implicit = ImmutableList.nil();
+        ImmutableList<JTerm> explicit = ImmutableList.nil();
         if (spec.arity() > 0 && spec.op().equals(Junctor.AND)) { // Conjunctions
             assert spec.arity() == 2;
             if (spec.hasLabels()
@@ -328,7 +327,7 @@ public abstract class WellDefinednessCheck implements Contract {
     }
 
     private ImmutableList<JTerm> replace(Iterable<JTerm> l, Variables vars) {
-        ImmutableList<JTerm> res = ImmutableSLList.nil();
+        ImmutableList<JTerm> res = ImmutableList.nil();
         for (JTerm t : l) {
             res = res.append(replace(t, vars));
         }
@@ -336,7 +335,7 @@ public abstract class WellDefinednessCheck implements Contract {
     }
 
     private ImmutableList<LocationVariable> getHeaps() {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         return result.append(getHeap());
     }
 
@@ -571,7 +570,7 @@ public abstract class WellDefinednessCheck implements Contract {
     private TermListAndFunc buildFreePre(JTerm implicitPre, LocationVariable self,
             LocationVariable heap, ImmutableList<LocationVariable> params,
             Services services) {
-        ImmutableList<JTerm> resList = ImmutableSLList.nil();
+        ImmutableList<JTerm> resList = ImmutableList.nil();
 
         // "self != null"
         final JTerm selfNotNull = generateSelfNotNull(self);
@@ -626,7 +625,7 @@ public abstract class WellDefinednessCheck implements Contract {
     private TermListAndFunc buildFreePreForTaclet(JTerm implicitPre, TermSV self,
             TermSV heap, ImmutableList<JOperatorSV> params,
             Services services) {
-        ImmutableList<JTerm> resList = ImmutableSLList.nil();
+        ImmutableList<JTerm> resList = ImmutableList.nil();
 
         // "self != null"
         final JTerm selfNotNull = generateSelfNotNull(self);
@@ -846,7 +845,7 @@ public abstract class WellDefinednessCheck implements Contract {
      * @return a list of all remaining clauses
      */
     ImmutableList<JTerm> getRest() {
-        ImmutableList<JTerm> rest = ImmutableSLList.nil();
+        ImmutableList<JTerm> rest = ImmutableList.nil();
         final JTerm accessible = this.accessible;
         if (accessible != null) {
             rest = rest.append(accessible);

--- a/key.core.wd/src/main/java/de/uka/ilkd/key/wd/po/WellDefinednessPO.java
+++ b/key.core.wd/src/main/java/de/uka/ilkd/key/wd/po/WellDefinednessPO.java
@@ -28,7 +28,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.op.Function;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -120,7 +119,7 @@ public class WellDefinednessPO extends AbstractPO implements ContractPO {
     private static ImmutableList<LocationVariable> addGhostParams(
             ImmutableList<LocationVariable> paramVars, ImmutableList<LocationVariable> origParams) {
         // make sure ghost parameters are present
-        ImmutableList<LocationVariable> ghostParams = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> ghostParams = ImmutableList.nil();
         for (LocationVariable param : origParams) {
             if (param.isGhost()) {
                 ghostParams = ghostParams.append(param);
@@ -180,7 +179,7 @@ public class WellDefinednessPO extends AbstractPO implements ContractPO {
         if (vars.params != null && !vars.params.isEmpty()) {
             params = createParams(target, vars.params, services);
         } else {
-            params = ImmutableSLList.nil();
+            params = ImmutableList.nil();
         }
         return new Variables(self, result, exception, atPres, params, heap, anonHeap, services);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/control/AbstractProofControl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/AbstractProofControl.java
@@ -29,7 +29,6 @@ import org.key_project.prover.strategy.DelegationBasedRuleApplicationManager;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -110,7 +109,7 @@ public abstract class AbstractProofControl implements ProofControl {
 
     @Override
     public ImmutableList<BuiltInRule> getBuiltInRule(Goal focusedGoal, PosInOccurrence pos) {
-        ImmutableList<BuiltInRule> rules = ImmutableSLList.nil();
+        ImmutableList<BuiltInRule> rules = ImmutableList.nil();
 
         for (RuleApp ruleApp : focusedGoal.ruleAppIndex()
                 .getBuiltInRules(focusedGoal, pos)) {
@@ -140,7 +139,7 @@ public abstract class AbstractProofControl implements ProofControl {
             return filterTaclet(focusedGoal,
                 focusedGoal.ruleAppIndex().getFindTaclet(TacletFilter.TRUE, pos), pos);
         }
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
     @Override
@@ -151,7 +150,7 @@ public abstract class AbstractProofControl implements ProofControl {
                 focusedGoal.ruleAppIndex().getRewriteTaclet(TacletFilter.TRUE, pos), pos);
         }
 
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
     /**
@@ -162,7 +161,7 @@ public abstract class AbstractProofControl implements ProofControl {
             ImmutableList<NoPosTacletApp> tacletInstances,
             PosInOccurrence pos) {
         HashSet<Taclet> applicableRules = new HashSet<>();
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
         for (NoPosTacletApp app : tacletInstances) {
             if (isMinimizeInteraction()) {
                 ImmutableList<TacletApp> ifCandidates = app.findIfFormulaInstantiations(
@@ -330,7 +329,7 @@ public abstract class AbstractProofControl implements ProofControl {
             TacletFilter filter) {
         Services services = goal.proof().getServices();
         ImmutableSet<TacletApp> result = DefaultImmutableSet.nil();
-        ImmutableList<TacletApp> fittingApps = ImmutableSLList.nil();
+        ImmutableList<TacletApp> fittingApps = ImmutableList.nil();
         final RuleAppIndex index = goal.ruleAppIndex();
 
         if (pos == null) {
@@ -460,7 +459,7 @@ public abstract class AbstractProofControl implements ProofControl {
     protected ImmutableSet<IBuiltInRuleApp> getBuiltInRuleAppsForName(Goal focusedGoal, String name,
             PosInOccurrence pos) {
         ImmutableSet<IBuiltInRuleApp> result = DefaultImmutableSet.nil();
-        ImmutableList<BuiltInRule> match = ImmutableSLList.nil();
+        ImmutableList<BuiltInRule> match = ImmutableList.nil();
 
         // get all possible rules for current position in sequent
         ImmutableList<BuiltInRule> list = getBuiltInRule(focusedGoal, pos);
@@ -636,7 +635,7 @@ public abstract class AbstractProofControl implements ProofControl {
             goal.setRuleAppManager(focusManager);
         }
 
-        startAutoMode(goal.proof(), ImmutableSLList.singleton(goal),
+        startAutoMode(goal.proof(), ImmutableList.singleton(goal),
             new FocussedAutoModeTaskListener(goal.proof()));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -35,7 +35,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.instantiation.IllegalInstantiationException;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.parsing.Location;
 import org.key_project.util.parsing.Position;
@@ -118,7 +117,7 @@ public class TacletFindModel extends AbstractTableModel {
 
         noEditRow = count - 1;
 
-        ImmutableList<String> proposals = ImmutableSLList.nil();
+        ImmutableList<String> proposals = ImmutableList.nil();
 
         for (SchemaVariable var : tacletApp.uninstantiatedVars()) {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
@@ -22,7 +22,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.parsing.Position;
 
 public class TacletInstantiationModel {
@@ -155,7 +154,7 @@ public class TacletInstantiationModel {
             SVInstantiationParserException, MissingInstantiationException, SortMismatchException {
 
         ImmutableList<AssumesFormulaInstantiation> instList =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
 
         for (int i = ifChoiceModel.length - 1; i >= 0; --i) {
             instList = instList.prepend(ifChoiceModel[i].getSelection(i));

--- a/key.core/src/main/java/de/uka/ilkd/key/java/JavaInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/JavaInfo.java
@@ -28,7 +28,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.jspecify.annotations.Nullable;
@@ -518,7 +517,7 @@ public final class JavaInfo {
     @Nullable
     public IProgramMethod getProgramMethod(KeYJavaType classType, String methodName,
             List<List<KeYJavaType>> signature, KeYJavaType context) {
-        ImmutableList<KeYJavaType> partialSignature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> partialSignature = ImmutableList.nil();
         return getProgramMethodFromPartialSignature(classType, methodName, signature,
             partialSignature, context);
     }
@@ -563,7 +562,7 @@ public final class JavaInfo {
 
     public IProgramMethod getToplevelPM(KeYJavaType kjt, IProgramMethod pm) {
         final String methodName = pm.getName();
-        final ImmutableList<KeYJavaType> sig = ImmutableSLList.<KeYJavaType>nil()
+        final ImmutableList<KeYJavaType> sig = ImmutableList.<KeYJavaType>nil()
                 .append(pm.getParamTypes().toArray(new KeYJavaType[pm.getNumParams()]));
         return getToplevelPM(kjt, methodName, sig);
     }
@@ -702,7 +701,7 @@ public final class JavaInfo {
      * gets an array of expression and returns a list of types
      */
     private ImmutableList<KeYJavaType> getKeYJavaTypes(ImmutableArray<? extends Expression> args) {
-        ImmutableList<KeYJavaType> result = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> result = ImmutableList.nil();
         if (args != null) {
             for (int i = args.size() - 1; i >= 0; i--) {
                 final Expression argument = args.get(i);
@@ -745,7 +744,7 @@ public final class JavaInfo {
      */
     private ImmutableList<Field> filterLocalDeclaredFields(TypeDeclaration classDecl,
             Filter filter) {
-        ImmutableList<Field> fields = ImmutableSLList.nil();
+        ImmutableList<Field> fields = ImmutableList.nil();
         final ImmutableArray<MemberDeclaration> members = classDecl.getMembers();
         for (int i = members.size() - 1; i >= 0; i--) {
             final MemberDeclaration member = members.get(i);
@@ -796,7 +795,7 @@ public final class JavaInfo {
      *         of the given list
      */
     private ImmutableList<Field> getFields(FieldDeclaration field) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         final ImmutableArray<FieldSpecification> spec = field.getFieldSpecifications();
         for (int i = spec.size() - 1; i >= 0; i--) {
             result = result.prepend(spec.get(i));
@@ -813,7 +812,7 @@ public final class JavaInfo {
      *         of the given list
      */
     private ImmutableList<Field> getFields(ImmutableArray<MemberDeclaration> list) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         for (int i = list.size() - 1; i >= 0; i--) {
             final MemberDeclaration pe = list.get(i);
             if (pe instanceof FieldDeclaration) {
@@ -943,7 +942,7 @@ public final class JavaInfo {
      */
     public ImmutableList<ProgramVariable> getAllAttributes(String programName, KeYJavaType type,
             boolean traverseSubtypes) {
-        ImmutableList<ProgramVariable> result = ImmutableSLList.nil();
+        ImmutableList<ProgramVariable> result = ImmutableList.nil();
 
         if (!(type.getSort().extendsTrans(objectSort()))) {
             return result;
@@ -1078,7 +1077,7 @@ public final class JavaInfo {
                                 DEFAULT_EXECUTION_CONTEXT_METHOD));
             final KeYJavaType kjt = getTypeByClassName(DEFAULT_EXECUTION_CONTEXT_CLASS);
             defaultExecutionContext = new ExecutionContext(new TypeRef(kjt), getToplevelPM(kjt,
-                DEFAULT_EXECUTION_CONTEXT_METHOD, ImmutableSLList.nil()), null);
+                DEFAULT_EXECUTION_CONTEXT_METHOD, ImmutableList.nil()), null);
         }
         return defaultExecutionContext;
     }
@@ -1154,7 +1153,7 @@ public final class JavaInfo {
             return result;
         }
 
-        result = ImmutableSLList.nil();
+        result = ImmutableList.nil();
 
         if (k1.getSort().extendsTrans(k2.getSort())) {
             result = getAllSubtypes(k1).prepend(k1);

--- a/key.core/src/main/java/de/uka/ilkd/key/java/JavaService.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/JavaService.java
@@ -38,7 +38,6 @@ import de.uka.ilkd.key.util.parsing.BuildingIssue;
 import org.key_project.logic.Namespace;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import com.github.javaparser.*;
@@ -937,7 +936,7 @@ public class JavaService {
      */
     public JavaBlock readBlockWithProgramVariables(Namespace<IProgramVariable> variables, String s,
             Namespace<SchemaVariable> allowSchemaJava) {
-        ImmutableList<IProgramVariable> pvs = ImmutableSLList.nil();
+        ImmutableList<IProgramVariable> pvs = ImmutableList.nil();
         for (IProgramVariable n : variables.allElements()) {
             if (n instanceof ProgramVariable) {
                 pvs = pvs.append(n); // preserve the order (nested namespaces!)

--- a/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
@@ -20,14 +20,12 @@ import de.uka.ilkd.key.util.Debug;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithModifiers;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
@@ -625,7 +623,7 @@ public class KeYProgModelInfo {
             rct = rct.getAncestors().get(1).getTypeDeclaration().orElseThrow();
         }
 
-        ImmutableList<KeYJavaType> classList = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> classList = ImmutableList.nil();
         classList = recFindImplementations(rct, name, jpSignature, classList);
 
         if (!declaresApplicableMethods(rct, name, jpSignature, rct)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/ContextStatementBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/ContextStatementBlock.java
@@ -18,7 +18,7 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.prover.rules.matcher.vm.ProgramChildrenMatcher;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -54,7 +54,7 @@ public class ContextStatementBlock extends StatementBlock {
             PositionInfo pi, List<Comment> c,
             ImmutableArray<? extends Statement> body,
             IExecutionContext execContext) {
-        super(pi, c, body, ImmutableSLList.nil());
+        super(pi, c, body, ImmutableList.nil());
         this.executionContext = execContext;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/ProgramElement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/ProgramElement.java
@@ -8,7 +8,6 @@ import de.uka.ilkd.key.rule.MatchConditions;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -28,7 +27,7 @@ public interface ProgramElement extends SourceElement, ModelElement {
 
     ///
     default ImmutableList<TextualJMLConstruct> getAttachedJml() {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/StatementBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/StatementBlock.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.util.Debug;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
@@ -89,7 +88,7 @@ public class StatementBlock extends JavaStatement implements StatementContainer,
         ProgramPrefixUtil.ProgramPrefixInfo info = ProgramPrefixUtil.computeEssentials(this);
         prefixLength = info.getLength();
         innerMostMethodFrame = info.getInnerMostMethodFrame();
-        attachedJML = ImmutableSLList.nil();
+        attachedJML = ImmutableList.nil();
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/ArrayDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/ArrayDeclaration.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.logic.ProgramElementName;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * KeY used to model arrays using only the {@link ArrayType}. As
@@ -239,7 +238,7 @@ public class ArrayDeclaration extends TypeDeclaration implements ArrayType {
      * returns the local declared supertypes
      */
     public ImmutableList<KeYJavaType> getSupertypes() {
-        return ImmutableSLList.<KeYJavaType>nil().append(superType);
+        return ImmutableList.<KeYJavaType>nil().append(superType);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/ClassDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/ClassDeclaration.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * There are several types of class declarations:
@@ -251,7 +250,7 @@ public class ClassDeclaration extends TypeDeclaration implements Statement {
      * returns the local declared supertypes
      */
     public ImmutableList<KeYJavaType> getSupertypes() {
-        ImmutableList<KeYJavaType> types = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> types = ImmutableList.nil();
         if (implementing != null) {
             for (int i = implementing.getTypeReferenceCount() - 1; i >= 0; i--) {
                 types = types.prepend(implementing.getTypeReferenceAt(i).getKeYJavaType());

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/InterfaceDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/InterfaceDeclaration.java
@@ -29,7 +29,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -235,7 +234,7 @@ public class InterfaceDeclaration extends TypeDeclaration {
      * returns the local declared supertypes
      */
     public ImmutableList<KeYJavaType> getSupertypes() {
-        ImmutableList<KeYJavaType> types = ImmutableSLList.<KeYJavaType>nil();
+        ImmutableList<KeYJavaType> types = ImmutableList.<KeYJavaType>nil();
         if (extending != null) {
             for (int i = extending.getTypeReferenceCount() - 1; i >= 0; i--) {
                 types = types.prepend(extending.getTypeReferenceAt(i).getKeYJavaType());

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/JavaDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/JavaDeclaration.java
@@ -28,7 +28,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -63,17 +62,17 @@ public abstract class JavaDeclaration extends JavaNonTerminalProgramElement impl
      * Java declaration.
      */
     public JavaDeclaration() {
-        this(null, null, new ImmutableArray<>(), ImmutableSLList.nil());
+        this(null, null, new ImmutableArray<>(), ImmutableList.nil());
     }
 
 
     public JavaDeclaration(Modifier[] mods) {
-        this(null, null, new ImmutableArray<>(mods), ImmutableSLList.nil());
+        this(null, null, new ImmutableArray<>(mods), ImmutableList.nil());
     }
 
 
     public JavaDeclaration(ImmutableArray<Modifier> mods) {
-        this(null, null, mods, ImmutableSLList.nil());
+        this(null, null, mods, ImmutableList.nil());
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/SuperArrayDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/SuperArrayDeclaration.java
@@ -9,7 +9,6 @@ import de.uka.ilkd.key.java.visitor.Visitor;
 import de.uka.ilkd.key.logic.ProgramElementName;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * At the moment the mere purpose of this Class is to provide an encapsulation for the length
@@ -44,7 +43,7 @@ public class SuperArrayDeclaration extends TypeDeclaration {
      * returns the local declared supertypes
      */
     public ImmutableList<KeYJavaType> getSupertypes() {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/TypeDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/TypeDeclaration.java
@@ -18,7 +18,6 @@ import de.uka.ilkd.key.speclang.njml.SpecMathMode;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -225,10 +224,10 @@ public abstract class TypeDeclaration extends JavaDeclaration
      */
     public ImmutableList<Field> getAllFields(Services services) {
         if (members == null) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
 
         for (MemberDeclaration member : members) {
             if (member instanceof FieldDeclaration) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/VariableDeclaration.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/declaration/VariableDeclaration.java
@@ -14,7 +14,7 @@ import de.uka.ilkd.key.java.visitor.Visitor;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -102,7 +102,7 @@ public abstract class VariableDeclaration extends JavaDeclaration
 
     public VariableDeclaration(PositionInfo pi, List<Comment> c, ImmutableArray<Modifier> modArray,
             TypeReference type, boolean parentIsInferface) {
-        super(pi, c, modArray, ImmutableSLList.nil());
+        super(pi, c, modArray, ImmutableList.nil());
         this.typeReference = type;
         this.parentIsInterfaceDeclaration = parentIsInferface;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/reference/MethodReference.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/reference/MethodReference.java
@@ -22,7 +22,6 @@ import de.uka.ilkd.key.util.Debug;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Method reference.
@@ -287,7 +286,7 @@ public class MethodReference extends JavaNonTerminalProgramElement
      * determines the arguments types and constructs a signature of the current method
      */
     public ImmutableList<KeYJavaType> getMethodSignature(Services services, ExecutionContext ec) {
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
         if (arguments != null) {
             final TypeConverter typeConverter = services.getTypeConverter();
             for (int i = arguments.size() - 1; i >= 0; i--) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/Do.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/Do.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Do.
@@ -44,7 +43,7 @@ public class Do extends LoopStatement {
     }
 
     public Do(PositionInfo pi, List<Comment> comments, Guard guard, Statement body) {
-        super(pi, comments, null, null, guard, body, ImmutableSLList.nil());
+        super(pi, comments, null, null, guard, body, ImmutableList.nil());
     }
 
     public Do(PositionInfo pi, List<Comment> comments, Guard guard, Statement body,

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/EnhancedFor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/EnhancedFor.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -30,12 +29,12 @@ import org.jspecify.annotations.NonNull;
 public class EnhancedFor extends LoopStatement implements VariableScope {
     private EnhancedFor(PositionInfo pi, List<Comment> comments, ILoopInit inits,
             IForUpdates updates, IGuard guard, Statement body) {
-        super(pi, comments, inits, updates, guard, body, ImmutableSLList.nil());
+        super(pi, comments, inits, updates, guard, body, ImmutableList.nil());
     }
 
     public EnhancedFor(PositionInfo pi, List<Comment> comments, ILoopInit inits,
             IGuard guard, Statement body) {
-        super(pi, comments, inits, null, guard, body, ImmutableSLList.nil());
+        super(pi, comments, inits, null, guard, body, ImmutableList.nil());
     }
 
     public EnhancedFor(PositionInfo pi, List<Comment> comments, ILoopInit inits,

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/For.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/For.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * For.
@@ -54,7 +53,7 @@ public class For extends LoopStatement implements VariableScope {
 
     public For(PositionInfo pi, List<Comment> comments, ILoopInit inits, IForUpdates updates,
             IGuard guard, Statement body) {
-        super(pi, comments, inits, updates, guard, body, ImmutableSLList.nil());
+        super(pi, comments, inits, updates, guard, body, ImmutableList.nil());
     }
 
     public <T> For(PositionInfo pi, List<Comment> comments, ILoopInit inits, IForUpdates updates,

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/LoopStatement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/LoopStatement.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
@@ -66,7 +65,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = null;
         this.inits = null;
         this.guard = new Guard(guard);
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
     public LoopStatement(Expression guard, @NonNull Statement body, ExtList comments,
@@ -76,7 +75,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = null;
         this.inits = null;
         this.guard = new Guard(guard);
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
     public LoopStatement(Expression guard, @NonNull Statement body) {
@@ -84,7 +83,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = null;
         this.inits = null;
         this.guard = new Guard(guard);
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
     public LoopStatement(Expression guard, @NonNull Statement body, PositionInfo pos) {
@@ -93,7 +92,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = null;
         this.inits = null;
         this.guard = new Guard(guard);
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
 
@@ -119,7 +118,7 @@ public abstract class LoopStatement extends JavaStatement
         }
         this.inits = new LoopInit(inits);
         this.guard = new Guard(guard);
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
     /**
@@ -144,7 +143,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = updates;
         this.inits = inits;
         this.guard = guard;
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
 
@@ -156,7 +155,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = updates;
         this.inits = inits;
         this.guard = guard;
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
 
@@ -182,7 +181,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = updates;
         this.inits = inits;
         this.guard = guard;
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
 
@@ -204,7 +203,7 @@ public abstract class LoopStatement extends JavaStatement
         this.updates = updates;
         this.inits = inits;
         this.guard = guard;
-        this.attachedJml = ImmutableSLList.nil();
+        this.attachedJml = ImmutableList.nil();
     }
 
     public LoopStatement(PositionInfo pi, List<Comment> comments, ILoopInit inits,

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/MergePointStatement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/MergePointStatement.java
@@ -28,7 +28,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLMergePointDecl;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * A statement indicating a merge point.
@@ -45,7 +44,7 @@ public class MergePointStatement extends JavaStatement
 
     @Override
     public ImmutableList<TextualJMLConstruct> getAttachedJml() {
-        return context == null ? ImmutableSLList.nil() : ImmutableList.of(context);
+        return context == null ? ImmutableList.nil() : ImmutableList.of(context);
     }
 
     public MergePointStatement(

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/While.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/While.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * While.
@@ -63,7 +62,7 @@ public class While extends LoopStatement {
     }
 
     public While(PositionInfo pi, List<Comment> c, Guard guard, Statement body) {
-        super(pi, c, null, null, guard, body, ImmutableSLList.nil());
+        super(pi, c, null, null, guard, body, ImmutableList.nil());
     }
 
     public While(PositionInfo pi, List<Comment> c, Guard guard, Statement body,

--- a/key.core/src/main/java/de/uka/ilkd/key/java/loader/CreateArrayMethodBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/loader/CreateArrayMethodBuilder.java
@@ -50,7 +50,6 @@ import de.uka.ilkd.key.logic.op.ProgramVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This class creates the <code>&lt;createArray&gt;</code> method for array creation and in
@@ -123,7 +122,7 @@ public final class CreateArrayMethodBuilder extends KeYJavaASTFactory {
      *         of the given list
      */
     private ImmutableList<Field> filterField(ImmutableArray<MemberDeclaration> list) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         for (int i = list.size() - 1; i >= 0; i--) {
             MemberDeclaration pe = list.get(i);
             if (pe instanceof FieldDeclaration) {
@@ -142,7 +141,7 @@ public final class CreateArrayMethodBuilder extends KeYJavaASTFactory {
      *         of the given list
      */
     private ImmutableList<Field> filterField(FieldDeclaration field) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         ImmutableArray<FieldSpecification> spec = field.getFieldSpecifications();
         for (int i = spec.size() - 1; i >= 0; i--) {
             result = result.prepend(spec.get(i));
@@ -158,7 +157,7 @@ public final class CreateArrayMethodBuilder extends KeYJavaASTFactory {
      * @return a list with all implicit fields found in 'list'
      */
     private ImmutableList<Field> filterImplicitFields(ImmutableList<Field> list) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         for (Field field : list) {
             if (field.isImplicit()) {
                 result = result.append(field);

--- a/key.core/src/main/java/de/uka/ilkd/key/java/loader/JP2KeYTypeConverter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/loader/JP2KeYTypeConverter.java
@@ -474,7 +474,7 @@ public class JP2KeYTypeConverter {
      *         of the given list
      */
     private ImmutableList<Field> filterField(FieldDeclaration field) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         ImmutableArray<FieldSpecification> spec = field.getFieldSpecifications();
         for (int i = spec.size() - 1; i >= 0; i--) {
             result = result.prepend(spec.get(i));
@@ -491,7 +491,7 @@ public class JP2KeYTypeConverter {
      *         of the given list
      */
     private ImmutableList<Field> filterField(ExtList list) {
-        ImmutableList<Field> result = ImmutableSLList.nil();
+        ImmutableList<Field> result = ImmutableList.nil();
         for (Object aList : list) {
             Object pe = aList;
             if (pe instanceof FieldDeclaration) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/visitor/JavaASTCollector.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/visitor/JavaASTCollector.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.java.visitor;
 import de.uka.ilkd.key.java.ast.ProgramElement;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Walks through a java AST in depth-left-fist-order. You can set the type of nodes you want to
@@ -18,7 +17,7 @@ public class JavaASTCollector extends JavaASTWalker {
     /** the type of nodes to be collected */
     private final Class<?> type;
     /** the list of found elements */
-    private ImmutableList<ProgramElement> resultList = ImmutableSLList.nil();
+    private ImmutableList<ProgramElement> resultList = ImmutableList.nil();
 
     /**
      * create the JavaASTWalker

--- a/key.core/src/main/java/de/uka/ilkd/key/java/visitor/ProgVarReplaceVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/visitor/ProgVarReplaceVisitor.java
@@ -34,7 +34,6 @@ import org.key_project.logic.op.UpdateableOperator;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -191,7 +190,7 @@ public class ProgVarReplaceVisitor extends CreatingASTVisitor {
     }
 
     private ImmutableList<JTerm> replaceVariablesInTerms(ImmutableList<JTerm> terms) {
-        ImmutableList<JTerm> res = ImmutableSLList.nil();
+        ImmutableList<JTerm> res = ImmutableList.nil();
         boolean changed = false;
         for (final JTerm term : terms) {
             final JTerm newTerm = replaceVariablesInTerm(term);
@@ -203,7 +202,7 @@ public class ProgVarReplaceVisitor extends CreatingASTVisitor {
 
     private ImmutableList<InfFlowSpec> replaceVariablesInTermListTriples(
             ImmutableList<InfFlowSpec> terms) {
-        ImmutableList<InfFlowSpec> res = ImmutableSLList.nil();
+        ImmutableList<InfFlowSpec> res = ImmutableList.nil();
         boolean changed = false;
         for (final InfFlowSpec innerTerms : terms) {
             final ImmutableList<JTerm> renamedPreExpressions =

--- a/key.core/src/main/java/de/uka/ilkd/key/ldt/HeapLDT.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/ldt/HeapLDT.java
@@ -32,7 +32,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -125,7 +124,7 @@ public final class HeapLDT extends LDT {
         acc = addFunction(services, "acc");
         reach = addFunction(services, "reach");
         prec = addFunction(services, "prec");
-        heaps = ImmutableSLList.<LocationVariable>nil()
+        heaps = ImmutableList.<LocationVariable>nil()
                 .append((LocationVariable) progVars.lookup(BASE_HEAP_NAME))
                 .append((LocationVariable) progVars.lookup(SAVED_HEAP_NAME));
         if (services instanceof Services s) {

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/GenericArgument.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/GenericArgument.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import org.key_project.logic.TerminalSyntaxElement;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -27,7 +26,7 @@ public record GenericArgument(@NonNull Sort sort) implements TerminalSyntaxEleme
             return new GenericArgument(
                 svInst.getGenericSortInstantiations().getRealSort(gs, services));
         } else if (sort instanceof ParametricSortInstance psi) {
-            ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+            ImmutableList<GenericArgument> args = ImmutableList.nil();
 
             for (int i = psi.getArgs().size() - 1; i >= 0; i--) {
                 args = args.prepend(psi.getArgs().get(i).instantiate(svInst, services));

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/MethodStackInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/MethodStackInfo.java
@@ -9,7 +9,6 @@ import de.uka.ilkd.key.logic.op.IProgramMethod;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public class MethodStackInfo implements NameCreationInfo {
 
@@ -28,7 +27,7 @@ public class MethodStackInfo implements NameCreationInfo {
      * returns the method call stack
      */
     public ImmutableList<IProgramMethod> getMethodStack() {
-        ImmutableList<IProgramMethod> list = ImmutableSLList.nil();
+        ImmutableList<IProgramMethod> list = ImmutableList.nil();
         if (element instanceof ProgramPrefix) {
             final ImmutableArray<ProgramPrefix> prefix =
                 ((ProgramPrefix) element).getPrefixElements();

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
@@ -247,7 +247,7 @@ public class TermBuilder {
      */
     public ImmutableList<LocationVariable> paramVars(IObserverFunction obs,
             boolean makeNamesUnique) {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (int i = 0, n = obs.getNumParams(); i < n; i++) {
             final KeYJavaType paramType = obs.getParamType(i);
             String name;
@@ -269,7 +269,7 @@ public class TermBuilder {
     public ImmutableList<LocationVariable> paramVars(String postfix, IObserverFunction obs,
             boolean makeNamesUnique) {
         final ImmutableList<LocationVariable> paramVars = paramVars(obs, makeNamesUnique);
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (LocationVariable paramVar : paramVars) {
             ProgramElementName pen = new ProgramElementName(paramVar.name() + postfix);
             LocationVariable formalParamVar = new LocationVariable(pen, paramVar.getKeYJavaType());
@@ -406,7 +406,7 @@ public class TermBuilder {
     }
 
     public ImmutableList<JTerm> var(ProgramVariable... vs) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (ProgramVariable v : vs) {
             result = result.append(var(v));
         }
@@ -414,7 +414,7 @@ public class TermBuilder {
     }
 
     public ImmutableList<JTerm> var(Iterable<? extends ProgramVariable> vs) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (ProgramVariable v : vs) {
             result = result.append(var(v));
         }
@@ -1046,7 +1046,7 @@ public class TermBuilder {
     }
 
     public JTerm parallel(Iterable<JTerm> lhss, Iterable<JTerm> values) {
-        ImmutableList<JTerm> updates = ImmutableSLList.nil();
+        ImmutableList<JTerm> updates = ImmutableList.nil();
         Iterator<JTerm> lhssIt = lhss.iterator();
         Iterator<JTerm> rhssIt = values.iterator();
         while (lhssIt.hasNext()) {
@@ -1087,7 +1087,7 @@ public class TermBuilder {
     }
 
     public ImmutableList<JTerm> apply(JTerm update, ImmutableList<JTerm> targets) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JTerm target : targets) {
             result = result.append(apply(update, target));
         }
@@ -1115,7 +1115,7 @@ public class TermBuilder {
     }
 
     public ImmutableList<JTerm> applyElementary(JTerm heap, Iterable<JTerm> targets) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JTerm target : targets) {
             result = result.append(apply(elementary(heap), target, null));
         }
@@ -1143,7 +1143,7 @@ public class TermBuilder {
         if (updates.length == 0) {
             return target;
         } else {
-            ImmutableList<JTerm> updateList = ImmutableSLList.<JTerm>nil().append(updates).tail();
+            ImmutableList<JTerm> updateList = ImmutableList.<JTerm>nil().append(updates).tail();
             return apply(updates[0], applySequential(updateList, target), null);
         }
     }
@@ -1535,7 +1535,7 @@ public class TermBuilder {
     }
 
     public ImmutableList<JTerm> wd(Iterable<JTerm> l) {
-        ImmutableList<JTerm> res = ImmutableSLList.nil();
+        ImmutableList<JTerm> res = ImmutableList.nil();
         for (JTerm t : l) {
             res = res.append(wd(t));
         }
@@ -2016,7 +2016,7 @@ public class TermBuilder {
         final JTerm modifiableAtPre = or.replace(modifiable);
         final JTerm createdAtPre = or.replace(created(heapTerm, objVarTerm));
 
-        ImmutableList<QuantifiableVariable> quantVars = ImmutableSLList.nil();
+        ImmutableList<QuantifiableVariable> quantVars = ImmutableList.nil();
         quantVars = quantVars.append(objVar);
         quantVars = quantVars.append(fieldVar);
         // selects on permission heaps have to be explicitly typed as field type
@@ -2054,7 +2054,7 @@ public class TermBuilder {
 
         final OpReplacer or = new OpReplacer(normalToAtPre, tf);
 
-        ImmutableList<QuantifiableVariable> quantVars = ImmutableSLList.nil();
+        ImmutableList<QuantifiableVariable> quantVars = ImmutableList.nil();
         quantVars = quantVars.append(objVar);
         quantVars = quantVars.append(fieldVar);
 
@@ -2205,7 +2205,7 @@ public class TermBuilder {
         assert s.sort().equals(setLDT.targetSort());
         final Function union = setLDT.getUnion();
         ImmutableSet<JTerm> result = DefaultImmutableSet.nil();
-        ImmutableList<JTerm> workingList = ImmutableSLList.<JTerm>nil().prepend(s);
+        ImmutableList<JTerm> workingList = ImmutableList.<JTerm>nil().prepend(s);
         while (!workingList.isEmpty()) {
             JTerm f = workingList.head();
             workingList = workingList.tail();
@@ -2232,7 +2232,7 @@ public class TermBuilder {
      * Removes leading updates from the passed term.
      */
     public static Pair<ImmutableList<JTerm>, JTerm> goBelowUpdates2(JTerm term) {
-        ImmutableList<JTerm> updates = ImmutableSLList.nil();
+        ImmutableList<JTerm> updates = ImmutableList.nil();
         while (term.op() instanceof UpdateApplication) {
             updates = updates.append(UpdateApplication.getUpdate(term));
             term = UpdateApplication.getTarget(term);
@@ -2256,7 +2256,7 @@ public class TermBuilder {
      * @return The {@link JTerm} {@link Sort}s.
      */
     public ImmutableList<Sort> getSorts(Iterable<JTerm> terms) {
-        ImmutableList<Sort> result = ImmutableSLList.nil();
+        ImmutableList<Sort> result = ImmutableList.nil();
         for (JTerm t : terms) {
             result = result.append(t.sort());
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/equality/RenamingTermProperty.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/equality/RenamingTermProperty.java
@@ -15,7 +15,6 @@ import org.key_project.logic.op.Operator;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import static de.uka.ilkd.key.logic.equality.RenamingSourceElementProperty.RENAMING_SOURCE_ELEMENT_PROPERTY;
 
@@ -59,8 +58,8 @@ public class RenamingTermProperty implements Property<Term> {
         if (term2 == term1) {
             return true;
         }
-        return unifyHelp(term1, term2, ImmutableSLList.nil(),
-            ImmutableSLList.nil(), null);
+        return unifyHelp(term1, term2, ImmutableList.nil(),
+            ImmutableList.nil(), null);
     }
 
     /**
@@ -72,7 +71,7 @@ public class RenamingTermProperty implements Property<Term> {
     @Override
     public int hashCodeModThisProperty(Term term) {
         // Labels can be completely ignored
-        return hashTermHelper(term, ImmutableSLList.nil(), 1);
+        return hashTermHelper(term, ImmutableList.nil(), 1);
     }
 
     // equals modulo renaming logic

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/label/TermLabelManager.java
@@ -26,7 +26,6 @@ import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.CollectionUtil;
 
@@ -119,7 +118,7 @@ public class TermLabelManager {
     /**
      * All rule independent {@link TermLabelUpdate}s.
      */
-    private ImmutableList<TermLabelUpdate> allRulesUpdates = ImmutableSLList.nil();
+    private ImmutableList<TermLabelUpdate> allRulesUpdates = ImmutableList.nil();
 
     /**
      * All rule specific {@link TermLabelRefactoring}s.
@@ -131,12 +130,12 @@ public class TermLabelManager {
      * All rule independent {@link TermLabelRefactoring}s.
      */
     private ImmutableList<TermLabelRefactoring> allRulesRefactorings =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
 
     /**
      * The {@link Name}s of all supported {@link TermLabel}s.
      */
-    private ImmutableList<Name> supportedTermLabelnames = ImmutableSLList.nil();
+    private ImmutableList<Name> supportedTermLabelnames = ImmutableList.nil();
 
     /**
      * {@link Map}s the {@link Name} of a {@link TermLabel} to its {@link TermLabelMerger}.
@@ -262,7 +261,7 @@ public class TermLabelManager {
                     for (Name rule : supportedRules) {
                         ImmutableList<TermLabelUpdate> ruleUpdates = ruleSpecificUpdates.get(rule);
                         if (ruleUpdates == null) {
-                            ruleUpdates = ImmutableSLList.nil();
+                            ruleUpdates = ImmutableList.nil();
                         }
                         ruleUpdates = ruleUpdates.prepend(update);
                         ruleSpecificUpdates.put(rule, ruleUpdates);
@@ -293,7 +292,7 @@ public class TermLabelManager {
                         ImmutableList<TermLabelRefactoring> ruleRefactorings =
                             ruleSpecificRefactorings.get(rule);
                         if (ruleRefactorings == null) {
-                            ruleRefactorings = ImmutableSLList.nil();
+                            ruleRefactorings = ImmutableList.nil();
                         }
                         ruleRefactorings = ruleRefactorings.prepend(refactoring);
                         ruleSpecificRefactorings.put(rule, ruleRefactorings);
@@ -333,7 +332,7 @@ public class TermLabelManager {
         if (manager != null) {
             return manager.getSupportedTermLabelNames();
         } else {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramMethod.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramMethod.java
@@ -24,7 +24,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.parsing.Position;
 
@@ -452,7 +451,7 @@ public final class ProgramMethod extends ObserverFunction
 
     @Override
     public ImmutableList<LocationVariable> collectParameters() {
-        ImmutableList<LocationVariable> paramVars = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> paramVars = ImmutableList.nil();
         int numParams = getParameterDeclarationCount();
         for (int i = numParams - 1; i >= 0; i--) {
             ParameterDeclaration pd = getParameterDeclarationAt(i);

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
@@ -16,7 +16,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.sort.AbstractSort;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -140,7 +139,7 @@ public final class ParametricSortInstance extends AbstractSort {
             return arg == null ? gs : arg.sort();
         } else if (sort instanceof ParametricSortInstance psi) {
             var base = psi.getBase();
-            ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+            ImmutableList<GenericArgument> args = ImmutableList.nil();
             for (int i = psi.getArgs().size() - 1; i >= 0; i--) {
                 var psiArg = psi.getArgs().get(i);
                 args = args.prepend(new GenericArgument(instantiate(psiArg.sort(), map, services)));
@@ -176,7 +175,7 @@ public final class ParametricSortInstance extends AbstractSort {
 
     /// Get the sort if this parametric sort with all generics instantiated with `instMap`.
     public Sort resolveSort(SVInstantiations instMap, Services services) {
-        ImmutableList<GenericArgument> newArgs = ImmutableSLList.nil();
+        ImmutableList<GenericArgument> newArgs = ImmutableList.nil();
         for (int i = args.size() - 1; i >= 0; i--) {
             GenericArgument arg = args.get(i);
             var sort = arg.sort();

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/AbstractProofMacro.java
@@ -12,7 +12,6 @@ import de.uka.ilkd.key.settings.ProofSettings;
 import org.key_project.prover.engine.ProverTaskListener;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Takes care of providing the whole ProofMacro interface by only making it necessary to implement
@@ -28,7 +27,7 @@ public abstract class AbstractProofMacro implements ProofMacro {
     private static ImmutableList<Goal> getGoals(Node node) {
         if (node == null) {
             // can happen during initialisation
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         } else {
             return node.proof().getSubtreeEnabledGoals(node);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.prover.impl.DefaultTaskFinishedInfo;
 
 import org.key_project.prover.engine.ProofSearchInformation;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -38,7 +37,7 @@ public class ProofMacroFinishedInfo extends DefaultTaskFinishedInfo {
 
     ProofMacroFinishedInfo(ProofMacro macro, Goal goal, Proof proof, long time, int appliedRules,
             int closedGoals) {
-        this(macro, ImmutableSLList.<Goal>nil().prepend(goal), proof, time, appliedRules,
+        this(macro, ImmutableList.<Goal>nil().prepend(goal), proof, time, appliedRules,
             closedGoals);
     }
 
@@ -115,13 +114,13 @@ public class ProofMacroFinishedInfo extends DefaultTaskFinishedInfo {
     public ImmutableList<Goal> getGoals() {
         final Object result = getResult();
         if (result == null) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         } else {
             return (ImmutableList<Goal>) result;
         }
     }
 
     public static ProofMacroFinishedInfo getDefaultInfo(ProofMacro macro, Proof proof) {
-        return new ProofMacroFinishedInfo(macro, ImmutableSLList.nil(), proof);
+        return new ProofMacroFinishedInfo(macro, ImmutableList.nil(), proof);
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
@@ -15,7 +15,6 @@ import org.key_project.prover.engine.ProverCore;
 import org.key_project.prover.engine.ProverTaskListener;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * The Class TryCloseMacro tries to close goals. Goals are either closed or left untouched.
@@ -173,7 +172,7 @@ public class TryCloseMacro extends AbstractProofMacro {
                 int maxSteps = numberSteps > 0 ? numberSteps
                         : proof.getSettings().getStrategySettings().getMaxSteps();
                 final ProofSearchInformation<Proof, Goal> result = applyStrategy.start(proof,
-                    ImmutableSLList.<Goal>nil().prepend(goal), maxSteps, -1, false);
+                    ImmutableList.<Goal>nil().prepend(goal), maxSteps, -1, false);
                 // final Goal closedGoal;
 
                 // retreat if not closed

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/DefaultBuilder.java
@@ -32,7 +32,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -381,7 +380,7 @@ public class DefaultBuilder extends AbstractBuilder<Object> {
             semanticError(ctx, "Expected %d sort arguments, got only %d",
                 params.size(), ctx.sortId().size());
         }
-        ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+        ImmutableList<GenericArgument> args = ImmutableList.nil();
         for (int i = params.size() - 1; i >= 0; i--) {
             var arg = ctx.sortId(i);
             var sort = visitSortId(arg);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -44,7 +44,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.StringUtil;
 import org.key_project.util.parsing.Position;
@@ -603,7 +602,7 @@ public class ExpressionBuilder extends DefaultBuilder {
         }
         if (head != null && ss != null) {
             // A sequent with only head in the antecedent.
-            var ant = ImmutableSLList.singleton(new SequentFormula(head));
+            var ant = ImmutableList.singleton(new SequentFormula(head));
             return JavaDLSequentKit.createSequent(ant, ss);
         }
         if (head != null && s != null) {
@@ -612,7 +611,7 @@ public class ExpressionBuilder extends DefaultBuilder {
             return JavaDLSequentKit.createSequent(newAnt, s.succedent().asList());
         }
         if (ss != null) {
-            return JavaDLSequentKit.createSequent(ImmutableSLList.nil(), ss);
+            return JavaDLSequentKit.createSequent(ImmutableList.nil(), ss);
         }
         assert (false);
         return null;
@@ -622,7 +621,7 @@ public class ExpressionBuilder extends DefaultBuilder {
     public ImmutableList<SequentFormula> visitSemisequent(JavaKeYParser.SemisequentContext ctx) {
         ImmutableList<SequentFormula> ss = accept(ctx.ss);
         if (ss == null) {
-            ss = ImmutableSLList.nil();
+            ss = ImmutableList.nil();
         }
         JTerm head = accept(ctx.term());
         if (head != null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ProblemFinder.java
@@ -18,7 +18,7 @@ import de.uka.ilkd.key.util.parsing.BuildingException;
 
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -112,7 +112,7 @@ public class ProblemFinder extends ExpressionBuilder {
             return s;
         if (obj instanceof JTerm t)
             return JavaDLSequentKit
-                    .createSuccSequent(ImmutableSLList.singleton(new SequentFormula(t)));
+                    .createSuccSequent(ImmutableList.singleton(new SequentFormula(t)));
         return null;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/TacletPBuilder.java
@@ -27,10 +27,7 @@ import de.uka.ilkd.key.rule.conditions.TypeResolver;
 import de.uka.ilkd.key.rule.tacletbuilder.*;
 import de.uka.ilkd.key.util.parsing.BuildingException;
 
-import org.key_project.logic.Choice;
-import org.key_project.logic.ChoiceExpr;
-import org.key_project.logic.Name;
-import org.key_project.logic.Namespace;
+import org.key_project.logic.*;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.op.sv.SchemaVariable;
@@ -139,7 +136,7 @@ public class TacletPBuilder extends ExpressionBuilder {
         TacletBuilder<?> b = peekTBuilder();
         JTerm t = accept(ctx.t);
         List<JTerm> avoidConditions = mapOf(ctx.avoidCond);
-        b.setTrigger(new Trigger(triggerVar, t, ImmutableList.fromList(avoidConditions)));
+        b.setTrigger(new Trigger(triggerVar, t, ImmutableList.<Term>fromList(avoidConditions)));
         return null;
     }
 
@@ -165,8 +162,8 @@ public class TacletPBuilder extends ExpressionBuilder {
             TacletBuilder<?> b = createTacletBuilderFor(null, ApplicationRestriction.NONE, ctx);
             currentTBuilder.push(b);
             SequentFormula sform = new SequentFormula(form);
-            Sequent addSeq = JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(sform));
-            ImmutableList<Taclet> noTaclets = ImmutableSLList.nil();
+            Sequent addSeq = JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(sform));
+            ImmutableList<Taclet> noTaclets = ImmutableList.nil();
             DefaultImmutableSet<SchemaVariable> noSV = DefaultImmutableSet.nil();
             addGoalTemplate(null, null, addSeq, noTaclets, noSV, null, null, ctx);
             b.setName(new Name(name));
@@ -262,7 +259,7 @@ public class TacletPBuilder extends ExpressionBuilder {
         if (genParams != null) {
             var psd = namespaces().parametricSorts().lookup(ctx.name.getText());
             assert psd != null;
-            ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+            ImmutableList<GenericArgument> args = ImmutableList.nil();
             for (int i = psd.getParameters().size() - 1; i >= 0; i--) {
                 args = args.prepend(new GenericArgument(psd.getParameters().get(i).sort()));
             }
@@ -368,7 +365,7 @@ public class TacletPBuilder extends ExpressionBuilder {
 
         tacletBuilder.setFind(tb.func(function, tb.var(x)));
         tacletBuilder.setAssumesSequent(JavaDLSequentKit.createAnteSequent(
-            ImmutableSLList
+            ImmutableList
                     .singleton(new SequentFormula(tb.equals(tb.func(consFn, args), tb.var(x))))));
         tacletBuilder.addTacletGoalTemplate(new RewriteTacletGoalTemplate(tb.var(res)));
         tacletBuilder.setApplicationRestriction(
@@ -423,8 +420,8 @@ public class TacletPBuilder extends ExpressionBuilder {
 
         var use = tb.all(qvar, tb.var(phi));
         var useCase = new TacletGoalTemplate(
-            JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(new SequentFormula(use))),
-            ImmutableSLList.nil());
+            JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(new SequentFormula(use))),
+            ImmutableList.nil());
         useCase.setName("Use case of " + ctx.name.getText());
         cases.add(new GoalTemplAndVars(useCase, null));
 
@@ -439,8 +436,8 @@ public class TacletPBuilder extends ExpressionBuilder {
         var constr = createQuantifiedFormula(it, qvar, var, sort);
         var goal = new TacletGoalTemplate(
             JavaDLSequentKit
-                    .createSuccSequent(ImmutableSLList.singleton(new SequentFormula(constr.term))),
-            ImmutableSLList.nil());
+                    .createSuccSequent(ImmutableList.singleton(new SequentFormula(constr.term))),
+            ImmutableList.nil());
         goal.setName(it.getText());
         return new GoalTemplAndVars(goal, constr.vars);
     }
@@ -476,8 +473,8 @@ public class TacletPBuilder extends ExpressionBuilder {
 
         var goal = new TacletGoalTemplate(
             JavaDLSequentKit
-                    .createAnteSequent(ImmutableSLList.singleton(new SequentFormula(axiom))),
-            ImmutableSLList.nil());
+                    .createAnteSequent(ImmutableList.singleton(new SequentFormula(axiom))),
+            ImmutableList.nil());
         tacletBuilder.addTacletGoalTemplate(goal);
 
         tacletBuilder.setName(new Name(String.format("DT_%s_Axiom", sort.name())));
@@ -564,9 +561,9 @@ public class TacletPBuilder extends ExpressionBuilder {
             for (int i = 0; i < args.length; i++) {
                 args[i] = variables.get(context.argName.get(i).getText());
             }
-            Sequent addedSeq = JavaDLSequentKit.createAnteSequent(ImmutableSLList
+            Sequent addedSeq = JavaDLSequentKit.createAnteSequent(ImmutableList
                     .singleton(new SequentFormula(tb.equals(tb.var(phi), tb.func(func, args)))));
-            TacletGoalTemplate goal = new TacletGoalTemplate(addedSeq, ImmutableSLList.nil());
+            TacletGoalTemplate goal = new TacletGoalTemplate(addedSeq, ImmutableList.nil());
             goal.setName("#var = " + context.name.getText());
             b.addTacletGoalTemplate(goal);
         }
@@ -799,7 +796,7 @@ public class TacletPBuilder extends ExpressionBuilder {
         String name = accept(ctx.string_value());
 
         Sequent addSeq = JavaDLSequentKit.getInstance().getEmptySequent();
-        ImmutableSLList<Taclet> addRList = ImmutableSLList.nil();
+        ImmutableList<Taclet> addRList = ImmutableList.nil();
         DefaultImmutableSet<SchemaVariable> addpv = DefaultImmutableSet.nil();
 
         Object rwObj = accept(ctx.replacewith());

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/HideSequentPrintFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/HideSequentPrintFilter.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 import de.uka.ilkd.key.pp.IdentitySequentPrintFilter.IdentityFilterEntry;
 
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 /**
  * This filter takes a search string and yields a sequent containing only sequent formulas that
@@ -50,7 +50,7 @@ public class HideSequentPrintFilter extends SearchSequentPrintFilter {
             return;
         }
 
-        antec = ImmutableSLList.nil();
+        antec = ImmutableList.nil();
         it = originalSequent.antecedent().iterator();
         while (it.hasNext()) {
             SequentFormula sf = it.next();
@@ -63,7 +63,7 @@ public class HideSequentPrintFilter extends SearchSequentPrintFilter {
             }
         }
 
-        succ = ImmutableSLList.nil();
+        succ = ImmutableList.nil();
         it = originalSequent.succedent().iterator();
         while (it.hasNext()) {
             SequentFormula sf = it.next();

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/InitialPositionTable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/InitialPositionTable.java
@@ -7,7 +7,6 @@ import org.key_project.logic.IntIterator;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * An InitialPositionTable is a PositionTable that describes the beginning of the element/subelement
@@ -22,12 +21,12 @@ import org.key_project.util.collection.ImmutableSLList;
  */
 public class InitialPositionTable extends PositionTable {
 
-    private ImmutableList<Range> updateRanges = ImmutableSLList.nil();
+    private ImmutableList<Range> updateRanges = ImmutableList.nil();
 
     /** Ranges of keywords */
-    private ImmutableList<Range> keywordRanges = ImmutableSLList.nil();
+    private ImmutableList<Range> keywordRanges = ImmutableList.nil();
     /** Ranges of java blocks */
-    private ImmutableList<Range> javaBlockRanges = ImmutableSLList.nil();
+    private ImmutableList<Range> javaBlockRanges = ImmutableList.nil();
 
     /**
      * creates a new Initial PositionTable.
@@ -88,7 +87,7 @@ public class InitialPositionTable extends PositionTable {
      */
     public ImmutableList<Integer> pathForPosition(PosInOccurrence pio,
             SequentPrintFilter filter) {
-        ImmutableList<Integer> p = ImmutableSLList.nil();
+        ImmutableList<Integer> p = ImmutableList.nil();
         p = prependPathInFormula(p, pio);
         int index = indexOfCfma(pio.sequentFormula(), filter);
         if (index == -1) {

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/PositionTable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/PositionTable.java
@@ -7,7 +7,6 @@ import org.key_project.logic.PosInTerm;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * A PositionTable describes the start and end positions of substrings of a String in order to get a
@@ -88,7 +87,7 @@ public class PositionTable {
     protected ImmutableList<Integer> pathForIndex(int index) {
         int sub = searchEntry(index);
         if (sub == -1) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         } else {
             return children[sub].pathForIndex(index - startPos[sub]).prepend(sub);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/RegroupSequentPrintFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/RegroupSequentPrintFilter.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 import de.uka.ilkd.key.pp.IdentitySequentPrintFilter.IdentityFilterEntry;
 
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 /**
  * @author jschiffl This filter takes a search string and regroups the sequent so that the sequent
@@ -45,7 +45,7 @@ public class RegroupSequentPrintFilter extends SearchSequentPrintFilter {
             return;
         }
 
-        antec = ImmutableSLList.nil();
+        antec = ImmutableList.nil();
         it = originalSequent.antecedent().iterator();
         while (it.hasNext()) {
             SequentFormula sf = it.next();
@@ -60,7 +60,7 @@ public class RegroupSequentPrintFilter extends SearchSequentPrintFilter {
             }
         }
 
-        succ = ImmutableSLList.nil();
+        succ = ImmutableList.nil();
         it = originalSequent.succedent().iterator();
         while (it.hasNext()) {
             SequentFormula sf = it.next();

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/SequentPrintFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/SequentPrintFilter.java
@@ -10,7 +10,6 @@ import de.uka.ilkd.key.pp.IdentitySequentPrintFilter.IdentityFilterEntry;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -26,12 +25,12 @@ public abstract class SequentPrintFilter {
     /**
      * the antecedent of the filtered formula
      */
-    ImmutableList<SequentPrintFilterEntry> antec = ImmutableSLList.nil();
+    ImmutableList<SequentPrintFilterEntry> antec = ImmutableList.nil();
 
     /**
      * the antecedent of the filtered formula
      */
-    ImmutableList<SequentPrintFilterEntry> succ = ImmutableSLList.nil();
+    ImmutableList<SequentPrintFilterEntry> succ = ImmutableList.nil();
 
     /**
      * @return the original sequent
@@ -82,13 +81,13 @@ public abstract class SequentPrintFilter {
      * entries.
      */
     protected void filterIdentity() {
-        antec = ImmutableSLList.nil();
+        antec = ImmutableList.nil();
         Iterator<SequentFormula> it = originalSequent.antecedent().iterator();
         while (it.hasNext()) {
             antec = antec.append(new IdentityFilterEntry(it.next()));
         }
 
-        succ = ImmutableSLList.nil();
+        succ = ImmutableList.nil();
         it = originalSequent.succedent().iterator();
         while (it.hasNext()) {
             succ = succ.append(new IdentityFilterEntry(it.next()));

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/ShowSelectedSequentPrintFilter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/ShowSelectedSequentPrintFilter.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.pp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This filter takes a {@link PosInOccurrence} and only shows the sub-formula at that position.
@@ -35,18 +34,18 @@ public class ShowSelectedSequentPrintFilter extends SequentPrintFilter {
     @Override
     public ImmutableList<SequentPrintFilterEntry> getFilteredAntec() {
         if (pos.isInAntec()) {
-            return ImmutableSLList.<SequentPrintFilterEntry>nil().append(new Entry(pos));
+            return ImmutableList.<SequentPrintFilterEntry>nil().append(new Entry(pos));
         } else {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
     }
 
     @Override
     public ImmutableList<SequentPrintFilterEntry> getFilteredSucc() {
         if (!pos.isInAntec()) {
-            return ImmutableSLList.<SequentPrintFilterEntry>nil().append(new Entry(pos));
+            return ImmutableList.<SequentPrintFilterEntry>nil().append(new Entry(pos));
         } else {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BranchLocation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BranchLocation.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 /**
@@ -20,7 +19,7 @@ public class BranchLocation {
     /**
      * Branch location of the initial proof branch.
      */
-    public static final BranchLocation ROOT = new BranchLocation(ImmutableSLList.nil());
+    public static final BranchLocation ROOT = new BranchLocation(ImmutableList.nil());
 
     /**
      * List of branch choices (branching nodes and sub-proof indices).

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleAppIndex.java
@@ -10,7 +10,6 @@ import org.key_project.logic.PosInTerm;
 import org.key_project.prover.sequent.*;
 import org.key_project.prover.strategy.NewRuleListener;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public class BuiltInRuleAppIndex {
 
@@ -34,7 +33,7 @@ public class BuiltInRuleAppIndex {
      */
     public ImmutableList<IBuiltInRuleApp> getBuiltInRule(Goal goal, PosInOccurrence pos) {
 
-        ImmutableList<IBuiltInRuleApp> result = ImmutableSLList.nil();
+        ImmutableList<IBuiltInRuleApp> result = ImmutableList.nil();
 
         ImmutableList<BuiltInRule> rules = index.rules();
         while (!rules.isEmpty()) {
@@ -98,7 +97,7 @@ public class BuiltInRuleAppIndex {
     private void scanSimplificationRule(ImmutableList<BuiltInRule> rules, Goal goal, boolean antec,
             SequentFormula cfma, NewRuleListener listener) {
         final PosInOccurrence pos = new PosInOccurrence(cfma, PosInTerm.getTopLevel(), antec);
-        ImmutableList<BuiltInRule> subrules = ImmutableSLList.nil();
+        ImmutableList<BuiltInRule> subrules = ImmutableList.nil();
         while (!rules.isEmpty()) {
             final BuiltInRule rule = rules.head();
             rules = rules.tail();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/BuiltInRuleIndex.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import de.uka.ilkd.key.rule.BuiltInRule;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Index for managing built-in rules such as integer decision or update simplification rule.
@@ -20,7 +19,7 @@ public class BuiltInRuleIndex implements Serializable {
      */
     private static final long serialVersionUID = -4399004272449882750L;
     /** list of available built-in rules */
-    private ImmutableList<BuiltInRule> rules = ImmutableSLList.nil();
+    private ImmutableList<BuiltInRule> rules = ImmutableList.nil();
 
     /** constructs empty rule index */
     public BuiltInRuleIndex() {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -42,7 +42,6 @@ import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.prover.strategy.DelegationBasedRuleApplicationManager;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -80,7 +79,7 @@ public final class Goal implements ProofGoal<Goal> {
      * list of all applied rule applications at this branch
      */
     private ImmutableList<RuleApp> appliedRuleApps =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
     /**
      * this object manages the tags for all formulas of the sequent
      */
@@ -134,7 +133,7 @@ public final class Goal implements ProofGoal<Goal> {
             Services services) {
         this.node = node;
         this.ruleAppIndex = new RuleAppIndex(tacletIndex, builtInRuleAppIndex, this, services);
-        this.appliedRuleApps = ImmutableSLList.nil();
+        this.appliedRuleApps = ImmutableList.nil();
         this.goalStrategy = null;
         this.strategyInfos = new MapProperties();
         this.tagManager = new FormulaTagManager(this);
@@ -553,7 +552,7 @@ public final class Goal implements ProofGoal<Goal> {
      * @return the list of new created goals.
      */
     public ImmutableList<Goal> split(int n) {
-        ImmutableList<Goal> goalList = ImmutableSLList.nil();
+        ImmutableList<Goal> goalList = ImmutableList.nil();
 
         final Node parent = node; // has to be stored because the node
         // of this goal will be replaced

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/InstantiationProposerCollection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/InstantiationProposerCollection.java
@@ -8,7 +8,6 @@ import de.uka.ilkd.key.rule.TacletApp;
 
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -17,7 +16,7 @@ import org.key_project.util.collection.ImmutableSLList;
 public class InstantiationProposerCollection implements InstantiationProposer {
 
     private ImmutableList<InstantiationProposer> proposers =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
 
     /**
      * adds an instantiation proposer to the collection

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/MultiThreadedTacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/MultiThreadedTacletIndex.java
@@ -17,7 +17,6 @@ import org.key_project.logic.LogicServices;
 import org.key_project.prover.proof.rulefilter.RuleFilter;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -75,7 +74,7 @@ final class MultiThreadedTacletIndex extends TacletIndex {
     protected ImmutableList<NoPosTacletApp> matchTaclets(
             @NonNull ImmutableList<NoPosTacletApp> tacletApps,
             RuleFilter p_filter, PosInOccurrence pos, LogicServices services) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
 
         if (tacletApps.size() > 256) {
             NoPosTacletApp[] toMatch = tacletApps.toArray(NoPosTacletApp.class);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/NameRecorder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/NameRecorder.java
@@ -5,17 +5,16 @@ package de.uka.ilkd.key.proof;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public class NameRecorder {
 
-    private ImmutableList<Name> pre = ImmutableSLList.nil();
+    private ImmutableList<Name> pre = ImmutableList.nil();
 
-    private ImmutableList<Name> post = ImmutableSLList.nil();
+    private ImmutableList<Name> post = ImmutableList.nil();
 
     public void setProposals(ImmutableList<Name> proposals) {
         if (proposals == null) {
-            pre = ImmutableSLList.nil();
+            pre = ImmutableList.nil();
         } else {
             pre = proposals;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
@@ -27,7 +27,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.lookup.Lookup;
@@ -73,13 +72,13 @@ public class Node implements Iterable<Node> {
      * a linked list of the locally generated program variables. It extends the list of the parent
      * node.
      */
-    private ImmutableList<IProgramVariable> localProgVars = ImmutableSLList.nil();
+    private ImmutableList<IProgramVariable> localProgVars = ImmutableList.nil();
 
     /**
      * a linked list of the locally generated function symbols. It extends the list of the parent
      * node.
      */
-    private ImmutableList<Function> localFunctions = ImmutableSLList.nil();
+    private ImmutableList<Function> localFunctions = ImmutableList.nil();
 
     private boolean closed = false;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/OpReplacer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/OpReplacer.java
@@ -16,7 +16,6 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import static de.uka.ilkd.key.logic.equality.TermLabelsProperty.TERM_LABELS_PROPERTY;
@@ -275,7 +274,7 @@ public class OpReplacer {
      * @return the list of transformed terms.
      */
     public ImmutableList<JTerm> replace(ImmutableList<JTerm> terms) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (final JTerm term : terms) {
             result = result.append(replace(term));
         }
@@ -289,7 +288,7 @@ public class OpReplacer {
      * @return the list of transformed terms.
      */
     public ImmutableList<InfFlowSpec> replaceInfFlowSpec(ImmutableList<InfFlowSpec> terms) {
-        ImmutableList<InfFlowSpec> result = ImmutableSLList.nil();
+        ImmutableList<InfFlowSpec> result = ImmutableList.nil();
         if (terms == null) {
             return result;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -39,7 +39,6 @@ import org.key_project.prover.proof.ProofObject;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.lookup.Lookup;
 
 import org.jspecify.annotations.NullMarked;
@@ -82,14 +81,14 @@ public class Proof implements ProofObject<Goal>, Named {
     /**
      * list with the open goals of the proof
      */
-    private ImmutableList<Goal> openGoals = ImmutableSLList.nil();
+    private ImmutableList<Goal> openGoals = ImmutableList.nil();
 
     /**
      * list with the closed goals of the proof, needed to make pruning in closed branches possible.
      * If the list needs too much memory, pruning can be disabled via the command line option
      * "--no-pruning-closed". In this case the list will not be filled.
      */
-    private ImmutableList<Goal> closedGoals = ImmutableSLList.nil();
+    private ImmutableList<Goal> closedGoals = ImmutableList.nil();
 
     /**
      * declarations &c, read from a problem file or otherwise
@@ -250,7 +249,7 @@ public class Proof implements ProofObject<Goal>, Named {
             InitConfig initConfig) {
         this(name,
             JavaDLSequentKit
-                    .createSuccSequent(ImmutableSLList.singleton(new SequentFormula(problem))),
+                    .createSuccSequent(ImmutableList.singleton(new SequentFormula(problem))),
             initConfig.createTacletIndex(), initConfig.createBuiltInRuleIndex(), initConfig);
         problemHeader = header;
     }
@@ -516,7 +515,7 @@ public class Proof implements ProofObject<Goal>, Named {
      * @see Goal#isAutomatic()
      */
     private ImmutableList<Goal> filterEnabledGoals(ImmutableList<Goal> goals) {
-        ImmutableList<Goal> enabledGoals = ImmutableSLList.nil();
+        ImmutableList<Goal> enabledGoals = ImmutableList.nil();
         for (Goal g : goals) {
             if (g.isAutomatic() && !g.isLinked()) {
                 enabledGoals = enabledGoals.prepend(g);
@@ -574,7 +573,7 @@ public class Proof implements ProofObject<Goal>, Named {
         if (b) {
             // For the moment it is necessary to fire the message ALWAYS
             // in order to detect branch closing.
-            fireProofGoalsAdded(ImmutableSLList.nil());
+            fireProofGoalsAdded(ImmutableList.nil());
         }
     }
 
@@ -687,7 +686,7 @@ public class Proof implements ProofObject<Goal>, Named {
     }
 
     void removeOpenGoals(Collection<Node> toBeRemoved) {
-        ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
+        ImmutableList<Goal> newGoalList = ImmutableList.nil();
         for (Goal openGoal : openGoals()) {
             if (!toBeRemoved.contains(openGoal.node())) {
                 newGoalList = newGoalList.append(openGoal);
@@ -704,7 +703,7 @@ public class Proof implements ProofObject<Goal>, Named {
      * @param toBeRemoved the goals to remove
      */
     void removeClosedGoals(Collection<Node> toBeRemoved) {
-        ImmutableList<Goal> newGoalList = ImmutableSLList.nil();
+        ImmutableList<Goal> newGoalList = ImmutableList.nil();
         for (Goal closedGoal : closedGoals) {
             if (!toBeRemoved.contains(closedGoal.node())) {
                 newGoalList = newGoalList.prepend(closedGoal);
@@ -888,7 +887,7 @@ public class Proof implements ProofObject<Goal>, Named {
      * fires the event that new goals have been added to the list of goals
      */
     protected void fireProofGoalsAdded(Goal goal) {
-        fireProofGoalsAdded(ImmutableSLList.<Goal>nil().prepend(goal));
+        fireProofGoalsAdded(ImmutableList.<Goal>nil().prepend(goal));
     }
 
 
@@ -1046,7 +1045,7 @@ public class Proof implements ProofObject<Goal>, Named {
      * @return the goals below node that are contained in <code>fromGoals</code>
      */
     private static ImmutableList<Goal> getGoalsBelow(Node node, ImmutableList<Goal> fromGoals) {
-        ImmutableList<Goal> result = ImmutableSLList.nil();
+        ImmutableList<Goal> result = ImmutableList.nil();
         List<Node> leaves = node.getLeaves();
         for (final Goal goal : fromGoals) {
             // if list contains node, remove it to make the list faster later

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.rule.merge.MergeRuleBuiltInRuleApp;
 import de.uka.ilkd.key.settings.GeneralSettings;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This class is responsible for pruning a proof tree at a certain cutting point. It has been
@@ -168,7 +167,7 @@ class ProofPruner {
     }
 
     private ImmutableList<Node> cut(Node node) {
-        ImmutableList<Node> children = ImmutableSLList.nil();
+        ImmutableList<Node> children = ImmutableList.nil();
         Iterator<Node> it = node.childrenIterator();
 
         while (it.hasNext()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofTreeEvent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofTreeEvent.java
@@ -4,7 +4,6 @@
 package de.uka.ilkd.key.proof;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Encapsulates information describing changes to a proof tree, and used to notify proof tree
@@ -16,7 +15,7 @@ public class ProofTreeEvent {
     private final Proof source;
     private Node node;
     private Goal goal;
-    private ImmutableList<Goal> goals = ImmutableSLList.nil();
+    private ImmutableList<Goal> goals = ImmutableList.nil();
 
     /**
      * Create ProofTreeEvent for an event that happens at the specified node.

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/RuleAppIndex.java
@@ -16,7 +16,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.strategy.NewRuleListener;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -146,7 +145,7 @@ public final class RuleAppIndex {
     public ImmutableList<TacletApp> getTacletAppAt(TacletFilter filter,
             PosInOccurrence pos,
             Services services) {
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
         if (!autoMode) {
             result =
                 result.prepend(interactiveTacletAppIndex.getTacletAppAt(pos, filter, services));
@@ -169,7 +168,7 @@ public final class RuleAppIndex {
     public ImmutableList<TacletApp> getTacletAppAtAndBelow(TacletFilter filter,
             PosInOccurrence pos,
             Services services) {
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
         if (!autoMode) {
             result = result.prepend(
                 interactiveTacletAppIndex.getTacletAppAtAndBelow(pos, filter, services));
@@ -189,7 +188,7 @@ public final class RuleAppIndex {
      */
     public ImmutableList<NoPosTacletApp> getFindTaclet(TacletFilter filter,
             PosInOccurrence pos) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
         if (!autoMode) {
             result = result.prepend(interactiveTacletAppIndex.getFindTaclet(pos, filter));
         }
@@ -206,7 +205,7 @@ public final class RuleAppIndex {
      * @return list of all possible instantiations
      */
     public ImmutableList<NoPosTacletApp> getNoFindTaclet(TacletFilter filter, Services services) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
         if (!autoMode) {
             result = interactiveTacletAppIndex.getNoFindTaclet(filter, services);
         }
@@ -225,7 +224,7 @@ public final class RuleAppIndex {
      */
     public ImmutableList<NoPosTacletApp> getRewriteTaclet(TacletFilter filter,
             PosInOccurrence pos) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
         if (!autoMode) {
             result =
                 result.prepend(interactiveTacletAppIndex.getRewriteTaclet(pos, filter));

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SingleThreadedTacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SingleThreadedTacletIndex.java
@@ -13,7 +13,6 @@ import org.key_project.logic.LogicServices;
 import org.key_project.prover.proof.rulefilter.RuleFilter;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -67,7 +66,7 @@ final class SingleThreadedTacletIndex extends TacletIndex {
     protected ImmutableList<NoPosTacletApp> matchTaclets(
             @NonNull ImmutableList<NoPosTacletApp> tacletApps,
             RuleFilter p_filter, PosInOccurrence pos, LogicServices services) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
 
         for (final NoPosTacletApp tacletApp : tacletApps) {
             if (!p_filter.filter(tacletApp.taclet())) {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
@@ -21,7 +21,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.strategy.NewRuleListener;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -208,7 +207,7 @@ public class TacletAppIndex {
      */
     static ImmutableList<TacletApp> createTacletApps(ImmutableList<NoPosTacletApp> tacletInsts,
             PosInOccurrence pos, Services services) {
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
         for (NoPosTacletApp tacletApp : tacletInsts) {
             if (tacletApp.taclet() instanceof FindTaclet) {
                 PosTacletApp newTacletApp = tacletApp.setPosInOccurrence(pos, services);
@@ -257,7 +256,7 @@ public class TacletAppIndex {
 
         final Iterator<NoPosTacletApp> it = getFindTaclet(pos, filter).iterator();
 
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
 
         while (it.hasNext()) {
             final NoPosTacletApp tacletApp = it.next();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletIndex.java
@@ -63,7 +63,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
     /**
      * contains NoFind-Taclets
      */
-    protected ImmutableList<NoPosTacletApp> noFindList = ImmutableSLList.nil();
+    protected ImmutableList<NoPosTacletApp> noFindList = ImmutableList.nil();
 
     /**
      * keeps track of no pos taclet apps with partial instantiations
@@ -84,7 +84,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
         rwList = new LinkedHashMap<>();
         antecList = new LinkedHashMap<>();
         succList = new LinkedHashMap<>();
-        noFindList = ImmutableSLList.nil();
+        noFindList = ImmutableList.nil();
         addTaclets(toNoPosTacletApp(tacletSet));
     }
 
@@ -145,7 +145,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
         Object indexObj = getIndexObj((FindTaclet) tacletApp.taclet());
         ImmutableList<NoPosTacletApp> opList = map.get(indexObj);
         opList = Objects.requireNonNullElseGet(opList,
-            ImmutableSLList::<NoPosTacletApp>nil).prepend(tacletApp);
+            ImmutableList::<NoPosTacletApp>nil).prepend(tacletApp);
         map.put(indexObj, opList);
     }
 
@@ -175,7 +175,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
     }
 
     public static ImmutableSet<NoPosTacletApp> toNoPosTacletApp(Iterable<Taclet> rule) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
         for (Taclet t : rule) {
             result = result.prepend(NoPosTacletApp.createNoPosTacletApp(t));
         }
@@ -307,7 +307,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
     private ImmutableList<NoPosTacletApp> getJavaTacletList(
             HashMap<Object, ImmutableList<NoPosTacletApp>> map, ProgramElement pe,
             PrefixOccurrences prefixOccurrences) {
-        ImmutableList<NoPosTacletApp> res = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> res = ImmutableList.nil();
         if (pe instanceof ProgramPrefix nt) {
             int next = prefixOccurrences.occurred(pe);
             if (next < nt.getChildCount()) {
@@ -327,7 +327,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
             final HashMap<Object, ImmutableList<NoPosTacletApp>> map, final JTerm term,
             final boolean ignoreUpdates, final PrefixOccurrences prefixOccurrences) {
 
-        ImmutableList<NoPosTacletApp> res = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> res = ImmutableList.nil();
         final Operator op = term.op();
 
         assert !(op instanceof Metavariable)
@@ -627,7 +627,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
          */
         public ImmutableList<NoPosTacletApp> getList(
                 HashMap<Object, ImmutableList<NoPosTacletApp>> map) {
-            ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+            ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
             for (int i = 0; i < PREFIXTYPES; i++) {
                 if (occurred[i]) {
                     ImmutableList<NoPosTacletApp> inMap = map.get(prefixClasses[i]);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TermTacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TermTacletAppIndex.java
@@ -78,7 +78,7 @@ public class TermTacletAppIndex {
     private static ImmutableList<NoPosTacletApp> getFindTaclet(
             PosInOccurrence pos,
             RuleFilter filter, Services services, TacletIndex tacletIndex) {
-        ImmutableList<NoPosTacletApp> tacletInsts = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> tacletInsts = ImmutableList.nil();
         if (pos.isTopLevel()) {
             if (pos.isInAntec()) {
                 tacletInsts = tacletInsts.prepend(antecTaclet(pos, filter, services, tacletIndex));
@@ -503,10 +503,10 @@ public class TermTacletAppIndex {
             PosInOccurrence pos, RuleFilter p_filter,
             Services services) {
 
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
 
         final ImmutableList<Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>>> allTacletsHereAndBelow =
-            collectAllTacletAppsHereAndBelow(pos, ImmutableSLList.nil());
+            collectAllTacletAppsHereAndBelow(pos, ImmutableList.nil());
 
         for (final Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>> pair : allTacletsHereAndBelow) {
             result = convert(pair.second, pair.first, p_filter, result, services);
@@ -526,7 +526,7 @@ public class TermTacletAppIndex {
             NewRuleListener listener) {
 
         final ImmutableList<Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>>> result =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         final ImmutableList<Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>>> allTacletsHereAndBelow =
             collectAllTacletAppsHereAndBelow(pos, result);
 
@@ -568,7 +568,7 @@ public class TermTacletAppIndex {
      */
     private void reportTacletApps(PIOPathIterator pathToModification, NewRuleListener listener) {
         final ImmutableList<Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>>> allTacletsHereAndBelow =
-            collectAllTacletAppsAffectedByModification(pathToModification, ImmutableSLList.nil());
+            collectAllTacletAppsAffectedByModification(pathToModification, ImmutableList.nil());
 
         for (final Pair<PosInOccurrence, ImmutableList<NoPosTacletApp>> pair : allTacletsHereAndBelow) {
             fireRulesAdded(listener, pair.second, pair.first);
@@ -633,7 +633,7 @@ public class TermTacletAppIndex {
      */
     public static ImmutableList<NoPosTacletApp> filter(RuleFilter p_filter,
             ImmutableList<NoPosTacletApp> taclets) {
-        ImmutableList<NoPosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
 
         for (final NoPosTacletApp app : taclets) {
             if (p_filter.filter(app.taclet())) {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TermTacletAppIndexCacheSet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TermTacletAppIndexCacheSet.java
@@ -17,7 +17,6 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.prover.rules.Taclet;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Cache that is used for accelerating <code>TermTacletAppIndex</code>. Basically, this is a mapping
@@ -91,7 +90,7 @@ public class TermTacletAppIndexCacheSet {
      * cache for locations that are below updates, but not below programs or in the scope of binders
      */
     private final ITermTacletAppIndexCache belowUpdateCacheEmptyPrefix =
-        new BelowUpdateCache(ImmutableSLList.nil());
+        new BelowUpdateCache(ImmutableList.nil());
 
     /**
      * cache for locations that are below programs, but not in the scope of binders
@@ -111,12 +110,12 @@ public class TermTacletAppIndexCacheSet {
     public TermTacletAppIndexCacheSet(Map<CacheKey, TermTacletAppIndex> cache) {
         assert cache != null;
         this.cache = cache;
-        antecCache = new TopLevelCache(ImmutableSLList.nil(), cache);
-        succCache = new TopLevelCache(ImmutableSLList.nil(), cache);
+        antecCache = new TopLevelCache(ImmutableList.nil(), cache);
+        succCache = new TopLevelCache(ImmutableList.nil(), cache);
         topLevelCacheEmptyPrefix =
-            new TopLevelCache(ImmutableSLList.nil(), cache);
+            new TopLevelCache(ImmutableList.nil(), cache);
         belowProgCacheEmptyPrefix =
-            new BelowProgCache(ImmutableSLList.nil(), cache);
+            new BelowProgCache(ImmutableList.nil(), cache);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/calculus/Semisequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/calculus/Semisequent.java
@@ -8,7 +8,6 @@ import de.uka.ilkd.key.logic.equality.RenamingTermProperty;
 import org.key_project.prover.sequent.SemisequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 class Semisequent extends org.key_project.prover.sequent.Semisequent {
 
@@ -63,7 +62,7 @@ class Semisequent extends org.key_project.prover.sequent.Semisequent {
         @Override
         public SemisequentChangeInfo insertFirst(SequentFormula sequentFormula) {
             final SemisequentChangeInfo sci = new SemisequentChangeInfo(
-                ImmutableSLList.singleton(sequentFormula));
+                ImmutableList.singleton(sequentFormula));
             sci.addedFormula(0, sequentFormula);
             return sci;
         }
@@ -117,7 +116,7 @@ class Semisequent extends org.key_project.prover.sequent.Semisequent {
          */
         @Override
         public SemisequentChangeInfo remove(int idx) {
-            return new SemisequentChangeInfo(ImmutableSLList.nil());
+            return new SemisequentChangeInfo(ImmutableList.nil());
         }
 
         /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/calculus/Sequent.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/calculus/Sequent.java
@@ -8,7 +8,6 @@ import java.util.Iterator;
 import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -42,7 +41,7 @@ class Sequent extends org.key_project.prover.sequent.Sequent {
 
             @Override
             public @NonNull Iterator<SequentFormula> iterator() {
-                return ImmutableSLList.<SequentFormula>nil().iterator();
+                return ImmutableList.<SequentFormula>nil().iterator();
             }
         };
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/delayedcut/DelayedCutProcessor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/delayedcut/DelayedCutProcessor.java
@@ -24,7 +24,6 @@ import org.key_project.prover.rules.Taclet;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * <p>
@@ -434,7 +433,7 @@ public class DelayedCutProcessor implements Runnable {
      * This function uncovers the decision predicate that is hidden after applying the cut rule.
      */
     private void uncoverDecisionPredicate(DelayedCut cut, List<NodeGoalPair> openLeaves) {
-        ImmutableList<NodeGoalPair> list = ImmutableSLList.nil();
+        ImmutableList<NodeGoalPair> list = ImmutableList.nil();
         for (NodeGoalPair pair : openLeaves) {
             list =
                 list.append(new NodeGoalPair(pair.node, pair.goal.apply(cut.getHideApp()).head()));

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractOperationPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractOperationPO.java
@@ -36,7 +36,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import com.github.javaparser.ast.key.KeyTransactionStatement;
@@ -779,7 +778,7 @@ public abstract class AbstractOperationPO extends AbstractPO {
             JTerm exceptionVar, String name, Services services) {
         // Create parameters for predicate
         // SETAccumulate(HeapSort, MethodParameter1Sort, ... MethodParameterNSort)
-        ImmutableList<JTerm> arguments = ImmutableSLList.nil(); // tb.var(paramVars);
+        ImmutableList<JTerm> arguments = ImmutableList.nil(); // tb.var(paramVars);
         // Method parameters
         for (LocationVariable formalParam : formalParamVars) {
             arguments = arguments.prepend(tb.var(formalParam));
@@ -1005,7 +1004,7 @@ public abstract class AbstractOperationPO extends AbstractPO {
     private ImmutableList<LocationVariable> createFormalParamVars(
             final ImmutableList<LocationVariable> paramVars, final Services proofServices) {
         // create arguments from formal parameters for method call
-        ImmutableList<LocationVariable> formalParamVars = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> formalParamVars = ImmutableList.nil();
         for (final LocationVariable paramVar : paramVars) {
             if (isCopyOfMethodArgumentsUsed()) {
                 ProgramElementName pen = new ProgramElementName("_" + paramVar.name());
@@ -1023,7 +1022,7 @@ public abstract class AbstractOperationPO extends AbstractPO {
     private ImmutableList<FunctionalOperationContract> collectLookupContracts(
             final IProgramMethod pm, final Services proofServices) {
         ImmutableList<FunctionalOperationContract> lookupContracts =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         ImmutableSet<FunctionalOperationContract> cs = proofServices.getSpecificationRepository()
                 .getOperationContracts(getCalleeKeYJavaType(), pm);
         for (KeYJavaType superType : proofServices.getJavaInfo()

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractPO.java
@@ -28,7 +28,6 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -300,7 +299,7 @@ public abstract class AbstractPO implements IPersistablePO {
             ImmutableList<Pair<Sort, IObserverFunction>> scc = allSCCs.get(node);
             for (Taclet axiomTaclet : axiom.getTaclets(
                 DefaultImmutableSet.fromImmutableList(
-                    scc == null ? ImmutableSLList.nil() : scc),
+                    scc == null ? ImmutableList.nil() : scc),
                 proofConfig.getServices())) {
                 assert axiomTaclet != null : "class axiom returned null taclet: " + axiom.getName();
                 // only include if choices are appropriate
@@ -353,7 +352,7 @@ public abstract class AbstractPO implements IPersistablePO {
 
         if (node.index == node.lowLink) {
             ImmutableList<Pair<Sort, IObserverFunction>> scc =
-                ImmutableSLList.nil();
+                ImmutableList.nil();
             Vertex sccMember;
             do {
                 sccMember = stack.pop();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractProfile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/AbstractProfile.java
@@ -22,7 +22,6 @@ import org.key_project.logic.Name;
 import org.key_project.prover.engine.GoalChooserFactory;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -98,7 +97,7 @@ public abstract class AbstractProfile implements Profile {
     }
 
     protected ImmutableList<BuiltInRule> initBuiltInRules() {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalOperationContractPO.java
@@ -32,7 +32,6 @@ import de.uka.ilkd.key.speclang.FunctionalOperationContract;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -166,7 +165,7 @@ public class FunctionalOperationContractPO extends AbstractOperationPO implement
             result[1] = new StatementBlock(call);
         }
         assert result[1] != null : "null body in method";
-        return ImmutableSLList.<StatementBlock>nil().prepend(result);
+        return ImmutableList.<StatementBlock>nil().prepend(result);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/InitConfig.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/InitConfig.java
@@ -32,7 +32,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -53,7 +52,7 @@ public class InitConfig {
     private RuleJustificationInfo justifInfo = new RuleJustificationInfo();
 
     /// List of all known taclets.
-    private ImmutableList<Taclet> taclets = ImmutableSLList.nil();
+    private ImmutableList<Taclet> taclets = ImmutableList.nil();
 
     /**
      * Map of categories to their default choice. The choices are overridden in activateChoice
@@ -293,7 +292,7 @@ public class InitConfig {
      */
     public ImmutableList<BuiltInRule> builtInRules() {
         Profile profile = getProfile();
-        return (profile == null ? ImmutableSLList.nil()
+        return (profile == null ? ImmutableList.nil()
                 : profile.getStandardRules().standardBuiltInRules());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/JavaProfile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/JavaProfile.java
@@ -25,7 +25,6 @@ import de.uka.ilkd.key.strategy.StrategyFactory;
 
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -97,11 +96,11 @@ public class JavaProfile extends AbstractProfile {
     @Override
     protected ImmutableList<TermLabelConfiguration> computeTermLabelConfiguration() {
         ImmutableList<TermLabelPolicy> originTermLabelPolicyList =
-            ImmutableSLList.<TermLabelPolicy>nil().append(new OriginTermLabelPolicy());
+            ImmutableList.<TermLabelPolicy>nil().append(new OriginTermLabelPolicy());
         ImmutableList<TermLabelRefactoring> originTermLabelRefactorings =
-            ImmutableSLList.<TermLabelRefactoring>nil().append(new OriginTermLabelRefactoring());
+            ImmutableList.<TermLabelRefactoring>nil().append(new OriginTermLabelRefactoring());
 
-        ImmutableList<TermLabelConfiguration> result = ImmutableSLList.nil();
+        ImmutableList<TermLabelConfiguration> result = ImmutableList.nil();
         result =
             result.prepend(new TermLabelConfiguration(ParameterlessTermLabel.ANON_HEAP_LABEL_NAME,
                 new SingletonLabelFactory<>(ParameterlessTermLabel.ANON_HEAP_LABEL)));

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProofInitServiceUtil.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/ProofInitServiceUtil.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.ServiceConfigurationError;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.reflection.ClassLoaderUtil;
 
 /**
@@ -48,7 +47,7 @@ public final class ProofInitServiceUtil {
      * @return The available {@link POExtension}s.
      */
     public static ImmutableList<POExtension> getOperationPOExtension(ProofOblInput po) {
-        ImmutableList<POExtension> result = ImmutableSLList.nil();
+        ImmutableList<POExtension> result = ImmutableList.nil();
         for (POExtension extension : poExtensions) {
             if (extension.isPOSupported(po)) {
                 result = result.prepend(extension);
@@ -63,7 +62,7 @@ public final class ProofInitServiceUtil {
      * @return The available {@link POExtension}s.
      */
     private static ImmutableList<POExtension> createOperationPOExtension() {
-        ImmutableList<POExtension> extensions = ImmutableSLList.nil();
+        ImmutableList<POExtension> extensions = ImmutableList.nil();
         Iterator<POExtension> iter = ClassLoaderUtil.loadServices(POExtension.class).iterator();
         while (iter.hasNext()) {
             try {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
@@ -16,7 +16,6 @@ import de.uka.ilkd.key.settings.ProofSettings;
 import org.key_project.logic.Name;
 import org.key_project.logic.PosInTerm;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 /**
@@ -173,14 +172,14 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
             case ASSUMES_INST_BUILT_IN -> { // ifInst (for built in rules)
                 BuiltinRuleInformation builtinInfo = (BuiltinRuleInformation) ruleInfo;
                 if (builtinInfo.builtinIfInsts == null) {
-                    builtinInfo.builtinIfInsts = ImmutableSLList.nil();
+                    builtinInfo.builtinIfInsts = ImmutableList.nil();
                 }
                 builtinInfo.currIfInstFormula = 0;
                 builtinInfo.currIfInstPosInTerm = PosInTerm.getTopLevel();
             }
             case NEW_NAMES -> {
                 final String[] newNames = str.split(",");
-                ruleInfo.currNewNames = ImmutableSLList.nil();
+                ruleInfo.currNewNames = ImmutableList.nil();
                 for (String newName : newNames) {
                     ruleInfo.currNewNames = ruleInfo.currNewNames.append(new Name(newName));
                 }
@@ -373,8 +372,8 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
     private static class TacletInformation extends RuleInformation {
         /* + Taclet Information */
         protected List<String> loadedInsts = null;
-        protected ImmutableList<String> ifSeqFormulaList = ImmutableSLList.nil();
-        protected ImmutableList<String> ifDirectFormulaList = ImmutableSLList.nil();
+        protected ImmutableList<String> ifSeqFormulaList = ImmutableList.nil();
+        protected ImmutableList<String> ifDirectFormulaList = ImmutableList.nil();
 
         public TacletInformation(String ruleName) {
             super(ruleName);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -67,7 +67,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -529,7 +528,7 @@ public class IntermediateProofReplayer {
 
         ourApp = constructInsts(ourApp, currGoal, currInterm.getInsts(), services);
 
-        ImmutableList<AssumesFormulaInstantiation> ifFormulaList = ImmutableSLList.nil();
+        ImmutableList<AssumesFormulaInstantiation> ifFormulaList = ImmutableList.nil();
         for (String ifFormulaStr : currInterm.getIfSeqFormulaList()) {
             ifFormulaList =
                 ifFormulaList
@@ -608,7 +607,7 @@ public class IntermediateProofReplayer {
 
         // Load ifInsts, if applicable
         if (currInterm.getBuiltInIfInsts() != null) {
-            builtinIfInsts = ImmutableSLList.nil();
+            builtinIfInsts = ImmutableList.nil();
             for (final Pair<Integer, PosInTerm> ifInstP : currInterm.getBuiltInIfInsts()) {
                 final int currIfInstFormula = ifInstP.first;
                 final PosInTerm currIfInstPosInTerm = ifInstP.second;
@@ -853,7 +852,7 @@ public class IntermediateProofReplayer {
 
         }
 
-        ImmutableList<MergePartner> joinPartners = ImmutableSLList.nil();
+        ImmutableList<MergePartner> joinPartners = ImmutableList.nil();
         for (PartnerNode partnerNodeInfo : partnerNodesInfo) {
 
             SymbolicExecutionStateWithProgCnt ownSEState =

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/join/JoinProcessor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/join/JoinProcessor.java
@@ -26,7 +26,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * <p>
@@ -106,7 +105,7 @@ public class JoinProcessor implements Runnable {
 
         orRight(result);
 
-        ImmutableList<Goal> list = ImmutableSLList.nil();
+        ImmutableList<Goal> list = ImmutableList.nil();
 
         for (NodeGoalPair pair : cut.getGoalsAfterUncovering()) {
             if (pair.node == partner.getNode(0) || pair.node == partner.getNode(1)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/ProofCorrectnessMgt.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/ProofCorrectnessMgt.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.speclang.Contract;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.slf4j.Logger;
@@ -98,7 +97,7 @@ public final class ProofCorrectnessMgt {
         // initial paths
         ImmutableSet<ImmutableList<Contract>> newPaths = DefaultImmutableSet.nil();
         for (Contract c : contractsToBeApplied) {
-            newPaths = newPaths.add(ImmutableSLList.<Contract>nil().prepend(c));
+            newPaths = newPaths.add(ImmutableList.<Contract>nil().prepend(c));
         }
 
         // look for cycles

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/mgt/SpecificationRepository.java
@@ -164,7 +164,7 @@ public class SpecificationRepository {
         tacletBuilder.setFind(limitedTerm);
         tacletBuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), unlimitedTerm));
+                ImmutableList.nil(), unlimitedTerm));
         tacletBuilder.setName(
             MiscTools.toValidTacletName("unlimit " + getUniqueNameForObserver(unlimited)));
         return tacletBuilder.getTaclet();
@@ -190,9 +190,9 @@ public class SpecificationRepository {
         tacletBuilder.setFind(tb.func(unlimited, subs));
         final SequentFormula cf = new SequentFormula(tb.equals(limitedTerm, unlimitedTerm));
         final Sequent addedSeq =
-            JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(cf));
+            JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(cf));
         tacletBuilder.addTacletGoalTemplate(new RewriteTacletGoalTemplate(addedSeq,
-            ImmutableSLList.nil(), tb.func(unlimited, subs)));
+            ImmutableList.nil(), tb.func(unlimited, subs)));
         tacletBuilder.setApplicationRestriction(
             new ApplicationRestriction(ApplicationRestriction.IN_SEQUENT_STATE));
         tacletBuilder.setName(
@@ -259,7 +259,7 @@ public class SpecificationRepository {
 
     private ImmutableSet<Pair<KeYJavaType, IObserverFunction>> getOverridingMethods(KeYJavaType kjt,
             IProgramMethod pm) {
-        ImmutableList<Pair<KeYJavaType, IObserverFunction>> result = ImmutableSLList.nil();
+        ImmutableList<Pair<KeYJavaType, IObserverFunction>> result = ImmutableList.nil();
 
         // static methods and constructors are not overriden
         if (pm.isConstructor() || pm.isStatic()) {
@@ -895,23 +895,23 @@ public class SpecificationRepository {
 
                 final ClassAxiom invRepresentsAxiom =
                     new RepresentsAxiom("Class invariant axiom for " + kjt.getFullName(), invSymbol,
-                        kjt, new Private(), null, invDef, selfVar, ImmutableSLList.nil(), null);
+                        kjt, new Private(), null, invDef, selfVar, ImmutableList.nil(), null);
                 result = result.add(invRepresentsAxiom);
 
                 final ClassAxiom staticInvRepresentsAxiom = new RepresentsAxiom(
                     "Static class invariant axiom for " + kjt.getFullName(), staticInvSymbol, kjt,
-                    new Private(), null, staticInvDef, null, ImmutableSLList.nil(), null);
+                    new Private(), null, staticInvDef, null, ImmutableList.nil(), null);
                 result = result.add(staticInvRepresentsAxiom);
 
                 final ClassAxiom invFreeRepresentsAxiom = new RepresentsAxiom(
                     "Free class invariant axiom for " + kjt.getFullName(), freeInvSymbol, kjt,
-                    new Private(), null, freeInvDef, selfVar, ImmutableSLList.nil(), null);
+                    new Private(), null, freeInvDef, selfVar, ImmutableList.nil(), null);
                 result = result.add(invFreeRepresentsAxiom);
 
                 final ClassAxiom staticFreeInvRepresentsAxiom = new RepresentsAxiom(
                     "Free static class invariant axiom for " + kjt.getFullName(),
                     freeStaticInvSymbol, kjt, new Private(), null, freeStaticInvDef, null,
-                    ImmutableSLList.nil(), null);
+                    ImmutableList.nil(), null);
                 result = result.add(staticFreeInvRepresentsAxiom);
 
             }
@@ -965,7 +965,7 @@ public class SpecificationRepository {
                     // We need to construct an inheritance chain of contracts
                     // starting at the bottom
                     ImmutableList<FunctionalOperationContract> lookupContracts =
-                        ImmutableSLList.nil();
+                        ImmutableList.nil();
                     ImmutableSet<FunctionalOperationContract> cs = getOperationContracts(kjt, pm);
                     List<KeYJavaType> superTypes =
                         services.getJavaInfo().getAllSupertypes(kjt);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeChangeJournal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeChangeJournal.java
@@ -17,7 +17,6 @@ import org.key_project.util.collection.DefaultImmutableMap;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableMapEntry;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -56,7 +55,7 @@ public class NodeChangeJournal implements GoalListener {
      * listeners
      */
     public RuleAppInfo getRuleAppInfo(RuleApp p_ruleApp) {
-        ImmutableList<NodeReplacement> nrs = ImmutableSLList.nil();
+        ImmutableList<NodeReplacement> nrs = ImmutableList.nil();
 
         for (final ImmutableMapEntry<Node, NodeChangesHolder> entry : changes) {
             final Node newNode = entry.key();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeChangesHolder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeChangesHolder.java
@@ -5,14 +5,13 @@ package de.uka.ilkd.key.proof.proofevent;
 
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 public class NodeChangesHolder {
     public ImmutableList<SequentChangeInfo> scis;
 
     NodeChangesHolder() {
-        this(ImmutableSLList.nil());
+        this(ImmutableList.nil());
     }
 
     NodeChangesHolder(

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeReplacement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/proofevent/NodeReplacement.java
@@ -16,7 +16,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -178,7 +177,7 @@ public class NodeReplacement {
 
     private void removeNodeChanges(SequentFormula p_cf, boolean p_inAntec) {
         Iterator<NodeChange> it = changes.iterator();
-        changes = ImmutableSLList.nil();
+        changes = ImmutableList.nil();
         NodeChange oldNC;
         PosInOccurrence oldPio;
 
@@ -205,7 +204,7 @@ public class NodeReplacement {
      */
     public Iterator<NodeChange> getNodeChanges() {
         if (changes == null) {
-            changes = ImmutableSLList.nil();
+            changes = ImmutableList.nil();
             addNodeChanges();
         }
         return changes.iterator();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/replay/AbstractProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/replay/AbstractProofReplayer.java
@@ -35,7 +35,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -122,7 +121,7 @@ public abstract class AbstractProofReplayer {
         }
 
         // Load ifInsts, if applicable
-        builtinIfInsts = ImmutableSLList.nil();
+        builtinIfInsts = ImmutableList.nil();
         for (PosInOccurrence oldFormulaPio : RuleAppUtil
                 .assumesInstantiationsOfRuleApp(originalStep.getAppliedRuleApp(), originalStep)) {
             PosInOccurrence newFormula =
@@ -266,7 +265,7 @@ public abstract class AbstractProofReplayer {
         ourApp = IntermediateProofReplayer.constructInsts(ourApp, currGoal,
             getInterestingInstantiations(instantantions), services);
 
-        ImmutableList<AssumesFormulaInstantiation> ifFormulaList = ImmutableSLList.nil();
+        ImmutableList<AssumesFormulaInstantiation> ifFormulaList = ImmutableList.nil();
         List<Pair<PosInOccurrence, Boolean>> oldFormulas = RuleAppUtil
                 .assumesInstantiationsOfRuleApp(originalTacletApp, originalStep)
                 .stream()

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ApplyStrategy.java
@@ -17,7 +17,6 @@ import org.key_project.prover.engine.impl.ApplyStrategyInfo;
 import org.key_project.prover.engine.impl.DefaultProver;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -78,7 +77,7 @@ public class ApplyStrategy extends DefaultProver<Proof, Goal> {
      */
     @Override
     public synchronized ApplyStrategyInfo<Proof, Goal> start(Proof proof, Goal goal) {
-        return start(proof, ImmutableSLList.<Goal>nil().prepend(goal));
+        return start(proof, ImmutableList.<Goal>nil().prepend(goal));
     }
 
     /*
@@ -244,7 +243,7 @@ public class ApplyStrategy extends DefaultProver<Proof, Goal> {
         final GoalChooser<Proof, Goal> goalChooser = getGoalChooserForProof(proof);
         proof = null;
         if (goalChooser != null) {
-            goalChooser.init(null, ImmutableSLList.nil());
+            goalChooser.init(null, ImmutableList.nil());
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DefaultGoalChooser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DefaultGoalChooser.java
@@ -13,7 +13,6 @@ import de.uka.ilkd.key.proof.ProofTreeEvent;
 
 import org.key_project.prover.engine.GoalChooser;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -71,9 +70,9 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
     }
 
     protected void setupGoals(ImmutableList<Goal> p_goals) {
-        goalList = ImmutableSLList.nil();
-        selectedList = ImmutableSLList.nil();
-        nextGoals = ImmutableSLList.nil();
+        goalList = ImmutableList.nil();
+        selectedList = ImmutableList.nil();
+        nextGoals = ImmutableList.nil();
 
         if (allGoalsSatisfiable) {
             goalList = p_goals;
@@ -151,7 +150,7 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
      */
     public void removeGoal(Goal goal) {
         selectedList = selectedList.removeAll(goal);
-        nextGoals = ImmutableSLList.nil();
+        nextGoals = ImmutableList.nil();
 
         if (selectedList.isEmpty()) {
             setupGoals(goalList);
@@ -176,7 +175,7 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
         if (proof.openGoals().isEmpty())
         // proof has been closed
         {
-            nextGoals = selectedList = goalList = ImmutableSLList.nil();
+            nextGoals = selectedList = goalList = ImmutableList.nil();
         } else {
             if (selectedList.isEmpty()
                     || (currentSubtreeRoot != null && !isSatisfiableSubtree(currentSubtreeRoot))) {
@@ -186,10 +185,10 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
     }
 
     protected void updateGoalListHelp(Object node, ImmutableList<Goal> newGoals) {
-        ImmutableList<Goal> prevGoalList = ImmutableSLList.nil();
+        ImmutableList<Goal> prevGoalList = ImmutableList.nil();
         boolean newGoalsInserted = false;
 
-        nextGoals = ImmutableSLList.nil();
+        nextGoals = ImmutableList.nil();
 
         // Remove "node" and goals contained within "newGoals"
         while (!selectedList.isEmpty()) {
@@ -233,7 +232,7 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
 
     protected static ImmutableList<Goal> rotateList(ImmutableList<Goal> p_list) {
         if (p_list.isEmpty()) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
         return p_list.tail().append(p_list.head());
@@ -242,7 +241,7 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
     protected void removeClosedGoals() {
         boolean changed = false;
         Iterator<Goal> it = goalList.iterator();
-        goalList = ImmutableSLList.nil();
+        goalList = ImmutableList.nil();
 
         while (it.hasNext()) {
             final Goal goal = it.next();
@@ -254,7 +253,7 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
         }
 
         it = selectedList.iterator();
-        ImmutableList<Goal> newList = ImmutableSLList.nil();
+        ImmutableList<Goal> newList = ImmutableList.nil();
 
         while (it.hasNext()) {
             final Goal goal = it.next();
@@ -271,11 +270,11 @@ public class DefaultGoalChooser implements GoalChooser<@Nullable Proof, @Nullabl
         }
 
         if (changed) {
-            nextGoals = ImmutableSLList.nil();
+            nextGoals = ImmutableList.nil();
 
             // for "selectedList", order does matter
             it = newList.iterator();
-            selectedList = ImmutableSLList.nil();
+            selectedList = ImmutableList.nil();
             while (it.hasNext()) {
                 selectedList = selectedList.prepend(it.next());
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DepthFirstGoalChooser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DepthFirstGoalChooser.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.prover.impl;
 import de.uka.ilkd.key.proof.Goal;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -69,10 +68,10 @@ public class DepthFirstGoalChooser extends DefaultGoalChooser {
 
     @Override
     protected void updateGoalListHelp(Object node, ImmutableList<Goal> newGoals) {
-        ImmutableList<Goal> prevGoalList = ImmutableSLList.nil();
+        ImmutableList<Goal> prevGoalList = ImmutableList.nil();
         boolean newGoalsInserted = false;
 
-        nextGoals = ImmutableSLList.nil();
+        nextGoals = ImmutableList.nil();
 
         // Remove "node" and goals contained within "newGoals"
         while (!selectedList.isEmpty()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractBuiltInRuleApp.java
@@ -13,7 +13,6 @@ import org.key_project.logic.Namespace;
 import org.key_project.logic.op.Function;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -34,7 +33,7 @@ public abstract class AbstractBuiltInRuleApp<T extends BuiltInRule> implements I
             @Nullable ImmutableList<PosInOccurrence> ifInsts) {
         this.builtInRule = rule;
         this.pio = pio;
-        this.ifInsts = (ifInsts == null ? ImmutableSLList.nil() : ifInsts);
+        this.ifInsts = (ifInsts == null ? ImmutableList.nil() : ifInsts);
     }
 
     protected AbstractBuiltInRuleApp(T rule, @Nullable PosInOccurrence pio) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractContractRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractContractRuleApp.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.speclang.Contract;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.jspecify.annotations.NullMarked;
@@ -29,7 +28,7 @@ public abstract class AbstractContractRuleApp<T extends BuiltInRule>
 
     protected AbstractContractRuleApp(T rule, @Nullable PosInOccurrence pio,
             @Nullable Contract contract) {
-        this(rule, pio, ImmutableSLList.nil(), contract);
+        this(rule, pio, ImmutableList.nil(), contract);
     }
 
     protected AbstractContractRuleApp(T rule,

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractLoopInvariantRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AbstractLoopInvariantRule.java
@@ -30,7 +30,6 @@ import org.key_project.prover.rules.RuleAbortException;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -502,7 +501,7 @@ public abstract class AbstractLoopInvariantRule implements BuiltInRule {
                 inst.inv.getFreeModifiable(heap, inst.selfTerm, atPres, services));
         }
 
-        ImmutableList<AnonUpdateData> anonUpdateData = ImmutableSLList.nil();
+        ImmutableList<AnonUpdateData> anonUpdateData = ImmutableList.nil();
         for (LocationVariable heap : heapContext) {
             // weigl: prevent NPE
             JTerm modifiableTerm = modifiables.get(heap);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/AuxiliaryContractBuilders.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/AuxiliaryContractBuilders.java
@@ -51,10 +51,7 @@ import org.key_project.logic.op.Modality;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.ExtList;
-import org.key_project.util.collection.DefaultImmutableSet;
-import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
-import org.key_project.util.collection.ImmutableSet;
+import org.key_project.util.collection.*;
 
 import com.github.javaparser.ast.key.KeyTransactionStatement;
 import org.jspecify.annotations.NonNull;
@@ -1359,7 +1356,7 @@ public final class AuxiliaryContractBuilders {
             JavaBlock newJavaBlock = getJavaBlock(exceptionParameter);
             JTerm newPost = tb.and(postconditions);
             newPost = AbstractOperationPO.addAdditionalUninterpretedPredicateIfRequired(services,
-                newPost, ImmutableSLList.<LocationVariable>nil()
+                newPost, ImmutableList.<LocationVariable>nil()
                         .prependReverse(terms.remembranceLocalVariables.keySet()),
                 terms.exception);
             if (goal != null) {
@@ -1681,7 +1678,7 @@ public final class AuxiliaryContractBuilders {
                 final TermBuilder tb) {
             JTerm post = tb.and(postconditions);
             post = AbstractOperationPO.addAdditionalUninterpretedPredicateIfRequired(services, post,
-                ImmutableSLList.<LocationVariable>nil()
+                ImmutableList.<LocationVariable>nil()
                         .prependReverse(terms.remembranceLocalVariables.keySet()),
                 terms.exception);
             post = TermLabelManager.refactorTerm(termLabelState, services, null, post, rule, goal,
@@ -1689,7 +1686,7 @@ public final class AuxiliaryContractBuilders {
 
             JTerm postNext = tb.and(postconditionsNext);
             postNext = AbstractOperationPO.addAdditionalUninterpretedPredicateIfRequired(services,
-                postNext, ImmutableSLList.<LocationVariable>nil()
+                postNext, ImmutableList.<LocationVariable>nil()
                         .prependReverse(terms.remembranceLocalVariables.keySet()),
                 terms.exception);
             postNext = TermLabelManager.refactorTerm(termLabelState, services, null, postNext, rule,

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/BoundUniquenessChecker.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/BoundUniquenessChecker.java
@@ -13,7 +13,6 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * The bound uniqueness checker ensures that schemavariables can be bound at most once in the
@@ -27,7 +26,7 @@ public class BoundUniquenessChecker {
 
     private final HashSet<QuantifiableVariable> boundVars =
         new LinkedHashSet<>();
-    private ImmutableList<JTerm> terms = ImmutableSLList.nil();
+    private ImmutableList<JTerm> terms = ImmutableList.nil();
 
     public BoundUniquenessChecker(Sequent seq) {
         addAll(seq);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/LoopApplyHeadRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/LoopApplyHeadRule.java
@@ -23,7 +23,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -104,7 +103,7 @@ public class LoopApplyHeadRule implements BuiltInRule {
             new SequentFormula(
                 tb.apply(update, tb.prog(modality.kind(), newJavaBlock, target.sub(0)))),
             ruleApp.pio);
-        return ImmutableSLList.<Goal>nil().append(goal);
+        return ImmutableList.<Goal>nil().append(goal);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/OneStepSimplifier.java
@@ -40,7 +40,6 @@ import org.key_project.prover.sequent.*;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Immutables;
 
 import org.jspecify.annotations.NonNull;
@@ -75,7 +74,7 @@ public final class OneStepSimplifier implements BuiltInRule {
      * would not improve prover performance. I tested it for "simplify_literals", "cast_del", and
      * "evaluate_instanceof"; in any case there was a measurable slowdown. -- DB 03/06/14
      */
-    private static final ImmutableList<String> ruleSets = ImmutableSLList.<String>nil()
+    private static final ImmutableList<String> ruleSets = ImmutableList.<String>nil()
             .append("concrete").append("concrete_java").append("update_elim")
             .append("update_apply_on_update")
             .append("update_apply").append("update_join").append("elimQuantifier");
@@ -116,7 +115,7 @@ public final class OneStepSimplifier implements BuiltInRule {
     private ImmutableList<Taclet> tacletsForRuleSet(Proof proof, String ruleSetName,
             ImmutableList<String> excludedRuleSetNames) {
         assert !proof.openGoals().isEmpty();
-        ImmutableList<Taclet> result = ImmutableSLList.nil();
+        ImmutableList<Taclet> result = ImmutableList.nil();
 
         // collect apps present in all open goals
         Set<NoPosTacletApp> allApps =
@@ -185,11 +184,11 @@ public final class OneStepSimplifier implements BuiltInRule {
         if (proof != lastProof) {
             shutdownIndices();
             lastProof = proof;
-            appsTakenOver = ImmutableSLList.nil();
+            appsTakenOver = ImmutableList.nil();
             indices = new TacletIndex[ruleSets.size()];
             notSimplifiableCaches = (Map<JTerm, JTerm>[]) new LRUCache[indices.length];
             int i = 0;
-            ImmutableList<String> done = ImmutableSLList.nil();
+            ImmutableList<String> done = ImmutableList.nil();
             for (String ruleSet : ruleSets) {
                 ImmutableList<Taclet> taclets = tacletsForRuleSet(proof, ruleSet, done);
                 indices[i] = TacletIndexKit.getKit().createTacletIndex(taclets);
@@ -425,7 +424,7 @@ public final class OneStepSimplifier implements BuiltInRule {
                 inAntecedent); // It is required to create a new PosInOccurrence because formula and
                                // pio.constrainedFormula().formula() are only equals module
                                // renamings and term labels
-        ImmutableList<AssumesFormulaInstantiation> ifInst = ImmutableSLList.nil();
+        ImmutableList<AssumesFormulaInstantiation> ifInst = ImmutableList.nil();
         ifInst = ifInst.append(new AssumesFormulaInstDirect(pio.sequentFormula()));
         TacletApp ta = PosTacletApp.createPosTacletApp(taclet, svi, ifInst, applicatinPIO,
             lastProof.getServices());
@@ -492,7 +491,7 @@ public final class OneStepSimplifier implements BuiltInRule {
             new ArrayList<>(seq.size());
 
         // simplify as long as possible
-        ImmutableList<SequentFormula> list = ImmutableSLList.nil();
+        ImmutableList<SequentFormula> list = ImmutableList.nil();
         SequentFormula simplifiedCf = cf;
         while (true) {
             simplifiedCf = simplifyConstrainedFormula(simplifiedCf, ossPIO.isInAntec(),
@@ -508,7 +507,7 @@ public final class OneStepSimplifier implements BuiltInRule {
         PosInOccurrence[] ifInstsArr =
             ifInsts.toArray(new PosInOccurrence[0]);
         ImmutableList<PosInOccurrence> immutableIfInsts =
-            ImmutableSLList.<PosInOccurrence>nil().append(ifInstsArr);
+            ImmutableList.<PosInOccurrence>nil().append(ifInstsArr);
         return new Instantiation(list.head(), list.size(), immutableIfInsts);
     }
 
@@ -614,9 +613,9 @@ public final class OneStepSimplifier implements BuiltInRule {
             ImmutableList<PosInOccurrence> ifInsts =
                 ((OneStepSimplifierRuleApp) ruleApp).assumesInsts();
             ImmutableList<SequentFormula> anteFormulas =
-                ImmutableSLList.nil();
+                ImmutableList.nil();
             ImmutableList<SequentFormula> succFormulas =
-                ImmutableSLList.nil();
+                ImmutableList.nil();
             if (ifInsts != null) {
                 for (PosInOccurrence it : ifInsts) {
                     if (it.isInAntec()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/QueryExpand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/QueryExpand.java
@@ -38,7 +38,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.jspecify.annotations.NonNull;
@@ -282,9 +281,9 @@ public class QueryExpand implements BuiltInRule {
         final int depth = term.depth();
         List<QueryEvalPos> qeps = new ArrayList<>();
         int[] path = new int[depth];
-        final ImmutableSLList<QuantifiableVariable> instVars;
+        final ImmutableList<QuantifiableVariable> instVars;
         if (allowExpandBelowInstQuantifier) {
-            instVars = ImmutableSLList.nil();
+            instVars = ImmutableList.nil();
         } else {
             instVars = null;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
@@ -32,7 +32,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * visitor for method {@link JTerm#execPostOrder(Visitor)}. Called with that
@@ -396,7 +395,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
     }
 
     private Operator handleParametricFunction(ParametricFunctionInstance pfi) {
-        ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+        ImmutableList<GenericArgument> args = ImmutableList.nil();
 
         for (int i = pfi.getArgs().size() - 1; i >= 0; i--) {
             args = args.prepend(pfi.getArgs().get(i).instantiate(svInst, services));

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletApp.java
@@ -535,7 +535,7 @@ public abstract class TacletApp implements RuleApp {
         final TermBuilder tb = services.getTermBuilder();
 
         TacletApp app = this;
-        ImmutableList<String> proposals = ImmutableSLList.nil();
+        ImmutableList<String> proposals = ImmutableList.nil();
 
         for (final SchemaVariable variable : uninstantiatedVars()) {
             if (!(variable instanceof JOperatorSV operatorSv)) {
@@ -847,7 +847,7 @@ public abstract class TacletApp implements RuleApp {
             // (LG 2022-02-07) Apparently findIfFormulaInstantiations() might return null
             // instantiations that should actually be nil().
             // So we replace null with nil() here as a bugfix.
-            p_list = ImmutableSLList.nil();
+            p_list = ImmutableList.nil();
         }
         assert ifInstsCorrectSize(p_list) && assumesFormulaInstantiations == null
                 : "If instantiations list has wrong size "
@@ -877,7 +877,7 @@ public abstract class TacletApp implements RuleApp {
             "The if formulas have already been instantiated");
 
         if (taclet().assumesSequent().isEmpty()) {
-            return ImmutableSLList.<TacletApp>nil().prepend(this);
+            return ImmutableList.<TacletApp>singleton(this);
         }
 
         return findIfFormulaInstantiationsHelp(
@@ -885,7 +885,7 @@ public abstract class TacletApp implements RuleApp {
             createSemisequentList(taclet().assumesSequent().antecedent()),
             AssumesFormulaInstSeq.createList(seq, false, services),
             AssumesFormulaInstSeq.createList(seq, true, services),
-            ImmutableSLList.nil(), matchConditions(), services);
+            ImmutableList.nil(), matchConditions(), services);
     }
 
     /**
@@ -918,9 +918,9 @@ public abstract class TacletApp implements RuleApp {
                 // All formulas have been matched, collect the results
                 TacletApp res = setAllInstantiations(matchCond, instAlreadyMatched, services);
                 if (res != null) {
-                    return ImmutableSLList.<TacletApp>nil().prepend(res);
+                    return ImmutableList.<TacletApp>singleton(res);
                 }
-                return ImmutableSLList.nil();
+                return ImmutableList.nil();
             } else {
                 // Change from succedent to antecedent
                 ruleSuccTail = ruleAntecTail;
@@ -936,7 +936,7 @@ public abstract class TacletApp implements RuleApp {
 
         // For each matching formula call the method again to match
         // the remaining terms
-        ImmutableList<TacletApp> res = ImmutableSLList.nil();
+        ImmutableList<TacletApp> res = ImmutableList.nil();
         Iterator<MatchResultInfo> itMC = mr.matchConditions().iterator();
         ruleSuccTail = ruleSuccTail.tail();
         for (final AssumesFormulaInstantiation instantiationCandidate : mr.candidates()) {
@@ -950,7 +950,7 @@ public abstract class TacletApp implements RuleApp {
 
     private ImmutableList<SequentFormula> createSemisequentList(
             Semisequent p_ss) {
-        ImmutableList<SequentFormula> res = ImmutableSLList.nil();
+        ImmutableList<SequentFormula> res = ImmutableList.nil();
 
         for (SequentFormula p_s : p_ss) {
             res = res.prepend(p_s);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/TacletSchemaVariableCollector.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/TacletSchemaVariableCollector.java
@@ -24,7 +24,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -48,7 +47,7 @@ public class TacletSchemaVariableCollector implements DefaultVisitor {
 
 
     public TacletSchemaVariableCollector() {
-        varList = ImmutableSLList.nil();
+        varList = ImmutableList.nil();
     }
 
 
@@ -57,7 +56,7 @@ public class TacletSchemaVariableCollector implements DefaultVisitor {
      *        constructs to determine which labels are needed)
      */
     public TacletSchemaVariableCollector(@NonNull SVInstantiations svInsts) {
-        varList = ImmutableSLList.nil();
+        varList = ImmutableList.nil();
         instantiations = svInsts;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractApp.java
@@ -17,7 +17,6 @@ import org.key_project.logic.Term;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 public class UseDependencyContractApp<T extends UseDependencyContractRule>
@@ -32,7 +31,7 @@ public class UseDependencyContractApp<T extends UseDependencyContractRule>
 
     public UseDependencyContractApp(UseDependencyContractRule builtInRule, PosInOccurrence pio,
             Contract instantiation, PosInOccurrence step) {
-        this(builtInRule, pio, ImmutableSLList.nil(), instantiation, step);
+        this(builtInRule, pio, ImmutableList.nil(), instantiation, step);
     }
 
     public UseDependencyContractApp(UseDependencyContractRule rule, PosInOccurrence pio,

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/UseDependencyContractRule.java
@@ -34,7 +34,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -92,7 +91,7 @@ public final class UseDependencyContractRule implements BuiltInRule, ComplexJust
 
 
     private ImmutableSet<JTerm> addEqualDefs(ImmutableSet<JTerm> terms, Goal g) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
 
         for (SequentFormula cf : g.sequent().antecedent()) {
             final JTerm formula = (JTerm) cf.formula();
@@ -183,7 +182,7 @@ public final class UseDependencyContractRule implements BuiltInRule, ComplexJust
         final TermBuilder TB = services.getTermBuilder();
         if (heapTerm.equals(stepHeap)) {
             return new Pair<>(TB.empty(),
-                ImmutableSLList.nil());
+                ImmutableList.nil());
         } else if (op == heapLDT.getStore()) {
             final JTerm h = heapTerm.sub(0);
             final JTerm o = heapTerm.sub(1);
@@ -416,7 +415,7 @@ public final class UseDependencyContractRule implements BuiltInRule, ComplexJust
             selfTerm = focus.sub(target.getHeapCount(services) * target.getStateCount());
         }
 
-        ImmutableList<JTerm> paramTerms = ImmutableSLList.nil();
+        ImmutableList<JTerm> paramTerms = ImmutableList.nil();
         for (int i = target.getHeapCount(services) * target.getStateCount()
                 + (target.isStatic() ? 0 : 1); i < focus.arity(); i++) {
             paramTerms = paramTerms.append(focus.sub(i));
@@ -461,7 +460,7 @@ public final class UseDependencyContractRule implements BuiltInRule, ComplexJust
         int heapExprIndex = 0;
         boolean useful = false;
         ImmutableList<PosInOccurrence> ifInsts =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         int hc = 0;
         for (LocationVariable heap : heaps) {
             if (hc >= obsHeapCount) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/UseOperationContractRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/UseOperationContractRule.java
@@ -154,7 +154,7 @@ public class UseOperationContractRule implements BuiltInRule, ComplexJustificati
             }
         } else {
             New n = (New) mr;
-            ImmutableList<KeYJavaType> sig = ImmutableSLList.nil();
+            ImmutableList<KeYJavaType> sig = ImmutableList.nil();
             for (Expression e : n.getArguments()) {
                 sig = sig.append(e.getKeYJavaType(services, ec));
             }
@@ -191,7 +191,7 @@ public class UseOperationContractRule implements BuiltInRule, ComplexJustificati
 
     private static ImmutableList<JTerm> getActualParams(MethodOrConstructorReference mr,
             ExecutionContext ec, Services services) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (Expression expr : mr.getArguments()) {
             JTerm actualParam = services.getTypeConverter().convertToLogicElement(expr, ec);
             result = result.append(actualParam);
@@ -672,7 +672,7 @@ public class UseOperationContractRule implements BuiltInRule, ComplexJustificati
         protected JTerm atPreUpdates;
         protected JTerm reachableState;
         protected ImmutableList<UseOperationContractRule.AnonUpdateData> anonUpdateDatas =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         protected final Map<LocationVariable, JTerm> modifiables;
         protected final JTerm globalDefs;
         protected final JTerm originalPre;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/WhileInvariantRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/WhileInvariantRule.java
@@ -314,7 +314,7 @@ public class WhileInvariantRule implements BuiltInRule {
             var anonUpdate = createLocalAnonUpdate(localOuts, services);
             localAnonUpdate = anonUpdate != null ? anonUpdate : tb.skip();
             // Term anonAssumption = null;
-            ImmutableList<AnonUpdateData> anonUpdateDatas = ImmutableSLList.nil();
+            ImmutableList<AnonUpdateData> anonUpdateDatas = ImmutableList.nil();
             for (LocationVariable heap : heapContext) {
                 final AnonUpdateData tAnon =
                     createAnonUpdate(heap, modifiables.get(heap), inst.inv, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/NewLocalVarsCondition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/NewLocalVarsCondition.java
@@ -83,8 +83,8 @@ public class NewLocalVarsCondition implements VariableCondition {
 
         var vars = MiscTools.getLocalOuts(body, services);
         List<VariableDeclaration> decls = new ArrayList<>(vars.size());
-        ImmutableList<JTerm> updatesBefore = ImmutableSLList.nil();
-        ImmutableList<JTerm> updatesFrame = ImmutableSLList.nil();
+        ImmutableList<JTerm> updatesBefore = ImmutableList.nil();
+        ImmutableList<JTerm> updatesFrame = ImmutableList.nil();
         var tb = services.getTermBuilder();
         // Names of "before" variables generated within this single application; needed because
         // the new variables are not yet registered in the namespaces while we build them.

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/FindTacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/FindTacletExecutor.java
@@ -19,7 +19,6 @@ import org.key_project.prover.rules.instantiation.MatchResultInfo;
 import org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -184,7 +183,7 @@ public abstract class FindTacletExecutor extends TacletExecutor {
         final ImmutableList<SequentChangeInfo> newSequentsForGoals = checkAssumesGoals(goal,
             tacletApp.assumesFormulaInstantiations(), mc, taclet.goalTemplates().size());
 
-        ImmutableList<SequentChangeInfo> result = ImmutableSLList.nil();
+        ImmutableList<SequentChangeInfo> result = ImmutableList.nil();
         final Iterator<SequentChangeInfo> it = newSequentsForGoals.iterator();
         for (var gt : taclet.goalTemplates()) {
             final SequentChangeInfo currentSequent = it.next();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/NoFindTacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/NoFindTacletExecutor.java
@@ -18,7 +18,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public class NoFindTacletExecutor extends TacletExecutor {
     public static final AtomicLong PERF_APPLY = new AtomicLong();
@@ -39,7 +38,7 @@ public class NoFindTacletExecutor extends TacletExecutor {
         final ImmutableList<SequentChangeInfo> newSequentsForGoals = checkAssumesGoals(goal,
             tacletApp.assumesFormulaInstantiations(), mc, taclet.goalTemplates().size());
 
-        ImmutableList<SequentChangeInfo> result = ImmutableSLList.nil();
+        ImmutableList<SequentChangeInfo> result = ImmutableList.nil();
         final Iterator<SequentChangeInfo> it = newSequentsForGoals.iterator();
         for (var gt : taclet.goalTemplates()) {
             final SequentChangeInfo currentSequent = it.next();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/TacletExecutor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/executor/javadl/TacletExecutor.java
@@ -29,7 +29,6 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.rules.instantiation.MatchResultInfo;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -66,7 +65,7 @@ public abstract class TacletExecutor
      *         not supported for this kind of taclet
      */
     public ImmutableList<SequentChangeInfo> getResultSequentChanges(Goal goal, RuleApp ruleApp) {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
     @Override
@@ -154,7 +153,7 @@ public abstract class TacletExecutor
             Object... instantiationInfo) { // TermLabelState termLabelState, TacletLabelHint
                                            // labelHint) {
 
-        ImmutableList<SequentFormula> replacements = ImmutableSLList.nil();
+        ImmutableList<SequentFormula> replacements = ImmutableList.nil();
 
         for (SequentFormula sf : semi) {
             replacements = replacements.append(instantiateReplacement(sf, services,
@@ -229,7 +228,7 @@ public abstract class TacletExecutor
             LogicServices p_services,
             MatchResultInfo matchCond) {
         final Services services = (Services) p_services;
-        ImmutableList<RenamingTable> renamings = ImmutableSLList.nil();
+        ImmutableList<RenamingTable> renamings = ImmutableList.nil();
         for (final SchemaVariable sv : pvs) {
             final LocationVariable inst =
                 (LocationVariable) matchCond.getInstantiations().getInstantiation(sv);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/inst/GenericSortCondition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/inst/GenericSortCondition.java
@@ -15,7 +15,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.instantiation.InstantiationEntry;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -98,7 +97,7 @@ public abstract class GenericSortCondition {
         if (!(s1 instanceof ParametricSortInstance ps1) || ps1.getBase() != psi.getBase()) {
             return null;
         }
-        ImmutableList<GenericSortCondition> conds = ImmutableSLList.nil();
+        ImmutableList<GenericSortCondition> conds = ImmutableList.nil();
         for (int i = psi.getArgs().size() - 1; i >= 0; i--) {
             var a0 = psi.getArgs().get(i);
             var a1 = ps1.getArgs().get(i);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/inst/GenericSortInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/inst/GenericSortInstantiations.java
@@ -24,7 +24,6 @@ import org.key_project.util.collection.DefaultImmutableMap;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableMapEntry;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -60,7 +59,7 @@ public final class GenericSortInstantiations {
             Iterator<ImmutableMapEntry<SchemaVariable, InstantiationEntry<?>>> p_instantiations,
             ImmutableList<GenericSortCondition> p_conditions, LogicServices services) {
 
-        ImmutableList<GenericSort> sorts = ImmutableSLList.nil();
+        ImmutableList<GenericSort> sorts = ImmutableList.nil();
         ImmutableList<GenericSortCondition> c;
 
         final Iterator<GenericSortCondition> it;
@@ -172,7 +171,7 @@ public final class GenericSortInstantiations {
      * anything about further generic sorts)
      */
     public ImmutableList<GenericSortCondition> toConditions() {
-        ImmutableList<GenericSortCondition> res = ImmutableSLList.nil();
+        ImmutableList<GenericSortCondition> res = ImmutableList.nil();
 
 
         for (final ImmutableMapEntry<GenericSort, Sort> entry : insts) {
@@ -200,7 +199,7 @@ public final class GenericSortInstantiations {
                 throw new GenericSortException("Generic sort is not yet instantiated", null);
             }
         } else if (p_s instanceof ParametricSortInstance psi && psi.containsGenericSort()) {
-            ImmutableList<GenericArgument> args = ImmutableSLList.nil();
+            ImmutableList<GenericArgument> args = ImmutableList.nil();
             for (int i = psi.getArgs().size() - 1; i >= 0; i--) {
                 GenericArgument oa = psi.getArgs().get(i);
                 Sort realSort = getRealSort(oa.sort(), services);
@@ -222,7 +221,7 @@ public final class GenericSortInstantiations {
     /** exception thrown if no solution exists */
     private final static GenericSortException UNSATISFIABLE_SORT_CONSTRAINTS =
         new GenericSortException("Conditions for generic sorts could not be solved: ",
-            ImmutableSLList.nil());
+            ImmutableList.nil());
 
     /**
      * Really solve the conditions given
@@ -243,7 +242,7 @@ public final class GenericSortInstantiations {
         ImmutableList<GenericSort> topologicalSorts = topology(p_sorts);
 
         res = solveHelp(topologicalSorts, DefaultImmutableMap.nilMap(),
-            p_conditions, ImmutableSLList.nil(), services);
+            p_conditions, ImmutableList.nil(), services);
 
 
         if (res == null) {
@@ -286,9 +285,9 @@ public final class GenericSortInstantiations {
 
         // Find the sorts "gs" has to be a supersort of and the
         // identity conditions
-        ImmutableList<Sort> subsorts = ImmutableSLList.nil();
+        ImmutableList<Sort> subsorts = ImmutableList.nil();
         ImmutableList<GenericSortCondition> idConditions =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
 
         // subsorts given by the conditions (could be made faster
         // by using a hash map for storing the conditions)
@@ -375,7 +374,7 @@ public final class GenericSortInstantiations {
                 }
             }
 
-            return ImmutableSLList.<Sort>nil().prepend(chosen);
+            return ImmutableList.<Sort>nil().prepend(chosen);
         } else {
             // if a list of possible instantiations of the generic
             // sort has been given, use it
@@ -390,7 +389,7 @@ public final class GenericSortInstantiations {
 
     private static ImmutableList<Sort> toList(ImmutableSet<Sort> p_set) {
         ImmutableList<Sort> res;
-        res = ImmutableSLList.nil();
+        res = ImmutableList.nil();
         for (Sort sort : p_set) {
             res = res.prepend(sort);
         }
@@ -433,7 +432,7 @@ public final class GenericSortInstantiations {
         }
 
         Iterator<GenericSort> it = topology(p_remainingSorts).iterator();
-        p_remainingSorts = ImmutableSLList.nil();
+        p_remainingSorts = ImmutableList.nil();
 
         // reverse the order of the sorts, to start with the most
         // general one
@@ -528,7 +527,7 @@ public final class GenericSortInstantiations {
      * @return sorted sorts
      */
     private static ImmutableList<GenericSort> topology(ImmutableList<GenericSort> p_sorts) {
-        ImmutableList<GenericSort> res = ImmutableSLList.nil();
+        ImmutableList<GenericSort> res = ImmutableList.nil();
         Iterator<GenericSort> it;
         GenericSort curMax;
         GenericSort tMax;
@@ -544,7 +543,7 @@ public final class GenericSortInstantiations {
                 continue;
             }
 
-            tList = ImmutableSLList.nil();
+            tList = ImmutableList.nil();
 
             while (it.hasNext()) {
                 tMax = it.next();
@@ -619,16 +618,16 @@ public final class GenericSortInstantiations {
      */
     private static ImmutableList<Sort> findMinimalElements(Set<Sort> p_inside) {
         if (p_inside.size() == 1) {
-            return ImmutableSLList.<Sort>nil().prepend(p_inside.iterator().next());
+            return ImmutableList.<Sort>nil().prepend(p_inside.iterator().next());
         }
 
-        ImmutableList<Sort> res = ImmutableSLList.nil();
+        ImmutableList<Sort> res = ImmutableList.nil();
         final Iterator<Sort> it = p_inside.iterator();
 
         mainloop: while (it.hasNext()) {
             final Sort sort = it.next();
 
-            ImmutableList<Sort> res2 = ImmutableSLList.nil();
+            ImmutableList<Sort> res2 = ImmutableList.nil();
             for (Sort oldMinimal : res) {
                 if (oldMinimal.extendsTrans(sort)) {
                     continue mainloop;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/inst/SVInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/inst/SVInstantiations.java
@@ -29,7 +29,6 @@ import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableMapEntry;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -84,8 +83,8 @@ public class SVInstantiations
 
     /** creates a new SVInstantiations object with an empty map */
     private SVInstantiations() {
-        genericSortConditions = ImmutableSLList.nil();
-        updateContext = ImmutableSLList.nil();
+        genericSortConditions = ImmutableList.nil();
+        updateContext = ImmutableList.nil();
         map = DefaultImmutableMap.nilMap();
         interesting = DefaultImmutableMap.nilMap();
     }
@@ -424,7 +423,7 @@ public class SVInstantiations
             // avoid unnecessary creation of SVInstantiations
             return this;
         }
-        return new SVInstantiations(map, interesting(), ImmutableSLList.nil(),
+        return new SVInstantiations(map, interesting(), ImmutableList.nil(),
             getGenericSortInstantiations(), getGenericSortConditions());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/match/vm/VMTacletMatcher.java
@@ -35,7 +35,6 @@ import org.key_project.prover.rules.matcher.vm.VMProgramInterpreter;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -188,12 +187,12 @@ public class VMTacletMatcher implements TacletMatcher {
         MatchProgram program = assumesMatchPrograms.get(p_template);
         final var mc = (MatchConditions) p_matchCond;
 
-        ImmutableList<AssumesFormulaInstantiation> resFormulas = ImmutableSLList.nil();
+        ImmutableList<AssumesFormulaInstantiation> resFormulas = ImmutableList.nil();
         ImmutableList<MatchResultInfo> resMC =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
 
         final boolean updateContextPresent = !mc.getInstantiations().getUpdateContext().isEmpty();
-        ImmutableList<UpdateLabelPair> context = ImmutableSLList.nil();
+        ImmutableList<UpdateLabelPair> context = ImmutableList.nil();
 
         if (updateContextPresent) {
             context = mc.getInstantiations().getUpdateContext();
@@ -281,7 +280,7 @@ public class VMTacletMatcher implements TacletMatcher {
             assert assumesSequentIterator.hasNext()
                     : "p_toMatch and assumes sequent must have same number of elements";
             newMC = matchAssumes(
-                ImmutableSLList.<AssumesFormulaInstantiation>nil().prepend(candidateInst),
+                ImmutableList.singleton(candidateInst),
                 assumesSequentIterator.next().formula(), p_matchCond, p_services).matchConditions();
 
             if (newMC.isEmpty()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeProcedure.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeProcedure.java
@@ -16,7 +16,6 @@ import de.uka.ilkd.key.util.mergerule.SymbolicExecutionState;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -40,11 +39,11 @@ import org.key_project.util.collection.ImmutableSet;
 public abstract class MergeProcedure {
 
     /** Concrete merge procedures. */
-    static ImmutableList<MergeProcedure> CONCRETE_RULES = ImmutableSLList.nil();
+    static ImmutableList<MergeProcedure> CONCRETE_RULES = ImmutableList.nil();
 
     static {
         CONCRETE_RULES =
-            ImmutableSLList.<MergeProcedure>nil().prepend(MergeTotalWeakening.instance())
+            ImmutableList.<MergeProcedure>nil().prepend(MergeTotalWeakening.instance())
                     .prepend(MergeWithPredicateAbstractionFactory.instance())
                     .prepend(MergeIfThenElseAntecedent.instance())
                     .prepend(MergeByIfThenElse.instance());

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRule.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRule.java
@@ -41,7 +41,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -332,7 +331,7 @@ public class MergeRule implements BuiltInRule {
         progVars = progVars.union(getUpdateLeftSideLocations(state1.first));
         progVars = progVars.union(getUpdateLeftSideLocations(state2.first));
 
-        ImmutableList<JTerm> newElementaryUpdates = ImmutableSLList.nil();
+        ImmutableList<JTerm> newElementaryUpdates = ImmutableList.nil();
 
         // New constraints on introduced Skolem constants
         JTerm newAdditionalConstraints = null;
@@ -680,7 +679,7 @@ public class MergeRule implements BuiltInRule {
 
         // Find potential partners -- for which isApplicable is true and
         // they have the same program counter (and post condition).
-        ImmutableList<MergePartner> potentialPartners = ImmutableSLList.nil();
+        ImmutableList<MergePartner> potentialPartners = ImmutableList.nil();
 
         for (final Goal g : allGoals) {
             if (!g.equals(goal) && !g.isLinked()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRuleBuiltInRuleApp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/merge/MergeRuleBuiltInRuleApp.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.util.mergerule.SymbolicExecutionStateWithProgCnt;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -138,7 +137,7 @@ public class MergeRuleBuiltInRuleApp extends AbstractBuiltInRuleApp<MergeRule> {
         // the concrete lattice.
         if (concreteRule.requiresDistinguishablePathConditions()
                 || concreteRule instanceof MergeWithLatticeAbstraction) {
-            ImmutableList<SymbolicExecutionState> allStates = ImmutableSLList.nil();
+            ImmutableList<SymbolicExecutionState> allStates = ImmutableList.nil();
             allStates = allStates.prepend(mergePartnerStates);
             allStates = allStates.prepend(thisSEState.toSymbolicExecutionState());
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/EnhancedForElimination.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/EnhancedForElimination.java
@@ -37,7 +37,7 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import de.uka.ilkd.key.speclang.LoopSpecification;
 
 import org.key_project.util.ExtList;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.Pair;
 
 /**
@@ -240,7 +240,7 @@ public class EnhancedForElimination extends ProgramTransformer {
         final KeYJavaType iterableType = iterableExpr.getKeYJavaType(services, data.execContext());
         final IProgramMethod iteratorMethod =
             services.getJavaInfo().getProgramMethod(iterableType, ITERATOR_METHOD_NAME,
-                ImmutableSLList.nil(), data.execContext().getTypeReference().getKeYJavaType());
+                ImmutableList.nil(), data.execContext().getTypeReference().getKeYJavaType());
 
         // local variable "it"
         final KeYJavaType iteratorType = iteratorMethod.getReturnType();

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ForToWhile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ForToWhile.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * converts a for-loop to a while loop. Invariant and other rules cannot be performed on for but
@@ -98,7 +97,7 @@ public class ForToWhile extends ProgramTransformer {
      */
     @Override
     public ImmutableList<SchemaVariable> neededInstantiations(SVInstantiations svInst) {
-        ImmutableList<SchemaVariable> ret = ImmutableSLList.nil();
+        ImmutableList<SchemaVariable> ret = ImmutableList.nil();
 
         if (innerLabel != null) {
             ret = ret.prepend(innerLabel);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/MethodCall.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/MethodCall.java
@@ -42,7 +42,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +109,7 @@ public class MethodCall extends ProgramTransformer {
     /** gets an array of expression and returns a list of types */
     private ImmutableList<KeYJavaType> getTypes(ImmutableArray<Expression> args,
             Services services) {
-        ImmutableList<KeYJavaType> result = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> result = ImmutableList.nil();
         for (int i = args.size() - 1; i >= 0; i--) {
             Expression argument = args.get(i);
             result =

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ObserverEqualityMetaConstruct.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ObserverEqualityMetaConstruct.java
@@ -136,7 +136,7 @@ public class ObserverEqualityMetaConstruct extends AbstractTermTransformer {
 
         // static methods do not a self var ==> one argument less to ignore (#1672)
         int paramOffset = contract.hasSelfVar() ? 2 : 1;
-        ImmutableList<JTerm> params = smaller.subs().toImmutableList().take(paramOffset);
+        ImmutableList<JTerm> params = smaller.subs().toImmutableList().skip(paramOffset);
 
         JTerm mod = contract.getDep(baseHeap, false, smaller.sub(0), smaller.sub(1), params,
             Collections.emptyMap(), services);
@@ -178,7 +178,7 @@ public class ObserverEqualityMetaConstruct extends AbstractTermTransformer {
         LocationVariable baseHeap = services.getTypeConverter().getHeapLDT().getHeap();
         // static methods do not a self var ==> one argument less to ignore (#1672)
         int paramOffset = contract.hasSelfVar() ? 2 : 1;
-        ImmutableList<JTerm> params = app.subs().toImmutableList().take(paramOffset);
+        ImmutableList<JTerm> params = app.subs().toImmutableList().skip(paramOffset);
 
         return contract.getPre(baseHeap, app.sub(0), app.sub(1), params, Collections.emptyMap(),
             services);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ProgramTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/ProgramTransformer.java
@@ -19,7 +19,6 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import org.key_project.logic.Name;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * ProgramTransformers are used to describe schematic transformations that cannot be expressed by
@@ -232,7 +231,7 @@ public abstract class ProgramTransformer extends JavaNonTerminalProgramElement
      * @return a list of schema variables relevant for this entity;
      */
     public ImmutableList<SchemaVariable> needs() {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
     /**
@@ -243,7 +242,7 @@ public abstract class ProgramTransformer extends JavaNonTerminalProgramElement
      * @return a list of schema variables relevant for this entity;
      */
     public ImmutableList<SchemaVariable> neededInstantiations(SVInstantiations svInst) {
-        return ImmutableSLList.nil();
+        return ImmutableList.nil();
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/UnwindLoop.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/UnwindLoop.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This class is used to perform program transformations needed for the symbolic execution of a
@@ -92,7 +91,7 @@ public class UnwindLoop extends ProgramTransformer {
      */
     @Override
     public ImmutableList<SchemaVariable> neededInstantiations(SVInstantiations svInst) {
-        ImmutableList<SchemaVariable> ret = ImmutableSLList.nil();
+        ImmutableList<SchemaVariable> ret = ImmutableList.nil();
 
         if (innerLabel != null) {
             ret = ret.prepend(innerLabel);

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/WhileInvariantTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/WhileInvariantTransformer.java
@@ -36,7 +36,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import com.github.javaparser.ast.key.KeyTransactionStatement;
 
@@ -302,7 +301,7 @@ public final class WhileInvariantTransformer {
         WhileInvariantTransformation w = new WhileInvariantTransformation(originalLoop, svInst,
             javaInfo == null ? null : javaInfo.getServices());
         w.start();
-        instantiations = ImmutableSLList.nil();
+        instantiations = ImmutableList.nil();
         if (w.innerLabelNeeded()) {
             instantiations = instantiations.prepend(innerLabel);
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Monomial.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Monomial.java
@@ -18,7 +18,6 @@ import org.key_project.logic.Term;
 import org.key_project.logic.op.Operator;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Class for analysing and modifying monomial expressions over the integers
@@ -33,7 +32,7 @@ public class Monomial {
         this.coefficient = coefficient;
     }
 
-    public static final Monomial ONE = new Monomial(ImmutableSLList.nil(), BigInteger.ONE);
+    public static final Monomial ONE = new Monomial(ImmutableList.nil(), BigInteger.ONE);
 
     public static Monomial create(Term monoTerm, Services services) {
         final LRUCache<Term, Monomial> monomialCache = services.getCaches().getMonomialCache();
@@ -134,7 +133,7 @@ public class Monomial {
         final BigInteger c = this.coefficient;
 
         if (a.signum() == 0 || c.signum() == 0) {
-            return new Monomial(ImmutableSLList.nil(), BigInteger.ZERO);
+            return new Monomial(ImmutableList.nil(), BigInteger.ZERO);
         }
 
         return new Monomial(difference(m.parts, this.parts), LexPathOrdering.divide(a, c));
@@ -237,7 +236,7 @@ public class Monomial {
 
     private static class Analyser {
         public BigInteger coeff = BigInteger.ONE;
-        public ImmutableList<Term> parts = ImmutableSLList.nil();
+        public ImmutableList<Term> parts = ImmutableList.nil();
         private final Services services;
         private final Operator numbers, mul;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Polynomial.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/metaconstruct/arith/Polynomial.java
@@ -17,7 +17,6 @@ import org.key_project.logic.Term;
 import org.key_project.logic.op.Operator;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Class for analysing and modifying polynomial expressions over the integers
@@ -28,12 +27,12 @@ public class Polynomial {
      * The polynomial expression of the BigInteger constant '0'.
      */
     public final static Polynomial ZERO =
-        new Polynomial(ImmutableSLList.nil(), BigInteger.ZERO);
+        new Polynomial(ImmutableList.nil(), BigInteger.ZERO);
     /**
      * The polynomial expression of the BigInteger constant '1'.
      */
     public final static Polynomial ONE =
-        new Polynomial(ImmutableSLList.nil(), BigInteger.ONE);
+        new Polynomial(ImmutableList.nil(), BigInteger.ONE);
 
     /**
      * The BigInteger constant for the value '-1'.
@@ -75,9 +74,9 @@ public class Polynomial {
 
     public Polynomial multiply(BigInteger c) {
         if (c.signum() == 0) {
-            return new Polynomial(ImmutableSLList.nil(), BigInteger.ZERO);
+            return new Polynomial(ImmutableList.nil(), BigInteger.ZERO);
         }
-        ImmutableList<Monomial> newParts = ImmutableSLList.nil();
+        ImmutableList<Monomial> newParts = ImmutableList.nil();
         for (Monomial part : parts) {
             newParts = newParts.prepend(part.multiply(c));
         }
@@ -87,10 +86,10 @@ public class Polynomial {
 
     public Polynomial multiply(Monomial m) {
         if (m.getCoefficient().signum() == 0) {
-            return new Polynomial(ImmutableSLList.nil(), BigInteger.ZERO);
+            return new Polynomial(ImmutableList.nil(), BigInteger.ZERO);
         }
 
-        ImmutableList<Monomial> newParts = ImmutableSLList.nil();
+        ImmutableList<Monomial> newParts = ImmutableList.nil();
         for (Monomial part : parts) {
             newParts = newParts.prepend(part.multiply(m));
         }
@@ -268,7 +267,7 @@ public class Polynomial {
 
     private static class Analyser {
         public BigInteger constantPart = BigInteger.ZERO;
-        public ImmutableList<Monomial> parts = ImmutableSLList.nil();
+        public ImmutableList<Monomial> parts = ImmutableList.nil();
         private final Services services;
         private final TypeConverter tc;
         private final Operator numbers, add;

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/RewriteTacletGoalTemplate.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/RewriteTacletGoalTemplate.java
@@ -13,7 +13,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -47,7 +46,7 @@ public class RewriteTacletGoalTemplate extends TacletGoalTemplate {
 
 
     public RewriteTacletGoalTemplate(JTerm replacewith) {
-        this(JavaDLSequentKit.getInstance().getEmptySequent(), ImmutableSLList.nil(), replacewith);
+        this(JavaDLSequentKit.getInstance().getEmptySequent(), ImmutableList.nil(), replacewith);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/TacletBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/TacletBuilder.java
@@ -28,7 +28,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -45,19 +44,19 @@ public abstract class TacletBuilder<T extends Taclet> {
 
     protected Name name = NONAME;
     protected Sequent assumesSeq = JavaDLSequentKit.getInstance().getEmptySequent();
-    protected ImmutableList<NewVarcond> varsNew = ImmutableSLList.nil();
-    protected ImmutableList<NotFreeIn> varsNotFreeIn = ImmutableSLList.nil();
-    protected ImmutableList<NewDependingOn> varsNewDependingOn = ImmutableSLList.nil();
+    protected ImmutableList<NewVarcond> varsNew = ImmutableList.nil();
+    protected ImmutableList<NotFreeIn> varsNotFreeIn = ImmutableList.nil();
+    protected ImmutableList<NewDependingOn> varsNewDependingOn = ImmutableList.nil();
     protected ImmutableList<org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate> goals =
-        ImmutableSLList.nil();
-    protected ImmutableList<RuleSet> ruleSets = ImmutableSLList.nil();
+        ImmutableList.nil();
+    protected ImmutableList<RuleSet> ruleSets = ImmutableList.nil();
     protected TacletAttributes attrs = new TacletAttributes(NONAME.toString(), null);
 
     /**
      * List of additional generic conditions on the instantiations of schema variables.
      */
     protected ImmutableList<VariableCondition> variableConditions =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
     protected HashMap<TacletGoalTemplate, ChoiceExpr> goal2Choices = null;
     protected ChoiceExpr choices = ChoiceExpr.TRUE;
     protected ImmutableSet<TacletAnnotation> tacletAnnotations =

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/TacletGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/tacletbuilder/TacletGenerator.java
@@ -34,7 +34,6 @@ import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -61,10 +60,10 @@ public class TacletGenerator {
     private TacletGoalTemplate createAxiomGoalTemplate(JTerm goalTerm) {
         final SequentFormula axiomSf = new SequentFormula(goalTerm);
         final ImmutableList<SequentFormula> axiomSemiSeq =
-            ImmutableSLList.singleton(axiomSf);
+            ImmutableList.singleton(axiomSf);
         final Sequent axiomSeq = JavaDLSequentKit.createAnteSequent(axiomSemiSeq);
         final TacletGoalTemplate axiomTemplate =
-            new TacletGoalTemplate(axiomSeq, ImmutableSLList.nil());
+            new TacletGoalTemplate(axiomSeq, ImmutableList.nil());
         return axiomTemplate;
     }
 
@@ -123,8 +122,8 @@ public class TacletGenerator {
         originalAxiom = tb.convertToFormula(originalAxiom);
 
         // create schema terms
-        ImmutableList<LocationVariable> pvs = ImmutableSLList.nil();
-        ImmutableList<JOperatorSV> svs = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> pvs = ImmutableList.nil();
+        ImmutableList<JOperatorSV> svs = ImmutableList.nil();
         List<TermSV> heapSVs = new ArrayList<>();
         for (LocationVariable heap : heaps) {
             if (target.getStateCount() >= 1) {
@@ -143,7 +142,7 @@ public class TacletGenerator {
 
         final JOperatorSV selfSV = createSchemaVariable(self);
 
-        ImmutableList<JOperatorSV> paramSVs = ImmutableSLList.nil();
+        ImmutableList<JOperatorSV> paramSVs = ImmutableList.nil();
         for (LocationVariable paramVar : paramVars) {
             paramSVs = paramSVs.append(createSchemaVariable(paramVar));
         }
@@ -156,8 +155,8 @@ public class TacletGenerator {
         SequentFormula guardedSchemaAxiom = generateGuard(kjt, target, services, selfSV, heapSVs,
             paramSVs, schemaAxiom.term, tacletBuilder, satisfiabilityGuard);
         final Sequent addedSeq = JavaDLSequentKit.createAnteSequent(
-            ImmutableSLList.singleton(guardedSchemaAxiom));
-        ImmutableList<JTerm> vars = ImmutableSLList.nil();
+            ImmutableList.singleton(guardedSchemaAxiom));
+        ImmutableList<JTerm> vars = ImmutableList.nil();
         for (TermSV heapSV : heapSVs) {
             vars = vars.append(tb.var(heapSV));
         }
@@ -170,7 +169,7 @@ public class TacletGenerator {
         final JTerm findTerm = tb.func(target, vars.toArray(new JTerm[0]));
 
         final RewriteTacletGoalTemplate axiomTemplate =
-            new RewriteTacletGoalTemplate(addedSeq, ImmutableSLList.nil(), findTerm);
+            new RewriteTacletGoalTemplate(addedSeq, ImmutableList.nil(), findTerm);
 
         // choices, rule set
         // Be careful that the choices used here is actually declared (see optionsDeclarations.key),
@@ -212,8 +211,8 @@ public class TacletGenerator {
         TermBuilder TB = services.getTermBuilder();
 
         // instantiate axiom with schema variables
-        ImmutableList<LocationVariable> pvs = ImmutableSLList.nil();
-        ImmutableList<JOperatorSV> svs = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> pvs = ImmutableList.nil();
+        ImmutableList<JOperatorSV> svs = ImmutableList.nil();
         List<TermSV> heapSVs = new ArrayList<>();
         for (var heap : heaps) {
             if (target.getStateCount() >= 1) {
@@ -231,7 +230,7 @@ public class TacletGenerator {
         }
 
         final TermSV selfSV = createSchemaVariable(self);
-        ImmutableList<JOperatorSV> paramSVs = ImmutableSLList.nil();
+        ImmutableList<JOperatorSV> paramSVs = ImmutableList.nil();
         for (ProgramVariable paramVar : paramVars) {
             paramSVs = paramSVs.append(createSchemaVariable(paramVar));
         }
@@ -262,12 +261,12 @@ public class TacletGenerator {
             // ifSeq = null;
             final JTerm ifFormula = TB.equals(TB.var(selfSV), TB.NULL());
             final SequentFormula ifCf = new SequentFormula(ifFormula);
-            ifSeq = JavaDLSequentKit.createSuccSequent(ImmutableSLList.singleton(ifCf));
+            ifSeq = JavaDLSequentKit.createSuccSequent(ImmutableList.singleton(ifCf));
         } else {
             /* \assumes ( Sort.exactInstance(self) ==> ) */
             final JTerm ifFormula = TB.exactInstance(kjt.getSort(), TB.var(selfSV));
             final SequentFormula ifCf = new SequentFormula(ifFormula);
-            ifSeq = JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(ifCf));
+            ifSeq = JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(ifCf));
         }
 
         JTerm addForumlaTerm = originalPreTerm;
@@ -311,7 +310,7 @@ public class TacletGenerator {
         tacletBuilder.setFind(schemaLhs);
         tacletBuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), limitedRhs));
+                ImmutableList.nil(), limitedRhs));
 
         // FIXME - there is a chance this will have to go along with all the other associated
         // changes
@@ -363,7 +362,7 @@ public class TacletGenerator {
             selfSV, paramSVs, schemaRepresents, tacletBuilder);
         SequentFormula addedCf = new SequentFormula(axiomSatisfiable);
         final Sequent addedSeq =
-            JavaDLSequentKit.createSuccSequent(ImmutableSLList.singleton(addedCf));
+            JavaDLSequentKit.createSuccSequent(ImmutableList.singleton(addedCf));
         final var skolemSV =
             SchemaVariableFactory.createSkolemTermSV(new Name("sk"), target.sort());
         for (SchemaVariable heapSV : heapSVs) {
@@ -376,7 +375,7 @@ public class TacletGenerator {
             tacletBuilder.addVarsNewDependingOn(skolemSV, paramSV);
         }
         tacletBuilder.addTacletGoalTemplate(new RewriteTacletGoalTemplate(addedSeq,
-            ImmutableSLList.nil(), services.getTermBuilder().var(skolemSV)));
+            ImmutableList.nil(), services.getTermBuilder().var(skolemSV)));
         tacletBuilder.goalTemplates().tail().head().setName("Use Axiom");
         tacletBuilder.goalTemplates().head().setName("Show Axiom Satisfiability");
     }
@@ -387,7 +386,7 @@ public class TacletGenerator {
             List<TermSV> heapSVs, final JOperatorSV selfSV,
             ImmutableList<JOperatorSV> paramSVs, final TermAndBoundVarPair schemaRepresents,
             final RewriteTacletBuilder<? extends RewriteTaclet> tacletBuilder) {
-        ImmutableList<JTerm> vars = ImmutableSLList.nil();
+        ImmutableList<JTerm> vars = ImmutableList.nil();
         TermBuilder TB = services.getTermBuilder();
         for (var heapSV : heapSVs) {
             vars = vars.append(TB.var(heapSV));
@@ -447,8 +446,8 @@ public class TacletGenerator {
             ImmutableSet<Pair<Sort, IObserverFunction>> toLimit, boolean satisfiabilityGuard,
             TermServices services) {
 
-        ImmutableList<LocationVariable> pvs = ImmutableSLList.nil();
-        ImmutableList<JOperatorSV> svs = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> pvs = ImmutableList.nil();
+        ImmutableList<JOperatorSV> svs = ImmutableList.nil();
         final List<TermSV> heapSVs = new ArrayList<>();
         for (var heap : heaps) {
             if (target.getStateCount() >= 1) {
@@ -542,7 +541,7 @@ public class TacletGenerator {
         final JTerm addedFormula = schemaAdd.term;
         final SequentFormula addedCf = new SequentFormula(addedFormula);
         final Sequent addedSeq = JavaDLSequentKit.createAnteSequent(
-            ImmutableSLList.singleton(addedCf));
+            ImmutableList.singleton(addedCf));
 
         for (VariableSV boundSV : schemaAdd.boundVars) {
             for (SchemaVariable heapSV : heapSVs) {
@@ -561,7 +560,7 @@ public class TacletGenerator {
         tacletBuilder.setApplicationRestriction(
             new ApplicationRestriction(ApplicationRestriction.SAME_UPDATE_LEVEL));
         tacletBuilder.addTacletGoalTemplate(
-            new TacletGoalTemplate(addedSeq, ImmutableSLList.nil()));
+            new TacletGoalTemplate(addedSeq, ImmutableList.nil()));
         tacletBuilder.setName(name);
         tacletBuilder.addRuleSet(new RuleSet(new Name("classAxiom")));
 
@@ -594,7 +593,7 @@ public class TacletGenerator {
         final ProgramSV resultProgSV = SchemaVariableFactory
                 .createProgramSV(new ProgramElementName("#res_sv"), ProgramSVSort.VARIABLE, false);
 
-        final ImmutableList<KeYJavaType> sig = ImmutableSLList.<KeYJavaType>nil()
+        final ImmutableList<KeYJavaType> sig = ImmutableList.<KeYJavaType>nil()
                 .append(target.getParamTypes().toArray(new KeYJavaType[target.getNumParams()]));
         final IProgramMethod targetImpl = services.getJavaInfo().getProgramMethod(kjt,
             ((ProgramMethod) target).getName(), sig, kjt);
@@ -679,7 +678,7 @@ public class TacletGenerator {
         // create added sequent
         final SequentFormula addedCf = new SequentFormula(limitedAxiom);
         final Sequent addedSeq =
-            JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(addedCf));
+            JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(addedCf));
 
         final JTerm[] hs = new JTerm[heapSVs.size()];
         i = 0;
@@ -701,7 +700,7 @@ public class TacletGenerator {
 
         tacletBuilder.setFind(invTerm);
         tacletBuilder.addTacletGoalTemplate(
-            new TacletGoalTemplate(addedSeq, ImmutableSLList.nil()));
+            new TacletGoalTemplate(addedSeq, ImmutableList.nil()));
         tacletBuilder.setName(name);
         tacletBuilder.addRuleSet(new RuleSet(new Name("partialInvAxiom")));
         for (VariableSV boundSV : schemaAxiom.boundVars) {
@@ -724,9 +723,9 @@ public class TacletGenerator {
             final SequentFormula selfEQSF = new SequentFormula(selfEQ);
             final SequentFormula eqNullSF = new SequentFormula(eqNull);
             final var antec =
-                ImmutableSLList.singleton(selfEQSF);
+                ImmutableList.singleton(selfEQSF);
             final var succ =
-                ImmutableSLList.singleton(eqNullSF);
+                ImmutableList.singleton(eqNullSF);
             final Sequent ifSeq = JavaDLSequentKit.createSequent(antec, succ);
             tacletBuilder.setAssumesSequent(ifSeq);
         } else if (!isStatic) {
@@ -734,7 +733,7 @@ public class TacletGenerator {
             final JTerm selfNull = TB.equals(TB.var(selfSV), TB.NULL());
             final SequentFormula selfNullSF = new SequentFormula(selfNull);
             final Sequent ifSeq =
-                JavaDLSequentKit.createSuccSequent(ImmutableSLList.singleton(selfNullSF));
+                JavaDLSequentKit.createSuccSequent(ImmutableList.singleton(selfNullSF));
             tacletBuilder.setAssumesSequent(ifSeq);
         }
 
@@ -746,8 +745,8 @@ public class TacletGenerator {
     @SuppressWarnings("unused")
     private TermAndBoundVarPair createSchemaTerm(JTerm term, TermServices services,
             Pair<LocationVariable, JOperatorSV>... varPairs) {
-        ImmutableList<LocationVariable> progVars = ImmutableSLList.nil();
-        ImmutableList<JOperatorSV> schemaVars = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> progVars = ImmutableList.nil();
+        ImmutableList<JOperatorSV> schemaVars = ImmutableList.nil();
         for (Pair<LocationVariable, JOperatorSV> varPair : varPairs) {
             progVars = progVars.append(varPair.first);
             schemaVars = schemaVars.append(varPair.second);
@@ -780,7 +779,7 @@ public class TacletGenerator {
 
     private ImmutableList<JOperatorSV> createSchemaVariables(
             ImmutableList<LocationVariable> programVars) {
-        ImmutableList<JOperatorSV> schemaVars = ImmutableSLList.nil();
+        ImmutableList<JOperatorSV> schemaVars = ImmutableList.nil();
         for (LocationVariable progVar : programVars) {
             JOperatorSV schemaVar = createSchemaVariable(progVar);
             schemaVars = schemaVars.append(schemaVar);
@@ -967,7 +966,7 @@ public class TacletGenerator {
             TermServices services) {
 
         final TermBuilder TB = services.getTermBuilder();
-        ImmutableList<JTerm> vars = ImmutableSLList.nil();
+        ImmutableList<JTerm> vars = ImmutableList.nil();
         for (TermSV heapSV : heapSVs) {
             vars = vars.append(TB.var(heapSV));
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.strategy.StrategyProperties;
 import org.key_project.prover.engine.ProverCore;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -69,7 +68,7 @@ public class AutoCommand extends AbstractCommand {
             goals = state().getProof().openGoals();
         } else {
             final Goal goal = state().getFirstOpenAutomaticGoal();
-            goals = ImmutableSLList.<Goal>nil().prepend(goal);
+            goals = ImmutableList.<Goal>singleton(goal);
 
             if (arguments.matches != null || arguments.breakpoint != null) {
                 setupFocussedBreakpointStrategy( //
@@ -105,7 +104,7 @@ public class AutoCommand extends AbstractCommand {
         // start actual autoprove
         try {
             for (Goal goal : goals) {
-                applyStrategy.start(state().getProof(), ImmutableSLList.<Goal>nil().prepend(goal));
+                applyStrategy.start(state().getProof(), ImmutableList.<Goal>singleton(goal));
 
                 // only now reraise the interruption exception
                 if (applyStrategy.hasBeenInterrupted()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/InstantiateCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/InstantiateCommand.java
@@ -28,7 +28,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -110,7 +109,7 @@ public class InstantiateCommand extends AbstractCommand {
         RuleAppIndex index = g.ruleAppIndex();
         index.autoModeStopped();
 
-        ImmutableList<TacletApp> allApps = ImmutableSLList.nil();
+        ImmutableList<TacletApp> allApps = ImmutableList.nil();
         for (SequentFormula sf : g.node().sequent().antecedent()) {
             if (p.formula != null
                     && !(RENAMING_TERM_PROPERTY.equalsModThisProperty(sf.formula(), p.formula))) {

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/RewriteCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/RewriteCommand.java
@@ -23,7 +23,6 @@ import org.key_project.prover.proof.rulefilter.TacletFilter;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jspecify.annotations.Nullable;
@@ -109,7 +108,7 @@ public class RewriteCommand extends AbstractCommand {
         RuleAppIndex index = g.ruleAppIndex();
         index.autoModeStopped();
 
-        ImmutableList<TacletApp> allApps = ImmutableSLList.nil();
+        ImmutableList<TacletApp> allApps = ImmutableList.nil();
 
         // filter taclets that are applicable on the given formula
         // filter taclets that are applicable on the given formula in the antecedent

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/RuleCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/RuleCommand.java
@@ -27,7 +27,6 @@ import org.key_project.prover.rules.Taclet;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jspecify.annotations.Nullable;
@@ -288,7 +287,7 @@ public class RuleCommand extends AbstractCommand {
         final Goal g = state.getFirstOpenAutomaticGoal();
         final BuiltInRuleAppIndex index = g.ruleAppIndex().builtInRuleAppIndex();
 
-        ImmutableList<IBuiltInRuleApp> allApps = ImmutableSLList.nil();
+        ImmutableList<IBuiltInRuleApp> allApps = ImmutableList.nil();
         for (SequentFormula sf : g.node().sequent().antecedent()) {
             if (!isFormulaSearchedFor(p, sf, services)) {
                 continue;
@@ -319,7 +318,7 @@ public class RuleCommand extends AbstractCommand {
         RuleAppIndex index = g.ruleAppIndex();
         index.autoModeStopped();
 
-        ImmutableList<TacletApp> allApps = ImmutableSLList.nil();
+        ImmutableList<TacletApp> allApps = ImmutableList.nil();
         for (SequentFormula sf : g.node().sequent().antecedent()) {
             if (!isFormulaSearchedFor(p, sf, services)) {
                 continue;

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/SMTCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/SMTCommand.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.smt.solvertypes.SolverTypes;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -58,7 +57,7 @@ public class SMTCommand extends AbstractCommand {
         if (args.all) {
             goals = state.getProof().openGoals();
         } else {
-            goals = ImmutableSLList.<Goal>nil().prepend(state.getFirstOpenAutomaticGoal());
+            goals = ImmutableList.<Goal>nil().prepend(state.getFirstOpenAutomaticGoal());
         }
 
         for (Goal goal : goals) {

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/SelectCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/SelectCommand.java
@@ -39,9 +39,9 @@ public class SelectCommand extends AbstractCommand {
             ImmutableList<Goal> goals = state.getProof().openEnabledGoals();
 
             if (args.number >= 0) {
-                g = goals.take(args.number).head();
+                g = goals.get(args.number);
             } else {
-                g = goals.take(goals.size() + args.number).head();
+                g = goals.get(goals.size() + args.number);
             }
         } else if (args.formula != null && args.number == null && args.branch == null) {
             g = findGoalWith(args.formula, state.getProof());

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/TryCloseCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/TryCloseCommand.java
@@ -44,9 +44,9 @@ public class TryCloseCommand extends AbstractCommand {
                 int num = Integer.parseInt(args.branch);
                 ImmutableList<Goal> goals = state().getProof().openEnabledGoals();
                 if (num >= 0) {
-                    target = goals.take(num).head().node();
+                    target = goals.get(num).node();
                 } else {
-                    target = goals.take(goals.size() + num).head().node();
+                    target = goals.get(goals.size() + num).node();
                 }
             } catch (NumberFormatException e) {
                 target = state().getProof().root();

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ChoiceSettings.java
@@ -11,7 +11,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.Namespace;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -76,7 +75,7 @@ public class ChoiceSettings extends AbstractSettings {
     }
 
     private static ImmutableSet<Choice> choiceMap2choiceSet(Map<String, String> ccc) {
-        ImmutableList<Choice> choices = ImmutableSLList.nil();
+        ImmutableList<Choice> choices = ImmutableList.nil();
         for (final Map.Entry<String, String> entry : ccc.entrySet()) {
             choices = choices.prepend(new Choice(new Name(entry.getValue()), entry.getKey()));
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTFocusResults.java
@@ -24,7 +24,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -155,7 +154,7 @@ public final class SMTFocusResults {
         Arrays.stream(numbers).forEach(unsatCore::add);
 
         ImmutableList<PosInOccurrence> unsatCoreFormulas =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
 
         Semisequent antecedent = goalNode.sequent().antecedent();
         int i = 1;

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/SMTProblem.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/SMTProblem.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.smt.SMTSolverResult.ThreeValuedTruth;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Represents a problem that can be passed to a solver. This class was introduced because the SMT
@@ -157,7 +156,7 @@ public class SMTProblem {
     }
 
     public static JTerm sequentToTerm(Sequent s, Services services) {
-        ImmutableList<JTerm> ante = ImmutableSLList.nil();
+        ImmutableList<JTerm> ante = ImmutableList.nil();
 
         final TermBuilder tb = services.getTermBuilder();
         ante = ante.append(tb.tt());
@@ -165,7 +164,7 @@ public class SMTProblem {
             ante = ante.append((JTerm) f.formula());
         }
 
-        ImmutableList<JTerm> succ = ImmutableSLList.nil();
+        ImmutableList<JTerm> succ = ImmutableList.nil();
         succ = succ.append(tb.ff());
         for (SequentFormula f : s.succedent()) {
             succ = succ.append((JTerm) f.formula());
@@ -178,7 +177,7 @@ public class SMTProblem {
 
     private JTerm sequentToTerm(Sequent s) {
 
-        ImmutableList<JTerm> ante = ImmutableSLList.nil();
+        ImmutableList<JTerm> ante = ImmutableList.nil();
 
         final TermBuilder tb = goal.proof().getServices().getTermBuilder();
         ante = ante.append(tb.tt());
@@ -186,7 +185,7 @@ public class SMTProblem {
             ante = ante.append((JTerm) f.formula());
         }
 
-        ImmutableList<JTerm> succ = ImmutableSLList.nil();
+        ImmutableList<JTerm> succ = ImmutableList.nil();
         succ = succ.append(tb.ff());
         for (SequentFormula f : s.succedent()) {
             succ = succ.append((JTerm) f.formula());

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/AuxiliaryContract.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/AuxiliaryContract.java
@@ -42,7 +42,6 @@ import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 /**
@@ -911,7 +910,7 @@ public interface AuxiliaryContract extends SpecificationElement {
                 atPreVars.put(h, remembranceLocalVariables.get(h));
             }
             return new OriginalVariables(self, result, exception, atPreVars,
-                ImmutableSLList.nil());
+                ImmutableList.nil());
         }
 
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/ClassAxiomImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/ClassAxiomImpl.java
@@ -22,7 +22,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -131,7 +130,7 @@ public final class ClassAxiomImpl extends ClassAxiom {
     @Override
     public ImmutableSet<Taclet> getTaclets(ImmutableSet<Pair<Sort, IObserverFunction>> toLimit,
             Services services) {
-        ImmutableList<LocationVariable> replaceVars = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> replaceVars = ImmutableList.nil();
         replaceVars = replaceVars.append(services.getTypeConverter().getHeapLDT().getHeap());
         if (!isStatic) {
             replaceVars = replaceVars.append(originalSelfVar);

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/ClassInvariantImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/ClassInvariantImpl.java
@@ -19,7 +19,7 @@ import de.uka.ilkd.key.proof.OpReplacer;
 import de.uka.ilkd.key.speclang.Contract.OriginalVariables;
 
 import org.key_project.logic.op.Operator;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 
 /**
@@ -211,6 +211,6 @@ public final class ClassInvariantImpl implements ClassInvariant {
         self = this.originalSelfVar;
         return new OriginalVariables(self, null, null,
             new LinkedHashMap<>(),
-            ImmutableSLList.nil());
+            ImmutableList.nil());
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/Contract.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/Contract.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.proof.init.ProofOblInput;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * A contractual agreement about an ObserverFunction.
@@ -330,7 +329,7 @@ public interface Contract extends SpecificationElement {
             this.exception = excVar;
             this.atPres = atPreVars;
             if (paramVars == null) {
-                this.params = ImmutableSLList.nil();
+                this.params = ImmutableList.nil();
             } else {
                 this.params = paramVars;
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/FunctionalOperationContractImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/FunctionalOperationContractImpl.java
@@ -33,7 +33,6 @@ import org.key_project.logic.SyntaxElement;
 import org.key_project.logic.op.Operator;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.MapUtil;
 
 import static de.uka.ilkd.key.logic.equality.RenamingTermProperty.RENAMING_TERM_PROPERTY;
@@ -410,7 +409,7 @@ public class FunctionalOperationContractImpl implements FunctionalOperationContr
     private ImmutableList<LocationVariable> addGhostParams(
             ImmutableList<LocationVariable> paramVars) {
         // make sure ghost parameters are present
-        ImmutableList<LocationVariable> ghostParams = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> ghostParams = ImmutableList.nil();
         for (LocationVariable param : originalParamVars) {
             if (param.isGhost()) {
                 ghostParams = ghostParams.append(param);
@@ -423,7 +422,7 @@ public class FunctionalOperationContractImpl implements FunctionalOperationContr
     /** Make sure ghost parameters appear in the list of parameter variables. */
     private ImmutableList<JTerm> addGhostParamTerms(ImmutableList<JTerm> paramVars) {
         // make sure ghost parameters are present
-        ImmutableList<JTerm> ghostParams = ImmutableSLList.nil();
+        ImmutableList<JTerm> ghostParams = ImmutableList.nil();
         for (LocationVariable param : originalParamVars) {
             if (param.isGhost()) {
                 ghostParams = ghostParams.append(tb.var(param));

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/LoopSpecImpl.java
@@ -25,7 +25,6 @@ import de.uka.ilkd.key.speclang.Contract.OriginalVariables;
 import de.uka.ilkd.key.util.InfFlowSpec;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.MapUtil;
 
 /**
@@ -561,7 +560,7 @@ public final class LoopSpecImpl implements LoopSpecification {
             self = null;
         }
         return new OriginalVariables(self, null, null, atPreVars,
-            ImmutableSLList.nil());
+            ImmutableList.nil());
     }
 
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/QueryAxiom.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/QueryAxiom.java
@@ -34,7 +34,6 @@ import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
 
@@ -171,7 +170,7 @@ public final class QueryAxiom extends ClassAxiom {
             tb.equals(tb.var(skolemSV), tb.var(resultProgSV)));
 
         // create java block
-        final ImmutableList<KeYJavaType> sig = ImmutableSLList.<KeYJavaType>nil()
+        final ImmutableList<KeYJavaType> sig = ImmutableList.<KeYJavaType>nil()
                 .append(target.getParamTypes().toArray(new KeYJavaType[target.getNumParams()]));
         // get real implementation of program method
         final IProgramMethod targetImpl =
@@ -189,7 +188,7 @@ public final class QueryAxiom extends ClassAxiom {
             final JTerm ifFormula = tb.exactInstance(kjt.getSort(), tb.var(selfSV));
             final SequentFormula ifCf = new SequentFormula(ifFormula);
             final ImmutableList<SequentFormula> antecedent =
-                ImmutableSLList.singleton(ifCf);
+                ImmutableList.singleton(ifCf);
             ifSeq = JavaDLSequentKit.createAnteSequent(antecedent);
         }
 
@@ -218,7 +217,7 @@ public final class QueryAxiom extends ClassAxiom {
             tb.apply(update, tb.prog(JModality.JavaModalityKind.BOX, jb, post), null);
         final SequentFormula addedCf = new SequentFormula(addedFormula);
         final Sequent addedSeq =
-            JavaDLSequentKit.createAnteSequent(ImmutableSLList.singleton(addedCf));
+            JavaDLSequentKit.createAnteSequent(ImmutableList.singleton(addedCf));
 
         // build taclet
         final RewriteTacletBuilder<RewriteTaclet> tacletBuilder =
@@ -240,7 +239,7 @@ public final class QueryAxiom extends ClassAxiom {
         tacletBuilder.setApplicationRestriction(
             new ApplicationRestriction(ApplicationRestriction.SAME_UPDATE_LEVEL));
         tacletBuilder.addTacletGoalTemplate(
-            new RewriteTacletGoalTemplate(addedSeq, ImmutableSLList.nil(), replacewith));
+            new RewriteTacletGoalTemplate(addedSeq, ImmutableList.nil(), replacewith));
         tacletBuilder.setName(MiscTools.toValidTacletName(name));
         tacletBuilder.addRuleSet(new RuleSet(new Name("query_axiom")));
         // Originally used to be "simplify"

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/dl/translation/DLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/dl/translation/DLSpecFactory.java
@@ -32,7 +32,6 @@ import de.uka.ilkd.key.speclang.ContractFactory;
 import de.uka.ilkd.key.speclang.FunctionalOperationContract;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -143,7 +142,7 @@ public final class DLSpecFactory {
 
     private ImmutableList<LocationVariable> extractParamVars(
             UseOperationContractRule.Instantiation inst) throws ProofInputException {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (JTerm param : inst.actualParams()) {
             if (param.op() instanceof LocationVariable lv) {
                 result = result.append(lv);

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLInfoExtractor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLInfoExtractor.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -84,7 +83,7 @@ public final class JMLInfoExtractor {
     }
 
     private static ImmutableList<Comment> getJMLComments(MethodDeclaration method) {
-        ImmutableList<Comment> coms = ImmutableSLList.nil();
+        ImmutableList<Comment> coms = ImmutableList.nil();
 
         // Either method is attached to the method itself ...
         Comment[] methodComments = method.getComments();

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
@@ -67,7 +67,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
         ParameterlessTermLabel.IMPLICIT_SPECIFICATION_LABEL;
     private final Services services;
     private final JMLSpecFactory jsf;
-    private ImmutableList<PositionedString> warnings = ImmutableSLList.nil();
+    private ImmutableList<PositionedString> warnings = ImmutableList.nil();
 
     // -------------------------------------------------------------------------
     // constructors
@@ -575,7 +575,7 @@ public final class JMLSpecExtractor implements SpecExtractor {
         if (constructs.isEmpty()) {
             return result;
         }
-        TextualJMLConstruct c = constructs.take(constructs.size() - 1).head();
+        TextualJMLConstruct c = constructs.skip(constructs.size() - 1).head();
         if (c instanceof TextualJMLLoopSpec textualLoopSpec) {
             result = jsf.createJMLLoopInvariant(pm, loop, textualLoopSpec);
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatement.java
@@ -5,7 +5,7 @@ package de.uka.ilkd.key.speclang.jml.pretranslation;
 
 import de.uka.ilkd.key.nparser.KeyAst;
 
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.antlr.v4.runtime.RuleContext;
 
@@ -17,7 +17,7 @@ public class TextualJMLAssertStatement extends TextualJMLConstruct {
     private final Kind kind;
 
     public TextualJMLAssertStatement(Kind kind, KeyAst.Expression clause) {
-        super(ImmutableSLList.nil(), kind.toString() + " " + clause);
+        super(ImmutableList.nil(), kind.toString() + " " + clause);
         this.kind = kind;
         this.context = clause;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLClassAxiom.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLClassAxiom.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -26,8 +25,8 @@ public final class TextualJMLClassAxiom extends TextualJMLConstruct {
      */
     public TextualJMLClassAxiom(ImmutableList<JMLModifier> modifiers,
             LabeledParserRuleContext inv) {
-        super(ImmutableSLList.nil()); // no modifiers allowed in axiom clause (see
-                                      // Sect. 8 of reference manual)
+        super(ImmutableList.nil()); // no modifiers allowed in axiom clause (see
+                                    // Sect. 8 of reference manual)
         assert inv != null;
         this.inv = inv;
         setPosition(inv);

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDepends.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLDepends.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -28,11 +27,11 @@ public final class TextualJMLDepends extends TextualJMLConstruct {
         super(modifiers);
         setPosition(depends);
         for (Name hName : HeapLDT.VALID_HEAP_NAMES) {
-            this.depends.put(hName, ImmutableSLList.nil());
+            this.depends.put(hName, ImmutableList.nil());
         }
 
         for (Name heap : heaps) {
-            this.depends.put(heap, ImmutableSLList.singleton(depends));
+            this.depends.put(heap, ImmutableList.singleton(depends));
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLLoopSpec.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLLoopSpec.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.jspecify.annotations.Nullable;
@@ -137,14 +136,14 @@ public final class TextualJMLLoopSpec extends TextualJMLConstruct {
             if (clause.equals(entry.clauseType)) {
                 String h = (entry.heap != null ? entry.heap : defaultHeap).toString();
                 ImmutableList<LabeledParserRuleContext> l =
-                    map.getOrDefault(h, ImmutableSLList.nil());
+                    map.getOrDefault(h, ImmutableList.nil());
                 map.put(h, l.append(entry.ctx));
             }
         }
 
         for (Name h : HeapLDT.VALID_HEAP_NAMES) {
             if (!map.containsKey(h.toString())) {
-                map.put(h.toString(), ImmutableSLList.nil());
+                map.put(h.toString(), ImmutableList.nil());
             }
         }
         return map;
@@ -157,14 +156,14 @@ public final class TextualJMLLoopSpec extends TextualJMLConstruct {
             if (clause.equals(entry.clauseType)) {
                 String h = (entry.heap != null ? entry.heap : defaultHeap).toString();
                 ImmutableList<LabeledParserRuleContext> l =
-                    map.getOrDefault(h, ImmutableSLList.nil());
+                    map.getOrDefault(h, ImmutableList.nil());
                 map.put(h, l.append(entry.ctx));
             }
         }
 
         for (Name h : HeapLDT.VALID_HEAP_NAMES) {
             if (!map.containsKey(h.toString())) {
-                map.put(h.toString(), ImmutableSLList.nil());
+                map.put(h.toString(), ImmutableList.nil());
             }
         }
         return map;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
@@ -266,7 +266,7 @@ public class JMLSpecFactory {
     // internal classes
     // -------------------------------------------------------------------------
     public static class ContractClauses {
-        public ImmutableList<JTerm> abbreviations = ImmutableSLList.nil();
+        public ImmutableList<JTerm> abbreviations = ImmutableList.nil();
         public final Map<LocationVariable, JTerm> requires = new LinkedHashMap<>();
         public final Map<LocationVariable, JTerm> requiresFree = new LinkedHashMap<>();
         public JTerm measuredBy;
@@ -327,7 +327,7 @@ public class JMLSpecFactory {
      */
     private ImmutableList<LocationVariable> collectLocalVariables(StatementContainer sc,
             LoopStatement loop) {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (int i = 0, m = sc.getStatementCount(); i < m; i++) {
             Statement s = sc.getStatementAt(i);
 
@@ -569,7 +569,7 @@ public class JMLSpecFactory {
             final Boolean hasAssignable = clauses.hasAssignable.get(heap);
             if (hasAssignable == null || !hasAssignable) {
                 final ImmutableList<LabeledParserRuleContext> assignableNothing =
-                    ImmutableSLList.<LabeledParserRuleContext>nil().append(getAssignableNothing());
+                    ImmutableList.<LabeledParserRuleContext>nil().append(getAssignableNothing());
                 clauses.assignables.put(heap, translateAssignable(context, progVars.paramVars,
                     progVars.atPres, progVars.atBefores, assignableNothing));
             } else {
@@ -584,7 +584,7 @@ public class JMLSpecFactory {
             final Boolean hasFreeAssignable = clauses.hasFreeAssignable.get(heap);
             if (hasFreeAssignable == null || !hasFreeAssignable) {
                 final ImmutableList<LabeledParserRuleContext> assignableFreeNothing =
-                    ImmutableSLList
+                    ImmutableList
                             .<LabeledParserRuleContext>nil().append(getAssignableFreeNothing());
                 clauses.assignablesFree.put(heap,
                     translateAssignableFree(context, progVars.paramVars,
@@ -645,9 +645,9 @@ public class JMLSpecFactory {
             ImmutableList<LocationVariable> paramVars, LocationVariable resultVar,
             LocationVariable excVar, ImmutableList<LabeledParserRuleContext> originalClauses) {
         if (originalClauses.isEmpty()) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         } else {
-            ImmutableList<InfFlowSpec> result = ImmutableSLList.nil();
+            ImmutableList<InfFlowSpec> result = ImmutableList.nil();
             for (LabeledParserRuleContext expr : originalClauses) {
                 InfFlowSpec translated = new JmlIO(services).context(context).parameters(paramVars)
                         .resultVariable(resultVar).exceptionVariable(excVar).translateInfFlow(expr);
@@ -1189,7 +1189,7 @@ public class JMLSpecFactory {
         JTerm repFormula = tb.convertToFormula(rep.second);
         // create class axiom
         return new RepresentsAxiom("JML represents clause for " + rep.first.name(), rep.first, kjt,
-            visibility, null, repFormula, context.selfVar(), ImmutableSLList.nil(), null);
+            visibility, null, repFormula, context.selfVar(), ImmutableList.nil(), null);
     }
 
     public ClassAxiom createJMLRepresents(KeYJavaType kjt, TextualJMLRepresents textualRep)
@@ -1217,7 +1217,7 @@ public class JMLSpecFactory {
                 : "JML represents clause \"" + textualRep.getName() + "\" for " + rep.first.name();
         JTerm repFormula = tb.convertToFormula(rep.second);
         return new RepresentsAxiom(name, displayName, rep.first, kjt, getVisibility(textualRep),
-            null, repFormula, context.selfVar(), ImmutableSLList.nil(), null);
+            null, repFormula, context.selfVar(), ImmutableList.nil(), null);
     }
 
     /**
@@ -1375,7 +1375,7 @@ public class JMLSpecFactory {
                 tb.var(tb.atPreVar(param.toString(), param.sort(), false))));
 
             final MergeParamsSpec specs = new JmlIO(services).context(context)
-                    .parameters(append(ImmutableSLList.nil(), params))
+                    .parameters(append(ImmutableList.nil(), params))
                     .resultVariable(progVars.resultVar).exceptionVariable(progVars.excVar)
                     .atPres(atPres).translateMergeParams(ctx.mergeparamsspec());
 
@@ -1644,7 +1644,7 @@ public class JMLSpecFactory {
             vars = append(collectLocalVariables(method.getBody(), (For) first),
                 method.collectParameters()).append(collectLocalVariablesVisibleTo(block, method));
         } else {
-            vars = append(ImmutableSLList.nil(), method.collectParameters())
+            vars = append(ImmutableList.nil(), method.collectParameters())
                     .append(collectLocalVariablesVisibleTo(block, method));
         }
 
@@ -1670,7 +1670,7 @@ public class JMLSpecFactory {
 
     private ImmutableList<LocationVariable> collectLocalVariablesVisibleTo(Statement statement,
             StatementContainer container) {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         final int statementCount = container.getStatementCount();
         for (int i = 0; i < statementCount; i++) {
             final Statement s = container.getStatementAt(i);
@@ -1800,7 +1800,7 @@ public class JMLSpecFactory {
                 infFlowSpecTermList = translateInfFlowSpecClauses(context, allVars, resultVar,
                     excVar, originalInfFlowSpecs);
             } else {
-                infFlowSpecTermList = ImmutableSLList.nil();
+                infFlowSpecTermList = ImmutableList.nil();
             }
             infFlowSpecs.put(heap, infFlowSpecTermList);
         }
@@ -1846,7 +1846,7 @@ public class JMLSpecFactory {
     // Hence this little helper.
     private ImmutableList<LocationVariable> append(ImmutableList<LocationVariable> localVars,
             ImmutableList<LocationVariable> paramVars) {
-        ImmutableList<LocationVariable> result = ImmutableSLList.nil();
+        ImmutableList<LocationVariable> result = ImmutableList.nil();
         for (LocationVariable param : paramVars) {
             result = result.prepend(param);
         }
@@ -1875,7 +1875,7 @@ public class JMLSpecFactory {
     public FunctionalOperationContract initiallyClauseToContract(InitiallyClause ini,
             IProgramMethod pm) throws SLTranslationException {
         final ImmutableList<JMLModifier> modifiers =
-            ImmutableSLList.<JMLModifier>nil().append(JMLModifier.PRIVATE);
+            ImmutableList.<JMLModifier>singleton(JMLModifier.PRIVATE);
         final TextualJMLSpecCase specCase = new TextualJMLSpecCase(modifiers, Behavior.NONE);
         specCase.addName(ini.getName());
         for (LabeledParserRuleContext context : createPrecond(pm, ini.getOriginalSpec())) {
@@ -1903,7 +1903,7 @@ public class JMLSpecFactory {
 
     private ImmutableList<LabeledParserRuleContext> createPrecond(IProgramMethod pm,
             LabeledParserRuleContext originalSpec) {
-        ImmutableList<LabeledParserRuleContext> res = ImmutableSLList.nil();
+        ImmutableList<LabeledParserRuleContext> res = ImmutableList.nil();
         // TODO: add static invariant
         for (ParameterDeclaration p : pm.getMethodDeclaration().getParameters()) {
             if (!JMLInfoExtractor.parameterIsNullable(pm, p)) {

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
@@ -25,7 +25,6 @@ import de.uka.ilkd.key.util.parsing.BuildingExceptions;
 import de.uka.ilkd.key.util.parsing.BuildingIssue;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -51,7 +50,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class JmlIO {
 
-    private ImmutableList<PositionedString> warnings = ImmutableSLList.nil();
+    private ImmutableList<PositionedString> warnings = ImmutableList.nil();
 
     private final Services services;
 
@@ -422,7 +421,7 @@ public class JmlIO {
         this.specMathMode = null;
         clearWarnings();
         exceptionVariable(null);
-        parameters(ImmutableSLList.nil());
+        parameters(ImmutableList.nil());
         return this;
     }
 
@@ -436,6 +435,6 @@ public class JmlIO {
     }
 
     public void clearWarnings() {
-        warnings = ImmutableSLList.nil();
+        warnings = ImmutableList.nil();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlTermFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlTermFactory.java
@@ -35,7 +35,6 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.antlr.v4.runtime.Token;
@@ -380,7 +379,7 @@ public final class JmlTermFactory {
         if (it.hasNext() || !isBoundedNumerical(t1, lv)) {
             // not interval range, create unbounded comprehension term
             ImmutableList<LogicVariable> _qvs =
-                ImmutableSLList.<LogicVariable>nil().prepend(lv);
+                ImmutableList.<LogicVariable>singleton(lv);
             while (it.hasNext()) {
                 _qvs = _qvs.prepend(it.next());
             }
@@ -908,7 +907,7 @@ public final class JmlTermFactory {
                     || t.op().equals(locSetLDT.getSingleton())) {
                 return t;
             } else {
-                ImmutableList<SLExpression> exprList = ImmutableSLList.nil();
+                ImmutableList<SLExpression> exprList = ImmutableList.nil();
                 exprList = exprList.append(expr);
                 return createLocSet(exprList);
             }
@@ -917,7 +916,7 @@ public final class JmlTermFactory {
     }
 
     public JTerm createLocSet(ImmutableList<SLExpression> exprList) {
-        ImmutableList<JTerm> singletons = ImmutableSLList.nil();
+        ImmutableList<JTerm> singletons = ImmutableList.nil();
         for (SLExpression expr : exprList) {
             if (expr.isTerm()) {
                 JTerm t = expr.getTerm();
@@ -956,7 +955,7 @@ public final class JmlTermFactory {
     }
 
     public SLExpression createPairwiseDisjoint(ImmutableList<JTerm> list) {
-        ImmutableList<JTerm> disTerms = ImmutableSLList.nil();
+        ImmutableList<JTerm> disTerms = ImmutableList.nil();
         while (!list.isEmpty()) {
             JTerm t1 = list.head();
             list = list.tail();
@@ -978,7 +977,7 @@ public final class JmlTermFactory {
     }
 
     public SLExpression seqConst(ImmutableList<SLExpression> exprList) {
-        ImmutableList<JTerm> terms = ImmutableSLList.nil();
+        ImmutableList<JTerm> terms = ImmutableList.nil();
         for (SLExpression expr : exprList) {
             if (expr.isTerm()) {
                 JTerm t = ensureTerm(expr.getTerm());
@@ -1261,7 +1260,7 @@ public final class JmlTermFactory {
 
             JTerm[] args;
             if (list == null) {
-                list = ImmutableSLList.nil();
+                list = ImmutableList.nil();
             }
 
             JTerm heap = tb.getBaseHeap();

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/TextualTranslator.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.*;
 
 import org.key_project.logic.Name;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -38,8 +37,8 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
 
     private final boolean attachOriginLabel;
 
-    public ImmutableList<TextualJMLConstruct> constructs = ImmutableSLList.nil();
-    public ImmutableList<JMLModifier> mods = ImmutableSLList.nil();
+    public ImmutableList<TextualJMLConstruct> constructs = ImmutableList.nil();
+    public ImmutableList<JMLModifier> mods = ImmutableList.nil();
     private @Nullable TextualJMLSpecCase methodContract;
     private @Nullable TextualJMLLoopSpec loopContract;
 
@@ -102,7 +101,7 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
      */
     protected void finishConstruct(TextualJMLConstruct construct) {
         constructs = constructs.append(construct);
-        mods = ImmutableSLList.nil();
+        mods = ImmutableList.nil();
         methodContract = null;
         loopContract = null;
     }
@@ -133,7 +132,7 @@ class TextualTranslator extends JmlParserBaseVisitor<Object> {
         constructs = constructs.append(methodContract);
         super.visitSpec_body(ctx.spec_body());
         methodContract = null;
-        mods = ImmutableSLList.nil();
+        mods = ImmutableList.nil();
         return null;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/Translator.java
@@ -43,7 +43,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -146,7 +145,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @SuppressWarnings("unchecked")
     private <T> ImmutableList<T> listOf(List<? extends ParserRuleContext> contexts) {
-        ImmutableList<T> seq = ImmutableSLList.nil();
+        ImmutableList<T> seq = ImmutableList.nil();
         for (ParserRuleContext context : contexts) {
             seq = seq.append((T) accept(context));
         }
@@ -327,7 +326,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public ImmutableList<JTerm> visitStoreRefList(JmlParser.StoreRefListContext ctx) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JmlParser.StorerefContext context : ctx.storeref()) {
             result = result.append((JTerm) accept(context));
         }
@@ -361,7 +360,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     public Object visitCreateLocset(JmlParser.CreateLocsetContext ctx) {
         JmlParser.ExprListContext exprList = ctx.exprList();
         if (exprList == null) {
-            return termFactory.createLocSet(ImmutableSLList.nil());
+            return termFactory.createLocSet(ImmutableList.nil());
         } else {
             return termFactory.createLocSet(requireNonNull(accept(exprList)));
         }
@@ -370,7 +369,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public ImmutableList<SLExpression> visitExprList(JmlParser.ExprListContext ctx) {
-        ImmutableList<SLExpression> result = ImmutableSLList.nil();
+        ImmutableList<SLExpression> result = ImmutableList.nil();
         for (JmlParser.ExpressionContext context : ctx.expression()) {
             result = result.append((SLExpression) accept(context));
         }
@@ -1122,7 +1121,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     private SLParameters visitParameters(JmlParser.Param_listContext ctx) {
         ImmutableList<SLExpression> params =
             ctx.param_decl().stream().map(it -> lookupIdentifier(it.p.getText(), null, null, it))
-                    .collect(ImmutableSLList.toImmutableList());
+                    .collect(ImmutableList.collector());
         return getSlParametersWithHeap(params);
     }
 
@@ -1132,7 +1131,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     }
 
     private SLParameters getSlParametersWithHeap(ImmutableList<SLExpression> params) {
-        ImmutableList<SLExpression> preHeapParams = ImmutableSLList.nil();
+        ImmutableList<SLExpression> preHeapParams = ImmutableList.nil();
         for (LocationVariable heap : HeapContext.getModifiableHeaps(services, false)) {
             JTerm p;
             if (atPres == null || atPres.get(heap) == null) {
@@ -1540,7 +1539,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     @Override
     public Object visitPrimaryStoreRef(JmlParser.PrimaryStoreRefContext ctx) {
         if (ctx.storeRefUnion() == null) {
-            return new SLExpression(termFactory.createLocSet(ImmutableSLList.nil()));
+            return new SLExpression(termFactory.createLocSet(ImmutableList.nil()));
         }
         JTerm t = accept(ctx.storeRefUnion());
         return new SLExpression(t, javaInfo.getPrimitiveKeYJavaType(PrimitiveType.JAVA_LOCSET));
@@ -1865,7 +1864,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     @Override
     public Pair<KeYJavaType, ImmutableList<LogicVariable>> visitQuantifiedvardecls(
             JmlParser.QuantifiedvardeclsContext ctx) {
-        ImmutableList<LogicVariable> vars = ImmutableSLList.nil();
+        ImmutableList<LogicVariable> vars = ImmutableList.nil();
         KeYJavaType t = accept(ctx.typespec());
         for (JmlParser.QuantifiedvariabledeclaratorContext context : ctx
                 .quantifiedvariabledeclarator()) {
@@ -2026,7 +2025,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public SLExpression visitSignals_only_clause(JmlParser.Signals_only_clauseContext ctx) {
-        ImmutableList<KeYJavaType> typeList = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> typeList = ImmutableList.nil();
         for (JmlParser.ReferencetypeContext context : ctx.referencetype()) {
             typeList = typeList.append((KeYJavaType) accept(context));
         }
@@ -2069,7 +2068,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public ImmutableList<String> visitModifiers(JmlParser.ModifiersContext ctx) {
-        mods = ImmutableSLList.nil();
+        mods = ImmutableList.nil();
         return mods;
     }
 
@@ -2257,9 +2256,9 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public InfFlowSpec visitSeparates_clause(JmlParser.Separates_clauseContext ctx) {
-        ImmutableList<JTerm> decl = ImmutableSLList.nil();
-        ImmutableList<JTerm> erases = ImmutableSLList.nil();
-        ImmutableList<JTerm> newObs = ImmutableSLList.nil();
+        ImmutableList<JTerm> decl = ImmutableList.nil();
+        ImmutableList<JTerm> erases = ImmutableList.nil();
+        ImmutableList<JTerm> newObs = ImmutableList.nil();
 
         ImmutableList<JTerm> sep = accept(ctx.sep);
 
@@ -2275,17 +2274,17 @@ class Translator extends JmlParserBaseVisitor<Object> {
     @Override
     public Object visitLoop_separates_clause(JmlParser.Loop_separates_clauseContext ctx) {
         ImmutableList<JTerm> sep = accept(ctx.sep);
-        ImmutableList<JTerm> newObs = ImmutableSLList.nil();
+        ImmutableList<JTerm> newObs = ImmutableList.nil();
         newObs = append(newObs, ctx.newobj);
         return new InfFlowSpec(sep, sep, newObs);
     }
 
     @Override
     public Object visitDetermines_clause(JmlParser.Determines_clauseContext ctx) {
-        ImmutableList<JTerm> decl = ImmutableSLList.nil();
-        ImmutableList<JTerm> erases = ImmutableSLList.nil();
-        ImmutableList<JTerm> newObs = ImmutableSLList.nil();
-        ImmutableList<JTerm> by = ImmutableSLList.nil();
+        ImmutableList<JTerm> decl = ImmutableList.nil();
+        ImmutableList<JTerm> erases = ImmutableList.nil();
+        ImmutableList<JTerm> newObs = ImmutableList.nil();
+        ImmutableList<JTerm> by = ImmutableList.nil();
 
         ImmutableList<JTerm> determined = accept(ctx.determined);
 
@@ -2311,8 +2310,8 @@ class Translator extends JmlParserBaseVisitor<Object> {
 
     @Override
     public Object visitLoop_determines_clause(JmlParser.Loop_determines_clauseContext ctx) {
-        ImmutableList<JTerm> newObs = ImmutableSLList.nil();
-        ImmutableList<JTerm> det = append(ImmutableSLList.nil(), ctx.det);
+        ImmutableList<JTerm> newObs = ImmutableList.nil();
+        ImmutableList<JTerm> det = append(ImmutableList.nil(), ctx.det);
         newObs = append(newObs, ctx.newObs);
         return new InfFlowSpec(det, det, newObs);
     }
@@ -2320,7 +2319,7 @@ class Translator extends JmlParserBaseVisitor<Object> {
     @Override
     public ImmutableList<JTerm> visitInfflowspeclist(JmlParser.InfflowspeclistContext ctx) {
         if (ctx.NOTHING() != null) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
         ImmutableList<SLExpression> seq = accept(ctx.expressionlist());
         assert seq != null;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLParameters.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLParameters.java
@@ -9,7 +9,6 @@ import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.JTerm;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Wraps a list of expressions.
@@ -31,7 +30,7 @@ public record SLParameters(ImmutableList<SLExpression> parameters) {
      * @return the list of types that compose the type signature
      */
     public ImmutableList<KeYJavaType> getSignature(Services services) {
-        ImmutableList<KeYJavaType> result = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> result = ImmutableList.nil();
         for (SLExpression expr : parameters) {
             KeYJavaType type = expr.getType();
             if (type == null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLResolverManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLResolverManager.java
@@ -18,7 +18,6 @@ import org.key_project.logic.Name;
 import org.key_project.logic.Namespace;
 import org.key_project.logic.op.ParsableVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -31,16 +30,16 @@ public abstract class SLResolverManager {
     public final SLExceptionFactory excManager;
 
     private ImmutableList<SLExpressionResolver> resolvers =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
     private final KeYJavaType specInClass;
     private final LocationVariable selfVar;
     private final TermBuilder tb;
 
     private ImmutableList<Namespace<LocationVariable>> localVariablesNamespaces =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
 
     private ImmutableList<Namespace<LogicVariable>> logicVariablesNamespaces =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
 
     private final Map<ParsableVariable, KeYJavaType> kjts = new LinkedHashMap<>();
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/AbstractFeatureStrategy.java
@@ -31,7 +31,6 @@ import org.key_project.prover.strategy.costbased.termProjection.TermBuffer;
 import org.key_project.prover.strategy.costbased.termfeature.TermFeature;
 import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -72,7 +71,7 @@ public abstract class AbstractFeatureStrategy extends StaticFeatureCollection
     }
 
     protected TacletFilter getFilterFor(String[] p_names) {
-        ImmutableList<RuleSet> heur = ImmutableSLList.nil();
+        ImmutableList<RuleSet> heur = ImmutableList.nil();
         for (int i = 0; i != p_names.length; ++i) {
             heur = heur.prepend(getHeuristic(p_names[i]));
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/AssumesInstantiator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/AssumesInstantiator.java
@@ -24,7 +24,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This class implements custom instantiation of if-formulas.
@@ -36,7 +35,7 @@ public class AssumesInstantiator {
     private ImmutableArray<AssumesFormulaInstantiation> allAntecFormulas;
     private ImmutableArray<AssumesFormulaInstantiation> allSuccFormulas;
 
-    private ImmutableList<NoPosTacletApp> results = ImmutableSLList.nil();
+    private ImmutableList<NoPosTacletApp> results = ImmutableList.nil();
 
     private final TacletAppContainer tacletAppContainer;
 
@@ -79,7 +78,7 @@ public class AssumesInstantiator {
                                                                                       //// with the
                                                                                       //// last
                                                                                       //// formula
-                ifSequent.antecedent().asList().reverse(), ImmutableSLList.nil(),
+                ifSequent.antecedent().asList().reverse(), ImmutableList.nil(),
                 tacletAppContainer.getTacletApp().matchConditions(), false);
         }
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/BuiltInRuleAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/BuiltInRuleAppContainer.java
@@ -13,7 +13,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.RuleAppCost;
 import org.key_project.prover.strategy.costbased.TopRuleAppCost;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -115,7 +114,7 @@ public class BuiltInRuleAppContainer extends RuleAppContainer {
     static ImmutableList<RuleAppContainer> createInitialAppContainers(
             ImmutableList<IBuiltInRuleApp> birs, PosInOccurrence pio,
             Goal goal) {
-        ImmutableList<RuleAppContainer> result = ImmutableSLList.nil();
+        ImmutableList<RuleAppContainer> result = ImmutableList.nil();
 
         for (IBuiltInRuleApp bir : birs) {
             result = result.prepend(createAppContainer(bir, pio, goal));
@@ -129,16 +128,16 @@ public class BuiltInRuleAppContainer extends RuleAppContainer {
     @Override
     public ImmutableList<RuleAppContainer> createFurtherApps(Goal goal) {
         if (!isStillApplicable(goal)) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
         final PosInOccurrence pio = getPosInOccurrence(goal);
 
         RuleAppContainer container = createAppContainer(bir, pio, goal);
         if (container.getCost() instanceof TopRuleAppCost) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
-        return ImmutableSLList.<RuleAppContainer>nil().prepend(container);
+        return ImmutableList.<RuleAppContainer>singleton(container);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedBreakpointRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedBreakpointRuleApplicationManager.java
@@ -16,7 +16,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.DelegationBasedRuleApplicationManager;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -91,7 +90,7 @@ public class FocussedBreakpointRuleApplicationManager
     public void rulesAdded(ImmutableList<? extends RuleApp> rules,
             PosInOccurrence pos) {
         ImmutableList<RuleApp> applicableRules = //
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         for (RuleApp r : rules) {
             if (mayAddRule(r, pos)) {
                 applicableRules = applicableRules.prepend(r);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/FocussedRuleApplicationManager.java
@@ -15,7 +15,6 @@ import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.feature.BinaryFeature;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * A rule app manager that ensures that rules are only applied to a certain subterm within the proof
@@ -133,7 +132,7 @@ public class FocussedRuleApplicationManager
     @Override
     public void rulesAdded(ImmutableList<? extends RuleApp> rules,
             PosInOccurrence pos) {
-        ImmutableList<RuleApp> applicableRules = ImmutableSLList.nil();
+        ImmutableList<RuleApp> applicableRules = ImmutableList.nil();
         for (RuleApp r : rules) {
             if (isRuleApplicationForFocussedFormula(r, pos)) {
                 applicableRules = applicableRules.prepend(r);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -34,7 +34,6 @@ import org.key_project.prover.strategy.costbased.feature.Feature;
 import org.key_project.util.collection.ImmutableHeap;
 import org.key_project.util.collection.ImmutableLeftistHeap;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -334,7 +333,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
          * Working list contains rule apps that cannot be completed in the current round but will be
          * reconsidered during the next round.
          */
-        ImmutableList<RuleAppContainer> workingList = ImmutableSLList.nil();
+        ImmutableList<RuleAppContainer> workingList = ImmutableList.nil();
 
         // Wake parked assumes-bases whose \assumes top operator matches a formula added/modified
         // since the last round, re-inserting them into the active queue so they re-expand during

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/RuleAppContainer.java
@@ -13,7 +13,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.NumberRuleAppCost;
 import org.key_project.prover.strategy.costbased.RuleAppCost;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -108,15 +107,15 @@ public abstract class RuleAppContainer implements Comparable<RuleAppContainer> {
     public static ImmutableList<RuleAppContainer> createAppContainers(
             ImmutableList<? extends RuleApp> rules,
             PosInOccurrence pos, Goal goal) {
-        ImmutableList<RuleAppContainer> result = ImmutableSLList.nil();
+        ImmutableList<RuleAppContainer> result = ImmutableList.nil();
 
         if (rules.size() == 1) {
             result = result.prepend(createAppContainer(rules.head(), pos, goal));
         } else if (rules.size() > 1) {
             ImmutableList<NoPosTacletApp> tacletApplications =
-                ImmutableSLList.nil();
+                ImmutableList.nil();
             ImmutableList<IBuiltInRuleApp> builtInRuleApplications =
-                ImmutableSLList.nil();
+                ImmutableList.nil();
 
             for (RuleApp rule : rules) {
                 if (rule instanceof NoPosTacletApp) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/TacletAppContainer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/TacletAppContainer.java
@@ -24,7 +24,6 @@ import org.key_project.prover.strategy.costbased.RuleAppCost;
 import org.key_project.prover.strategy.costbased.TopRuleAppCost;
 import org.key_project.prover.strategy.costbased.feature.Feature;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.Nullable;
@@ -110,20 +109,20 @@ public abstract class TacletAppContainer extends RuleAppContainer {
         if (!isStillApplicable(p_goal)
                 || (getTacletApp().assumesInstantionsComplete()
                         && !assumesFormulasStillValid(p_goal))) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
         final TacletAppContainer newCont = costLocalReusedContainerOr(p_goal);
         if (newCont == null) {
             // a veto fired on the cost-local fast path: the re-costed base would be infinite
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
         if (newCont.getCost() instanceof TopRuleAppCost) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
         ImmutableList<RuleAppContainer> res =
-            ImmutableSLList.<RuleAppContainer>nil().prepend(newCont);
+            ImmutableList.<RuleAppContainer>singleton(newCont);
 
         if (getTacletApp().assumesInstantionsComplete()) {
             res = addInstances(getTacletApp(), res, p_goal);
@@ -268,7 +267,7 @@ public abstract class TacletAppContainer extends RuleAppContainer {
             costs.add(p_goal.getGoalStrategy().computeCost(app, p_pio, p_goal));
         }
 
-        ImmutableList<RuleAppContainer> result = ImmutableSLList.nil();
+        ImmutableList<RuleAppContainer> result = ImmutableList.nil();
         for (RuleAppCost cost : costs) {
             final TacletAppContainer container =
                 createContainer(p_app.head(), p_pio, p_goal, cost, true);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/DependencyContractFeature.java
@@ -19,7 +19,7 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.feature.BinaryFeature;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -73,7 +73,7 @@ public final class DependencyContractFeature extends BinaryFeature {
         }
 
         // instantiate with arbitrary remaining step
-        bapp = bapp.setAssumesInsts(ImmutableSLList.<PosInOccurrence>nil().prepend(steps.get(0)));
+        bapp = bapp.setAssumesInsts(ImmutableList.<PosInOccurrence>singleton(steps.get(0)));
         return true;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/SmallerThanFeature.java
@@ -10,7 +10,6 @@ import de.uka.ilkd.key.proof.Goal;
 import org.key_project.logic.Term;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -51,7 +50,7 @@ public abstract class SmallerThanFeature extends BinaryTacletAppFeature {
 
     protected abstract static class Collector {
 
-        private ImmutableList<Term> terms = ImmutableSLList.nil();
+        private ImmutableList<Term> terms = ImmutableList.nil();
 
         protected void addTerm(Term mon) {
             terms = terms.prepend(mon);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/instantiator/SVInstantiationCP.java
@@ -24,7 +24,7 @@ import org.key_project.prover.strategy.costbased.feature.instantiator.BackTracki
 import org.key_project.prover.strategy.costbased.feature.instantiator.CPBranch;
 import org.key_project.prover.strategy.costbased.feature.instantiator.ChoicePoint;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -124,7 +124,7 @@ public class SVInstantiationCP implements Feature {
                 public RuleApp getRuleAppForBranch() { return newApp; }
             };
 
-            return ImmutableSLList.<CPBranch>nil().prepend(branch).iterator();
+            return ImmutableList.<CPBranch>singleton(branch).iterator();
         }
 
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/EqualityConstraint.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/EqualityConstraint.java
@@ -25,7 +25,6 @@ import org.key_project.logic.sort.Sort;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import static de.uka.ilkd.key.logic.equality.RenamingSourceElementProperty.RENAMING_SOURCE_ELEMENT_PROPERTY;
@@ -538,8 +537,8 @@ public class EqualityConstraint implements Constraint {
      *         modified. <code>Constraint.TOP</code> is always returned for ununifiable terms
      */
     private Constraint unifyHelp(JTerm t1, JTerm t2, boolean modifyThis, Services services) {
-        return unifyHelp(t1, t2, ImmutableSLList.nil(),
-            ImmutableSLList.nil(), null, modifyThis, services);
+        return unifyHelp(t1, t2, ImmutableList.nil(),
+            ImmutableList.nil(), null, modifyThis, services);
     }
 
 
@@ -742,8 +741,8 @@ public class EqualityConstraint implements Constraint {
      * @return a boolean that is true iff. adding a mapping (mv,term) would cause a cycle
      */
     private boolean hasCycle(Metavariable mv, JTerm term, Services services) {
-        ImmutableList<Metavariable> body = ImmutableSLList.nil();
-        ImmutableList<JTerm> fringe = ImmutableSLList.nil();
+        ImmutableList<Metavariable> body = ImmutableList.nil();
+        ImmutableList<JTerm> fringe = ImmutableList.nil();
         JTerm checkForCycle = term;
 
         while (true) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Instantiation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Instantiation.java
@@ -24,7 +24,6 @@ import org.key_project.util.collection.DefaultImmutableMap;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 class Instantiation {
@@ -75,7 +74,7 @@ class Instantiation {
     }
 
     private static ImmutableSet<Term> sequentToTerms(Sequent seq) {
-        ImmutableList<Term> res = ImmutableSLList.nil();
+        ImmutableList<Term> res = ImmutableList.nil();
         for (final SequentFormula cf : seq) {
             res = res.prepend(cf.formula());
         }
@@ -150,7 +149,7 @@ class Instantiation {
      */
     private ImmutableSet<JTerm> initAssertLiterals(Sequent seq,
             TermServices services) {
-        ImmutableList<JTerm> assertLits = ImmutableSLList.nil();
+        ImmutableList<JTerm> assertLits = ImmutableList.nil();
         for (final SequentFormula cf : seq.antecedent()) {
             final Term atom = cf.formula();
             final var op = atom.op();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/MultiTrigger.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/MultiTrigger.java
@@ -13,7 +13,6 @@ import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableMapEntry;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 class MultiTrigger implements Trigger {
@@ -34,7 +33,7 @@ class MultiTrigger implements Trigger {
     @Override
     public ImmutableSet<Substitution> getSubstitutionsFromTerms(ImmutableSet<Term> targetTerms,
             Services services) {
-        ImmutableList<Substitution> res = ImmutableSLList.nil();
+        ImmutableList<Substitution> res = ImmutableList.nil();
 
         ImmutableSet<Substitution> mulsubs =
             setMultiSubstitution(triggers.iterator(), targetTerms, services);
@@ -51,7 +50,7 @@ class MultiTrigger implements Trigger {
     /** help function for getMultiSubstitution */
     private ImmutableSet<Substitution> setMultiSubstitution(Iterator<? extends Trigger> ts,
             ImmutableSet<Term> terms, Services services) {
-        ImmutableList<Substitution> res = ImmutableSLList.nil();
+        ImmutableList<Substitution> res = ImmutableList.nil();
         if (ts.hasNext()) {
             ImmutableSet<Substitution> subi = ts.next().getSubstitutionsFromTerms(terms, services);
             ImmutableSet<Substitution> nextSubs = setMultiSubstitution(ts, terms, services);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/UniTrigger.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/UniTrigger.java
@@ -14,7 +14,6 @@ import org.key_project.util.LRUCache;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 
@@ -138,8 +137,8 @@ class UniTrigger implements Trigger {
     private static boolean containsLoop(
             ImmutableMap<QuantifiableVariable, Term> varMap,
             QuantifiableVariable var) {
-        ImmutableList<QuantifiableVariable> body = ImmutableSLList.nil();
-        ImmutableList<Term> fringe = ImmutableSLList.nil();
+        ImmutableList<QuantifiableVariable> body = ImmutableList.nil();
+        ImmutableList<Term> fringe = ImmutableList.nil();
         Term checkForCycle = varMap.get(var);
 
         if (checkForCycle.op() == var) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
@@ -40,6 +40,6 @@ public class AssumptionProjection implements ProjectionToTerm<Goal> {
                     + " but got "
                     + app;
 
-        return tapp.assumesFormulaInstantiations().take(no).head().getSequentFormula().formula();
+        return tapp.assumesFormulaInstantiations().get(no).getSequentFormula().formula();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/MultiplesModEquationsGenerator.java
@@ -23,7 +23,6 @@ import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Try to rewrite a monomial (term) <code>source</code> so that it becomes a multiple of another
@@ -70,14 +69,14 @@ public class MultiplesModEquationsGenerator implements TermGenerator<Goal> {
         final List<CofactorPolynomial> cofactorPolys = extractPolys(goal, services);
 
         if (cofactorPolys.isEmpty()) {
-            return ImmutableSLList.<Term>nil().iterator();
+            return ImmutableList.<Term>nil().iterator();
         }
 
         return computeMultiples(sourceM, targetM, cofactorPolys, services).iterator();
     }
 
     private Iterator<Term> toIterator(Term quotient) {
-        return ImmutableSLList.<Term>nil().prepend(quotient).iterator();
+        return ImmutableList.<Term>singleton(quotient).iterator();
     }
 
     /**
@@ -89,7 +88,7 @@ public class MultiplesModEquationsGenerator implements TermGenerator<Goal> {
      */
     private ImmutableList<Term> computeMultiples(Monomial sourceM, Monomial targetM,
             List<CofactorPolynomial> cofactorPolys, Services services) {
-        ImmutableList<Term> res = ImmutableSLList.nil();
+        ImmutableList<Term> res = ImmutableList.nil();
 
         final List<CofactorItem> cofactorMonos = new ArrayList<>();
         cofactorMonos.add(new CofactorMonomial(targetM, Polynomial.ONE));

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/RootsGenerator.java
@@ -22,7 +22,7 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import static de.uka.ilkd.key.logic.equality.IrrelevantTermLabelsProperty.IRRELEVANT_TERM_LABELS_PROPERTY;
 
@@ -90,7 +90,7 @@ public class RootsGenerator implements TermGenerator<Goal> {
     }
 
     private Iterator<Term> emptyIterator() {
-        return ImmutableSLList.<Term>nil().iterator();
+        return ImmutableList.<Term>nil().iterator();
     }
 
     private Iterator<Term> toIterator(Term res) {
@@ -98,7 +98,7 @@ public class RootsGenerator implements TermGenerator<Goal> {
             tb.ff())) {
             return emptyIterator();
         }
-        return ImmutableSLList.<Term>nil().prepend(res).iterator();
+        return ImmutableList.<Term>singleton(res).iterator();
     }
 
     private Term breakDownEq(Term p_var, BigInteger lit, int pow) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termgenerator/TriggeredInstantiations.java
@@ -36,7 +36,6 @@ import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
 import org.key_project.util.collection.DefaultImmutableMap;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 public class TriggeredInstantiations implements TermGenerator<Goal> {
@@ -125,10 +124,10 @@ public class TriggeredInstantiations implements TermGenerator<Goal> {
                 } else {
                     // at the moment instantiations with more than one
                     // missing taclet variable not supported
-                    return ImmutableSLList.<org.key_project.logic.Term>nil().iterator();
+                    return ImmutableList.<org.key_project.logic.Term>nil().iterator();
                 }
             } else {
-                return ImmutableSLList.<org.key_project.logic.Term>nil().iterator();
+                return ImmutableList.<org.key_project.logic.Term>nil().iterator();
             }
 
         } else {
@@ -216,7 +215,7 @@ public class TriggeredInstantiations implements TermGenerator<Goal> {
     private ImmutableList<JTerm> instantiateConditions(Services services, TacletApp app,
             final JTerm middle) {
         ImmutableList<JTerm> conditions;
-        conditions = ImmutableSLList.nil();
+        conditions = ImmutableList.nil();
         for (var singleAvoidCond : app.taclet().getTrigger().avoidConditions()) {
             conditions =
                 conditions.append(

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/DefaultTacletTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/DefaultTacletTranslator.java
@@ -22,7 +22,6 @@ import org.key_project.prover.rules.ApplicationRestriction;
 import org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Translates a rewrite taclet to a formula.
@@ -164,7 +163,7 @@ public class DefaultTacletTranslator extends AbstractSkeletonGenerator {
         }
 
         // translate the replace and add patterns of the taclet.
-        ImmutableList<JTerm> list = ImmutableSLList.nil();
+        ImmutableList<JTerm> list = ImmutableList.nil();
 
         for (TacletGoalTemplate template : taclet.goalTemplates()) {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/SkeletonGenerator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/SkeletonGenerator.java
@@ -12,7 +12,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public interface SkeletonGenerator {
     SkeletonGenerator DEFAULT_TACLET_TRANSLATOR = new DefaultTacletTranslator();
@@ -71,7 +70,7 @@ abstract class AbstractSkeletonGenerator implements SkeletonGenerator {
      * @return A list of all formulae of the semisequent <code>s </code>.
      */
     private ImmutableList<JTerm> getFormulaeOfSemisequent(Semisequent s) {
-        ImmutableList<JTerm> terms = ImmutableSLList.nil();
+        ImmutableList<JTerm> terms = ImmutableList.nil();
         for (SequentFormula cf : s) {
             terms = terms.append((JTerm) cf.formula());
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/DefaultTacletSetTranslation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/DefaultTacletSetTranslation.java
@@ -25,7 +25,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.IOUtil;
 
@@ -42,17 +41,17 @@ public final class DefaultTacletSetTranslation
      * Translation of the taclets stored in <code>taclets</code>.
      *
      */
-    private ImmutableList<TacletFormula> translation = ImmutableSLList.nil();
+    private ImmutableList<TacletFormula> translation = ImmutableList.nil();
 
     /**
      * Taclets can not be translated because checking the taclet failed.
      */
-    private ImmutableList<TacletFormula> notTranslated = ImmutableSLList.nil();
+    private ImmutableList<TacletFormula> notTranslated = ImmutableList.nil();
 
     /**
      * If a instantiation failure occurs the returned information is stored in a String.
      */
-    private final ImmutableList<String> instantiationFailures = ImmutableSLList.nil();
+    private final ImmutableList<String> instantiationFailures = ImmutableList.nil();
 
 
     private ImmutableSet<Sort> usedFormulaSorts = DefaultImmutableSet.nil();
@@ -95,8 +94,8 @@ public final class DefaultTacletSetTranslation
         }
         translate = false;
         usedSorts.clear();
-        notTranslated = ImmutableSLList.nil();
-        translation = ImmutableSLList.nil();
+        notTranslated = ImmutableList.nil();
+        translation = ImmutableList.nil();
 
         ImmutableSet<Sort> emptySetSort = DefaultImmutableSet.nil();
         usedFormulaSorts = (sorts == null ? emptySetSort : sorts);

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/GenericTranslator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/GenericTranslator.java
@@ -24,7 +24,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 class GenericTranslator {
@@ -217,7 +216,7 @@ class GenericTranslator {
     private ImmutableList<JTerm> instantiateGeneric(JTerm term, Set<GenericSort> genericSorts,
             ImmutableSet<Sort> instSorts, Taclet t, TacletConditions conditions, int maxGeneric)
             throws IllegalTacletException {
-        ImmutableList<JTerm> instantiatedTerms = ImmutableSLList.nil();
+        ImmutableList<JTerm> instantiatedTerms = ImmutableList.nil();
         if (maxGeneric < genericSorts.size()) {
             throw new IllegalTacletException("To many different generic sorts. Found: "
                 + genericSorts.size() + " Allowed: " + maxGeneric);

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/TacletConditions.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/assumptions/TacletConditions.java
@@ -17,7 +17,6 @@ import de.uka.ilkd.key.taclettranslation.IllegalTacletException;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.VariableCondition;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * This class is used for wrapping all variable conditions of a taclet in one object.
@@ -25,12 +24,12 @@ import org.key_project.util.collection.ImmutableSLList;
 class TacletConditions {
 
     //
-    private ImmutableList<TypeComparisonCondition> comparisionCondition = ImmutableSLList.nil();
-    private ImmutableList<TypeCondition> typeCondition = ImmutableSLList.nil();
+    private ImmutableList<TypeComparisonCondition> comparisionCondition = ImmutableList.nil();
+    private ImmutableList<TypeCondition> typeCondition = ImmutableList.nil();
     private ImmutableList<AbstractOrInterfaceType> abstractInterfaceCondition =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
     private ImmutableList<ArrayComponentTypeCondition> arrayComponentCondition =
-        ImmutableSLList.nil();
+        ImmutableList.nil();
 
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/TacletLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/taclettranslation/lemma/TacletLoader.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.util.ProgressMonitor;
 
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 public abstract class TacletLoader {
@@ -82,7 +81,7 @@ public abstract class TacletLoader {
     public void manageAvailableTaclets(InitConfig initConfig, Taclet tacletToProve) {
         ImmutableList<Taclet> sysTaclets = initConfig.getTaclets();
 
-        ImmutableList<Taclet> newTaclets = ImmutableSLList.nil();
+        ImmutableList<Taclet> newTaclets = ImmutableList.nil();
         Map<Taclet, TacletBuilder<? extends Taclet>> map = initConfig.getTaclet2Builder();
         boolean tacletfound = false;
         for (Taclet taclet : sysTaclets) {
@@ -177,7 +176,9 @@ public abstract class TacletLoader {
 
             ImmutableList<Taclet> listAfter = initConfig.getTaclets();
 
-            return listAfter.take(sizeBefore);
+            // weigl: This implementation is no good. It assumes that the new Taclets are
+            // prepended to the Taclet lists. This does have to be the case!
+            return listAfter.skip(sizeBefore);
         }
 
         @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/util/HelperClassForTests.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/HelperClassForTests.java
@@ -30,7 +30,6 @@ import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.StrategyProperties;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.helper.FindResources;
 import org.key_project.util.java.CollectionUtil;
@@ -51,7 +50,7 @@ public class HelperClassForTests {
         @Override
         public RuleCollection getStandardRules() {
             final var ruleSource = RuleSourceFactory.fromDefaultLocation(ldtFile);
-            return new RuleCollection(ImmutableList.of(ruleSource), ImmutableSLList.nil());
+            return new RuleCollection(ImmutableList.of(ruleSource), ImmutableList.nil());
         }
     };
 

--- a/key.core/src/main/java/de/uka/ilkd/key/util/InfFlowSpec.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/InfFlowSpec.java
@@ -8,7 +8,6 @@ import java.util.function.UnaryOperator;
 import de.uka.ilkd.key.logic.JTerm;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 
 /**
@@ -45,8 +44,8 @@ public class InfFlowSpec {
     }
 
     private InfFlowSpec() {
-        this.preExpressions = ImmutableSLList.nil();
-        this.postExpressions = ImmutableSLList.nil();
-        this.newObjects = ImmutableSLList.nil();
+        this.preExpressions = ImmutableList.nil();
+        this.postExpressions = ImmutableList.nil();
+        this.newObjects = ImmutableList.nil();
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
@@ -645,7 +645,7 @@ public final class MiscTools {
     }
 
     public static ImmutableList<JTerm> toTermList(Iterable<LocationVariable> list, TermBuilder tb) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (var pv : list) {
             if (pv != null) {
                 JTerm t = tb.var(pv);
@@ -674,7 +674,7 @@ public final class MiscTools {
 
     public static ImmutableList<JTerm> filterOutDuplicates(ImmutableList<JTerm> localIns,
             ImmutableList<JTerm> localOuts) {
-        ImmutableList<JTerm> result = ImmutableSLList.nil();
+        ImmutableList<JTerm> result = ImmutableList.nil();
         for (JTerm localIn : localIns) {
             if (!localOuts.contains(localIn)) {
                 result = result.append(localIn);

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ProofStarter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ProofStarter.java
@@ -29,7 +29,6 @@ import org.key_project.prover.engine.ProverTaskListener;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -70,7 +69,7 @@ public class ProofStarter {
         public UserProvidedInput(JTerm formula, ProofEnvironment env) {
             this(
                 JavaDLSequentKit.createSuccSequent(
-                    ImmutableSLList.<SequentFormula>nil().prepend(new SequentFormula(formula))),
+                    ImmutableList.<SequentFormula>singleton(new SequentFormula(formula))),
                 env);
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/util/mergerule/MergeRuleUtils.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/mergerule/MergeRuleUtils.java
@@ -1071,7 +1071,7 @@ public class MergeRuleUtils {
             PosInOccurrence pio, Services services) {
 
         ImmutableList<SequentFormula> pathConditionSet =
-            ImmutableSLList.nil();
+            ImmutableList.nil();
         pathConditionSet = pathConditionSet.prepend(node.sequent().antecedent().asList());
 
         var selected = pio.subTerm();
@@ -1110,7 +1110,7 @@ public class MergeRuleUtils {
      */
     public static ImmutableList<SymbolicExecutionState> sequentsToSEPairs(
             Iterable<MergePartner> sequentInfos) {
-        ImmutableList<SymbolicExecutionState> result = ImmutableSLList.nil();
+        ImmutableList<SymbolicExecutionState> result = ImmutableList.nil();
         for (MergePartner sequentInfo : sequentInfos) {
             final Node node = sequentInfo.getGoal().node();
             final Services services = sequentInfo.getGoal().proof().getServices();
@@ -1351,7 +1351,7 @@ public class MergeRuleUtils {
         TermBuilder tb = services.getTermBuilder();
 
         ImmutableSet<QuantifiableVariable> freeVars = term.freeVars();
-        ImmutableList<JTerm> elementaries = ImmutableSLList.nil();
+        ImmutableList<JTerm> elementaries = ImmutableList.nil();
 
         for (LocationVariable loc : getLocationVariables(term, services)) {
             final String newName = tb.newName(stripIndex(loc.name().toString()));
@@ -1505,8 +1505,8 @@ public class MergeRuleUtils {
             boolean doSplit,
             String sideProofName, int timeout) throws ProofInputException {
         return tryToProve(// Sequent to prove
-            JavaDLSequentKit.createSequent(ImmutableSLList.nil(),
-                ImmutableSLList.singleton(new SequentFormula(toProve))),
+            JavaDLSequentKit.createSequent(ImmutableList.nil(),
+                ImmutableList.singleton(new SequentFormula(toProve))),
             services, doSplit, sideProofName, timeout);
     }
 
@@ -1632,7 +1632,7 @@ public class MergeRuleUtils {
         if (openGoals.isEmpty()) {
             return tb.tt();
         } else {
-            ImmutableList<JTerm> goalImplications = ImmutableSLList.nil();
+            ImmutableList<JTerm> goalImplications = ImmutableList.nil();
             for (Goal goal : openGoals) {
                 JTerm goalImplication = sequentToFormula(goal.sequent(), services);
                 goalImplications = goalImplications.append(goalImplication);
@@ -1654,8 +1654,8 @@ public class MergeRuleUtils {
     private static JTerm sequentToFormula(Sequent sequent, Services services) {
         TermBuilder tb = services.getTermBuilder();
 
-        ImmutableList<JTerm> negAntecedentForms = ImmutableSLList.nil();
-        ImmutableList<JTerm> succedentForms = ImmutableSLList.nil();
+        ImmutableList<JTerm> negAntecedentForms = ImmutableList.nil();
+        ImmutableList<JTerm> succedentForms = ImmutableList.nil();
 
         // Shift antecedent formulae to the succedent by negation
         for (SequentFormula sf : sequent.antecedent().asList()) {

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestClashFreeSubst.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestClashFreeSubst.java
@@ -19,7 +19,7 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.op.Operator;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -150,7 +150,7 @@ public class TestClashFreeSubst extends AbstractTestTermParser {
                     }
                     subStack.pop();
                     subStack.push(tb.all(
-                        ImmutableSLList.<QuantifiableVariable>nil().append(bv), top.sub(0)));
+                        ImmutableList.of(bv), top.sub(0)));
                     return;
                 }
             }

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTerm.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTerm.java
@@ -14,10 +14,9 @@ import de.uka.ilkd.key.rule.TacletForTests;
 import org.key_project.logic.Name;
 import org.key_project.logic.Term;
 import org.key_project.logic.op.Function;
-import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,7 +105,7 @@ public class TestTerm {
         JTerm t_allxt1 = tb.all(x, t2());
         JTerm t_allxt1_andt2 = tf.createTerm(Junctor.AND, t_allxt1, t1());
         JTerm t_exw_allxt1_andt2 =
-            tb.ex(ImmutableSLList.<QuantifiableVariable>nil().append(w, x), t_allxt1_andt2);
+            tb.ex(ImmutableList.of(w, x), t_allxt1_andt2);
         assertTrue(!t_exw_allxt1_andt2.freeVars().contains(w)
                 && !t_exw_allxt1_andt2.freeVars().contains(x));
     }

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermFactory.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermFactory.java
@@ -17,7 +17,7 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableArray;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,7 +146,7 @@ public class TestTermFactory {
 
     @Test
     public void testQuantifierTerm() {
-        JTerm t_forallx_px = TB.all(ImmutableSLList.<QuantifiableVariable>nil().append(x), t1());
+        JTerm t_forallx_px = TB.all(ImmutableList.<QuantifiableVariable>singleton(x), t1());
         assertEquals(t_forallx_px, new TermImpl(Quantifier.ALL, new ImmutableArray<>(t1()),
             new ImmutableArray<>(x)));
     }
@@ -221,7 +221,7 @@ public class TestTermFactory {
     public void testQuantifierWithNoBoundSubTerms() {
         JTerm result = null;
         try {
-            result = TB.all(ImmutableSLList.nil(), t1());
+            result = TB.all(ImmutableList.nil(), t1());
         } catch (TermCreationException e) {
         }
         assertEquals(result, t1());

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermLabelManager.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermLabelManager.java
@@ -36,7 +36,6 @@ import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Assertions;
@@ -612,38 +611,38 @@ public class TestTermLabelManager {
         Profile profile = new JavaProfile() {
             @Override
             protected ImmutableList<TermLabelConfiguration> computeTermLabelConfiguration() {
-                ImmutableList<TermLabelPolicy> applicationTermPolicies = ImmutableSLList.nil();
+                ImmutableList<TermLabelPolicy> applicationTermPolicies = ImmutableList.nil();
                 if (applicationTermPolicy != null) {
                     applicationTermPolicies =
                         applicationTermPolicies.prepend(applicationTermPolicy);
                 }
-                ImmutableList<TermLabelPolicy> modalityTermPolicies = ImmutableSLList.nil();
+                ImmutableList<TermLabelPolicy> modalityTermPolicies = ImmutableList.nil();
                 if (modalityTermPolicy != null) {
                     modalityTermPolicies = modalityTermPolicies.prepend(modalityTermPolicy);
                 }
                 ImmutableList<ChildTermLabelPolicy> directChildTermLabelPolicies =
-                    ImmutableSLList.nil();
+                    ImmutableList.nil();
                 if (directChildPolicy != null) {
                     directChildTermLabelPolicies =
                         directChildTermLabelPolicies.prepend(directChildPolicy);
                 }
                 ImmutableList<ChildTermLabelPolicy> childAndGrandchildTermLabelPolicies =
-                    ImmutableSLList.nil();
+                    ImmutableList.nil();
                 if (childAndGrandchildPolicy != null) {
                     childAndGrandchildTermLabelPolicies =
                         childAndGrandchildTermLabelPolicies.prepend(childAndGrandchildPolicy);
                 }
-                ImmutableList<TermLabelUpdate> termLabelUpdates = ImmutableSLList.nil();
+                ImmutableList<TermLabelUpdate> termLabelUpdates = ImmutableList.nil();
                 if (update != null) {
                     termLabelUpdates = termLabelUpdates.prepend(update);
                 }
                 ImmutableList<TermLabelRefactoring> termLabelRefactorings =
-                    ImmutableSLList.nil();
+                    ImmutableList.nil();
                 if (refactoring != null) {
                     termLabelRefactorings = termLabelRefactorings.prepend(refactoring);
                 }
 
-                ImmutableList<TermLabelConfiguration> result = ImmutableSLList.nil();
+                ImmutableList<TermLabelConfiguration> result = ImmutableList.nil();
                 result = result.prepend(new TermLabelConfiguration(new Name("ONE"),
                     new LoggingFactory(new Name("ONE")), applicationTermPolicies,
                     modalityTermPolicies, directChildTermLabelPolicies,
@@ -678,7 +677,7 @@ public class TestTermLabelManager {
     private static class LoggingTermLabelRefactoring implements TermLabelRefactoring {
         private final RefactoringScope scope;
 
-        private ImmutableList<Name> supportedRuleNames = ImmutableSLList.nil();
+        private ImmutableList<Name> supportedRuleNames = ImmutableList.nil();
 
         public LoggingTermLabelRefactoring(RefactoringScope scope, String... supportedRules) {
             this.scope = scope;
@@ -723,7 +722,7 @@ public class TestTermLabelManager {
     private static class LoggingTermLabelUpdate implements TermLabelUpdate {
         private final TermLabel toAdd;
 
-        private ImmutableList<Name> supportedRuleNames = ImmutableSLList.nil();
+        private ImmutableList<Name> supportedRuleNames = ImmutableList.nil();
 
         public LoggingTermLabelUpdate(TermLabel toAdd, String... supportedRules) {
             this.toAdd = toAdd;
@@ -749,7 +748,7 @@ public class TestTermLabelManager {
     }
 
     private static class LoggingChildTermLabelPolicy implements ChildTermLabelPolicy {
-        private ImmutableList<Name> supportedRuleNames = ImmutableSLList.nil();
+        private ImmutableList<Name> supportedRuleNames = ImmutableList.nil();
 
         private final List<TermLabel> log = new LinkedList<>();
 

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestVariableNamer.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestVariableNamer.java
@@ -29,7 +29,7 @@ import org.key_project.logic.Namespace;
 import org.key_project.logic.PosInTerm;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.sequent.*;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.Test;
 
@@ -84,8 +84,8 @@ public class TestVariableNamer {
 
 
     private Goal constructGoal(SequentFormula containedFormula) {
-        final var empty = ImmutableSLList.<SequentFormula>nil();
-        final var ante = ImmutableSLList.singleton(containedFormula);
+        final var empty = ImmutableList.<SequentFormula>nil();
+        final var ante = ImmutableList.singleton(containedFormula);
 
         Sequent seq = JavaDLSequentKit.createSequent(ante, empty);
         Node node = new Node(proof, seq);

--- a/key.core/src/test/java/de/uka/ilkd/key/parser/TestTacletParser.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/parser/TestTacletParser.java
@@ -26,7 +26,7 @@ import org.key_project.logic.Namespace;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,13 +104,13 @@ public class TestTacletParser {
     }
 
     public Sequent sequent(String a, String s) {
-        var antec = ImmutableSLList.<SequentFormula>nil();
-        var succ = ImmutableSLList.<SequentFormula>nil();
+        var antec = ImmutableList.<SequentFormula>nil();
+        var succ = ImmutableList.<SequentFormula>nil();
         if (a != null) {
-            antec = ImmutableSLList.singleton(cf(a));
+            antec = ImmutableList.singleton(cf(a));
         }
         if (s != null) {
-            succ = ImmutableSLList.singleton(cf(s));
+            succ = ImmutableList.singleton(cf(s));
         }
         return JavaDLSequentKit.createSequent(antec, succ);
     }
@@ -136,11 +136,11 @@ public class TestTacletParser {
         builder.setName(new Name("imp_left"));
         builder.addTacletGoalTemplate(
             new AntecSuccTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), sequent("b0", null)));
+                ImmutableList.nil(), sequent("b0", null)));
 
         builder.addTacletGoalTemplate(
             new AntecSuccTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), sequent(null, "b")));
+                ImmutableList.nil(), sequent(null, "b")));
 
         Taclet impleft = builder.getAntecTaclet();
         String impleftString =
@@ -156,7 +156,7 @@ public class TestTacletParser {
         builder.setFind(parseFma("b->b0"));
         builder.addTacletGoalTemplate(
             new AntecSuccTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), sequent("b", "b0")));
+                ImmutableList.nil(), sequent("b", "b0")));
         builder.setName(new Name("imp_right"));
         Taclet impright = builder.getSuccTaclet();
         String imprightString = "imp_right{\\find(==> b->b0) \\replacewith(b ==> b0)}";
@@ -170,10 +170,10 @@ public class TestTacletParser {
         // add(b=>) add(=>b)
         NoFindTacletBuilder builder = new NoFindTacletBuilder();
         builder.addTacletGoalTemplate(
-            new TacletGoalTemplate(sequent("b", null), ImmutableSLList.nil()));
+            new TacletGoalTemplate(sequent("b", null), ImmutableList.nil()));
 
         builder.addTacletGoalTemplate(
-            new TacletGoalTemplate(sequent(null, "b"), ImmutableSLList.nil()));
+            new TacletGoalTemplate(sequent(null, "b"), ImmutableList.nil()));
         builder.setName(new Name("cut"));
 
         Taclet cut = builder.getNoFindTaclet();
@@ -203,7 +203,7 @@ public class TestTacletParser {
         builder.setFind(parseFma("b->b0"));
         builder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), parseFma("!b0->!b")));
+                ImmutableList.nil(), parseFma("!b0->!b")));
         builder.setName(new Name("contraposition"));
         Taclet contraposition = builder.getRewriteTaclet();
         String contrapositionString = "contraposition{\\find(b->b0) \\replacewith(!b0 -> !b)}";
@@ -220,7 +220,7 @@ public class TestTacletParser {
         builder.setFind(parseFma("\\forall z; b"));
         builder.addTacletGoalTemplate(
             new AntecSuccTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), sequent(null, "{\\subst z; sk}b")));
+                ImmutableList.nil(), sequent(null, "{\\subst z; sk}b")));
         builder.addVarsNewDependingOn(lookup_schemavar("sk"), lookup_schemavar("b"));
         builder.setName(new Name("all_right"));
         Taclet allright = builder.getSuccTaclet();
@@ -239,7 +239,7 @@ public class TestTacletParser {
 
 
         builder.addTacletGoalTemplate(
-            new TacletGoalTemplate(sequent("{\\subst z; x}b", null), ImmutableSLList.nil()));
+            new TacletGoalTemplate(sequent("{\\subst z; x}b", null), ImmutableList.nil()));
         builder.setName(new Name("all_left"));
         Taclet allleft = builder.getAntecTaclet();
         String allleftString = "all_left{\\find(\\forall z; b==>) \\add({\\subst z; x}b==>)}";
@@ -257,7 +257,7 @@ public class TestTacletParser {
         builder.addVarsNotFreeIn(lookup_schemavar("z"), lookup_schemavar("b"));
         builder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), parseFma("b & \\exists z; b0")));
+                ImmutableList.nil(), parseFma("b & \\exists z; b0")));
         builder.setName(new Name("exists_conj_split"));
         Taclet exconjsplit = builder.getRewriteTaclet();
         String exconjsplitString =
@@ -276,7 +276,7 @@ public class TestTacletParser {
         builder.setFind(parseTerm("f(f(x))"));
         builder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), parseTerm("f(x)")));
+                ImmutableList.nil(), parseTerm("f(x)")));
         builder.setName(new Name("f_idempotent"));
         Taclet fidempotent = builder.getRewriteTaclet();
         String fidempotentString = "f_idempotent{\\find(f(f(x))) \\replacewith(f(x))}";
@@ -291,7 +291,7 @@ public class TestTacletParser {
         insertbuilder.setFind(parseTerm("x"));
         insertbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), parseTerm("x0")));
+                ImmutableList.nil(), parseTerm("x0")));
         insertbuilder.setName(new Name("insert_eq"));
         Taclet inserteq = insertbuilder.getTaclet();
 
@@ -300,7 +300,7 @@ public class TestTacletParser {
         builder.setFind(parseFma("x=x0"));
         builder.addTacletGoalTemplate(
             new TacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.<Taclet>nil().prepend(inserteq)));
+                ImmutableList.<Taclet>singleton(inserteq)));
         builder.setName(new Name("make_insert_eq"));
         Taclet makeinserteq = builder.getAntecTaclet();
         String makeinserteqString = "make_insert_eq" + "{\\find (x = x0 ==>)"

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
@@ -15,7 +15,6 @@ import de.uka.ilkd.key.rule.inst.SVInstantiations;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +45,7 @@ public class TestGoal {
     @Test
     public void testSetBack0() {
         Sequent seq = JavaDLSequentKit.createSuccSequent(
-            ImmutableSLList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
+            ImmutableList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
 
         final InitConfig initConfig =
             new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
@@ -98,7 +97,7 @@ public class TestGoal {
     @Test
     public void testSetBackRemovesJustificationOfResidualBranch() {
         Sequent seq = JavaDLSequentKit.createSuccSequent(
-            ImmutableSLList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
+            ImmutableList.of(new SequentFormula(TacletForTests.parseTerm("A"))));
         final InitConfig initConfig =
             new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
         proof = new Proof("", seq, null, initConfig.createTacletIndex(),
@@ -133,7 +132,7 @@ public class TestGoal {
     @Test
     public void testSetBack1() throws Exception {
         Sequent seq = JavaDLSequentKit.createSuccSequent(
-            ImmutableSLList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
+            ImmutableList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
         Node root = new Node(proof, seq);
         proof.setRoot(root);
         Goal g = new Goal(root, TacletIndexKit.getKit().createTacletIndex(),

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestProofTree.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestProofTree.java
@@ -19,7 +19,7 @@ import org.key_project.logic.Name;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,19 +66,19 @@ public class TestProofTree {
         JTerm t_b7 = tf.createTerm(Equality.EQUALS, tf.createTerm(b7), tf.createTerm(b7));
 
         Sequent s1 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b1)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b1)), ImmutableList.nil());
         Sequent s2 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b2)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b2)), ImmutableList.nil());
         Sequent s3 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b3)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b3)), ImmutableList.nil());
         Sequent s4 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b4)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b4)), ImmutableList.nil());
         Sequent s5 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b5)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b5)), ImmutableList.nil());
         Sequent s6 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b6)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b6)), ImmutableList.nil());
         Sequent s7 = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(t_b7)), ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(t_b7)), ImmutableList.nil());
 
         p = new Proof("TestProofTree",
             new InitConfig(new Services(AbstractProfile.getDefaultProfile())));

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestTacletIndex.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestTacletIndex.java
@@ -23,7 +23,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,7 +118,7 @@ public class TestTacletIndex {
     @Disabled
     public void disabled_testNonInteractiveIsShownOnlyIfHeuristicIsMissed() {
         JTerm term_p1 = TacletForTests.parseTerm("p(one, zero)");
-        ImmutableList<RuleSet> listofHeuristic = ImmutableSLList.nil();
+        ImmutableList<RuleSet> listofHeuristic = ImmutableList.nil();
         listofHeuristic = listofHeuristic.prepend(h3);
         PosInOccurrence pos =
             new PosInOccurrence(new SequentFormula(term_p1), PosInTerm.getTopLevel(), true);
@@ -137,7 +136,7 @@ public class TestTacletIndex {
 
         assertTrue(
             isRuleIn(
-                variante_one.getNoFindTaclet(new IHTacletFilter(true, ImmutableSLList.nil()), null),
+                variante_one.getNoFindTaclet(new IHTacletFilter(true, ImmutableList.nil()), null),
                 ruleNoFindNonH1H2H3),
             "Noninteractive nofindrule is not in list, but none of its " + "heuristics is active.");
 
@@ -152,7 +151,7 @@ public class TestTacletIndex {
     @Test
     public void testShownIfHeuristicFits() {
         Services services = new Services(AbstractProfile.getDefaultProfile());
-        ImmutableList<RuleSet> listofHeuristic = ImmutableSLList.nil();
+        ImmutableList<RuleSet> listofHeuristic = ImmutableList.nil();
         listofHeuristic = listofHeuristic.prepend(h3).prepend(h2);
 
         JTerm term_p1 = TacletForTests.parseTerm("p(one, zero)");
@@ -186,7 +185,7 @@ public class TestTacletIndex {
     @Test
     public void testNoMatchingFindRule() {
         Services services = new Services(AbstractProfile.getDefaultProfile());
-        ImmutableList<RuleSet> listofHeuristic = ImmutableSLList.nil();
+        ImmutableList<RuleSet> listofHeuristic = ImmutableList.nil();
 
         JTerm term_p2 = TacletForTests.parseTerm("\\forall nat z; p(z, one)").sub(0);
 
@@ -222,7 +221,7 @@ public class TestTacletIndex {
 
         JTerm term_p4 = TacletForTests.parseTerm("p(zero, one)");
 
-        ImmutableList<RuleSet> listofHeuristic = ImmutableSLList.nil();
+        ImmutableList<RuleSet> listofHeuristic = ImmutableList.nil();
         PosInOccurrence posAntec =
             new PosInOccurrence(new SequentFormula(term_p4), PosInTerm.getTopLevel(), true);
 
@@ -241,7 +240,7 @@ public class TestTacletIndex {
         JTerm term_p5 = TacletForTests.parseTerm("\\forall nat z; p(f(z), z)");
         SequentFormula cfma_p5 = new SequentFormula(term_p5);
         Sequent seq_p5 = JavaDLSequentKit.createAnteSequent(
-            ImmutableSLList.singleton(cfma_p5));
+            ImmutableList.singleton(cfma_p5));
         PosInOccurrence pio_p5 =
             new PosInOccurrence(cfma_p5, PosInTerm.getTopLevel(), true);
         RuleAppIndex appIdx = createGoalFor(seq_p5, ruleIdx);
@@ -254,7 +253,7 @@ public class TestTacletIndex {
 
         SequentFormula cfma_p6 = new SequentFormula(term_p6);
         Sequent seq_p6 = JavaDLSequentKit.createAnteSequent(
-            ImmutableSLList.singleton(cfma_p6));
+            ImmutableList.singleton(cfma_p6));
         PosInOccurrence pio_p6 =
             new PosInOccurrence(cfma_p6, PosInTerm.getTopLevel(), true);
         appIdx = createGoalFor(seq_p6, ruleIdx);

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestTermTacletAppIndex.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestTermTacletAppIndex.java
@@ -23,7 +23,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -171,7 +170,7 @@ public class TestTermTacletAppIndex {
 
     private void checkTermIndex(PosInOccurrence pio,
             TermTacletAppIndex termIdx) {
-        ImmutableList<Taclet> listA = ImmutableSLList.nil();
+        ImmutableList<Taclet> listA = ImmutableList.nil();
         ImmutableList<Taclet> listB = listA.prepend(remove_f.taclet());
         ImmutableList<Taclet> listC = listA.prepend(remove_zero.taclet());
 
@@ -185,7 +184,7 @@ public class TestTermTacletAppIndex {
 
     private void checkTermIndex2(PosInOccurrence pio,
             TermTacletAppIndex termIdx) {
-        ImmutableList<Taclet> listA = ImmutableSLList.nil();
+        ImmutableList<Taclet> listA = ImmutableList.nil();
         ImmutableList<Taclet> listB = listA.prepend(remove_f.taclet());
         ImmutableList<Taclet> listC = listA.prepend(remove_zero.taclet());
 
@@ -198,7 +197,7 @@ public class TestTermTacletAppIndex {
 
     private void checkTermIndex3(PosInOccurrence pio,
             TermTacletAppIndex termIdx) {
-        ImmutableList<Taclet> listA = ImmutableSLList.nil();
+        ImmutableList<Taclet> listA = ImmutableList.nil();
         ImmutableList<Taclet> listB = listA.prepend(remove_f.taclet());
         ImmutableList<Taclet> listC = listA.prepend(remove_zero.taclet());
         ImmutableList<Taclet> listD = listB.prepend(remove_ff.taclet());

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/calculus/TestSemisequent.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/calculus/TestSemisequent.java
@@ -18,7 +18,6 @@ import org.key_project.prover.sequent.Semisequent;
 import org.key_project.prover.sequent.SemisequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -244,7 +243,7 @@ public class TestSemisequent {
 
         Semisequent expected = extract(
             extract(extract(origin.insertLast(con[4])).insertLast(con[5])).insertLast(con[6]));
-        ImmutableList<SequentFormula> insertionList = ImmutableSLList
+        ImmutableList<SequentFormula> insertionList = ImmutableList
                 .<SequentFormula>nil()
                 .prepend(con[0]).prepend(con[1]).prepend(con[6]).prepend(con[5]).prepend(con[4]);
         Semisequent result = extract(origin.insert(origin.size(), insertionList));
@@ -260,7 +259,7 @@ public class TestSemisequent {
                     .insertLast(con[2]));
         Semisequent expected =
             extract(extract(extract(origin.insert(2, con[4])).insert(3, con[5])).insert(4, con[6]));
-        ImmutableList<SequentFormula> insertionList = ImmutableSLList
+        ImmutableList<SequentFormula> insertionList = ImmutableList
                 .<SequentFormula>nil()
                 .prepend(con[0]).prepend(con[1]).prepend(con[6]).prepend(con[5]).prepend(con[4]);
         Semisequent result = extract(origin.insert(origin.size() - 1, insertionList));
@@ -273,7 +272,7 @@ public class TestSemisequent {
         // [p,q,r]
         Semisequent origin = JavaDLSequentKit
                 .createAnteSequent(
-                    ImmutableSLList.<SequentFormula>nil().prepend(con[0], con[1], con[2]))
+                    ImmutableList.<SequentFormula>nil().prepend(con[0], con[1], con[2]))
                 .antecedent();
         // [p,q,a,b,c]
         Semisequent expected = JavaDLSequentKit
@@ -281,15 +280,15 @@ public class TestSemisequent {
                 .antecedent();
         // insert: [a,b,c,q,p]
         ImmutableList<SequentFormula> insertionList =
-            ImmutableSLList.<SequentFormula>nil().prepend(con[4], con[5], con[6], con[1], con[0]);
+            ImmutableList.<SequentFormula>nil().prepend(con[4], con[5], con[6], con[1], con[0]);
 
         SemisequentChangeInfo result = origin.replace(origin.size() - 1, insertionList);
 
         assertEquals(
-            ImmutableSLList.singleton(con[4]).prepend(con[5]).prepend(con[6]),
+            ImmutableList.singleton(con[4]).prepend(con[5]).prepend(con[6]),
             result.addedFormulas(),
             "SemisequentChangeInfo is corrupt due to wrong added formula list:");
-        assertEquals(ImmutableSLList.singleton(con[2]),
+        assertEquals(ImmutableList.singleton(con[2]),
             result.removedFormulas(),
             "SemisequentChangeInfo is corrupt due to wrong removed formula list:");
         assertEquals(expected, extract(result), "Both semisequents should be equal.");
@@ -308,16 +307,16 @@ public class TestSemisequent {
                 .insertLast(con[2]));
         // insert:[a,b,c,r,r,q,p]
         ImmutableList<SequentFormula> insertionList =
-            ImmutableSLList.singleton(con[0]).prepend(con[1]).prepend(con[2])
+            ImmutableList.singleton(con[0]).prepend(con[1]).prepend(con[2])
                     .prepend(con[3]).prepend(con[6]).prepend(con[5]).prepend(con[4]);
 
         SemisequentChangeInfo sci = origin.replace(origin.size(), insertionList);
         assertEquals(
-            ImmutableSLList.singleton(con[4]).prepend(con[5]).prepend(con[6])
+            ImmutableList.singleton(con[4]).prepend(con[5]).prepend(con[6])
                     .prepend(con[3]),
             sci.addedFormulas(),
             "SemisequentChangeInfo is corrupt due to wrong added formula list:");
-        assertEquals(ImmutableSLList.<SequentFormula>nil(), sci.removedFormulas(),
+        assertEquals(ImmutableList.<SequentFormula>nil(), sci.removedFormulas(),
             "SemisequentChangeInfo is corrupt due to wrong removed formula list:");
         assertEquals(expected, extract(sci), "Both semisequents should be equal.");
     }
@@ -325,7 +324,7 @@ public class TestSemisequent {
     @Test
     void constructorTest() {
         var a = JavaDLSequentKit.emptySemisequent();
-        var b = JavaDLSequentKit.createAnteSequent(ImmutableSLList.nil()).antecedent();
+        var b = JavaDLSequentKit.createAnteSequent(ImmutableList.nil()).antecedent();
         assertSame(a, b);
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/CreateTacletForTests.java
@@ -23,7 +23,7 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +141,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwb1.setFind(t_rn);
         rwb1.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t_0));
 
 
@@ -152,11 +152,11 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(t_rnminus1plus1);
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t_rn));
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.<Taclet>nil().prepend(rwb1.getTaclet()), t_0plus1));
+                ImmutableList.<Taclet>singleton(rwb1.getTaclet()), t_0plus1));
         rwbuilder.setName(new Name("pred-succ-elim"));
         pluszeroelim = rwbuilder.getRewriteTaclet();
 
@@ -166,7 +166,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(tf.createTerm(func_plus, t_rn, t_0));
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t_rn));
         rwbuilder.setName(new Name("plus-zero-elim"));
         predsuccelim = rwbuilder.getRewriteTaclet();
@@ -177,7 +177,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(tf.createTerm(func_plus, t_0, t_rn));
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t_rn));
         rwbuilder.setName(new Name("zero-plus-elim"));
         zeropluselim = rwbuilder.getRewriteTaclet();
@@ -204,7 +204,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(t_rnplus1plusrm);
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), t_rnplusrmplus1));
+                ImmutableList.nil(), t_rnplusrmplus1));
         rwbuilder.setName(new Name("switch-first-succ"));
         switchfirstsucc = rwbuilder.getRewriteTaclet();
 
@@ -218,7 +218,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(t_rnplus_rmplus1);
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(), t_rnplusrmplus1));
+                ImmutableList.nil(), t_rnplusrmplus1));
         rwbuilder.setName(new Name("switch-second-succ"));
         switchsecondsucc = rwbuilder.getRewriteTaclet();
 
@@ -229,7 +229,7 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         rwbuilder.setFind(tf.createTerm(func_eq, t_rnplus1, t_rmplus1));
         rwbuilder.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t_rneqrm));
         rwbuilder.setName(new Name("succ-elim"));
         succelim = rwbuilder.getRewriteTaclet();
@@ -272,11 +272,11 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         SequentFormula cf = new SequentFormula(t_test1);
         SequentFormula cf2 = new SequentFormula(t_test1);
         seq_test1 =
-            JavaDLSequentKit.createSequent(ImmutableSLList.nil(), ImmutableSLList.singleton(cf));
+            JavaDLSequentKit.createSequent(ImmutableList.nil(), ImmutableList.singleton(cf));
         seq_test2 =
-            JavaDLSequentKit.createSequent(ImmutableSLList.singleton(cf), ImmutableSLList.nil());
-        seq_test3 = JavaDLSequentKit.createSequent(ImmutableSLList.singleton(cf),
-            ImmutableSLList.singleton(cf2));
+            JavaDLSequentKit.createSequent(ImmutableList.singleton(cf), ImmutableList.nil());
+        seq_test3 = JavaDLSequentKit.createSequent(ImmutableList.singleton(cf),
+            ImmutableList.singleton(cf2));
 
 
         func_p = new JFunction(new Name("P"), JavaDLTheory.FORMULA, sort1);
@@ -304,16 +304,16 @@ public class CreateTacletForTests extends AbstractTestTermParser {
         JTerm tnat = tf.createTerm(Junctor.IMP, t_eq1, t_eq2);
 
         // => (c+d) = ((d -1 +1) +c) -> (c +1)+d = (d+c) +1
-        seq_testNat = JavaDLSequentKit.createSequent(ImmutableSLList.nil(),
-            ImmutableSLList.singleton(new SequentFormula(tnat)));
+        seq_testNat = JavaDLSequentKit.createSequent(ImmutableList.nil(),
+            ImmutableList.singleton(new SequentFormula(tnat)));
 
 
         z = new LogicVariable(new Name("z"), sort1);
         JTerm t_z = tf.createTerm(z);
         JTerm t_allzpz = services.getTermBuilder().all(z, tf.createTerm(func_p, t_z));
         SequentFormula cf3 = new SequentFormula(t_allzpz);
-        seq_testAll = JavaDLSequentKit.createSequent(ImmutableSLList.nil(),
-            ImmutableSLList.singleton(cf3));
+        seq_testAll = JavaDLSequentKit.createSequent(ImmutableList.nil(),
+            ImmutableList.singleton(cf3));
 
 
 

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TacletForTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TacletForTests.java
@@ -30,7 +30,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -67,7 +66,7 @@ public class TacletForTests {
         public RuleCollection getStandardRules() {
             return new RuleCollection(
                 ImmutableList.of(RuleSourceFactory.fromDefaultLocation(ldtFile)),
-                ImmutableSLList.nil());
+                ImmutableList.nil());
         }
     };
 

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestApplyTaclet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestApplyTaclet.java
@@ -24,7 +24,6 @@ import org.key_project.prover.rules.instantiation.AssumesFormulaInstantiation;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.junit.jupiter.api.AfterEach;
@@ -84,10 +83,10 @@ public class TestApplyTaclet {
 
     private static ImmutableList<SequentFormula> parseTermForSemisequent(String t) {
         if ("".equals(t)) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
         SequentFormula cf0 = new SequentFormula(TacletForTests.parseTerm(t));
-        return ImmutableSLList.singleton(cf0);
+        return ImmutableList.singleton(cf0);
     }
 
     @BeforeEach
@@ -162,7 +161,7 @@ public class TestApplyTaclet {
         assertEquals(seq.succedent().getFirst().formula(), fma.sub(1),
             "Wrong succedent after imp_right_add");
         ImmutableList<NoPosTacletApp> nfapp = goals.head().indexOfTaclets()
-                .getNoFindTaclet(new IHTacletFilter(true, ImmutableSLList.nil()), null);
+                .getNoFindTaclet(new IHTacletFilter(true, ImmutableList.nil()), null);
         JTerm aimpb = TacletForTests.parseTerm("A -> B");
         assertEquals(1, nfapp.size(), "Cut Rule should be inserted to TacletIndex.");
         assertEquals(
@@ -601,7 +600,7 @@ public class TestApplyTaclet {
 
         assertEquals(4, rApplist.size(), "Expected four rule applications.");
 
-        ImmutableList<TacletApp> appList = ImmutableSLList.nil();
+        ImmutableList<TacletApp> appList = ImmutableList.nil();
         for (TacletApp aRApplist : rApplist) {
             appList =
                 appList.prepend(aRApplist.findIfFormulaInstantiations(goal.sequent(), services));
@@ -633,7 +632,7 @@ public class TestApplyTaclet {
 
         assertEquals(3, rApplist.size(), "Expected three rule applications.");
 
-        ImmutableList<TacletApp> appList = ImmutableSLList.nil();
+        ImmutableList<TacletApp> appList = ImmutableList.nil();
         Iterator<TacletApp> appIt = rApplist.iterator();
         while (appIt.hasNext()) {
             appList =
@@ -644,7 +643,7 @@ public class TestApplyTaclet {
 
         JTerm ifterm = TacletForTests.parseTerm("{i:=0}(f(const)=f(f(const)))");
         SequentFormula ifformula = new SequentFormula(ifterm);
-        ImmutableList<AssumesFormulaInstantiation> ifInsts = ImmutableSLList
+        ImmutableList<AssumesFormulaInstantiation> ifInsts = ImmutableList
                 .<AssumesFormulaInstantiation>nil()
                 .prepend(new AssumesFormulaInstDirect(ifformula));
         appIt = rApplist.iterator();

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestCollisionResolving.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestCollisionResolving.java
@@ -22,7 +22,6 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -223,7 +222,7 @@ public class TestCollisionResolving {
         FindTaclet taclet =
             (FindTaclet) TacletForTests.getTaclet("TestCollisionResolving_name_conflict").taclet();
         final ImmutableList<SequentFormula> semiseq =
-            ImmutableSLList
+            ImmutableList
                     .singleton(new SequentFormula(TacletForTests.parseTerm("\\forall s x; p(x)")))
                     .append(new SequentFormula(TacletForTests.parseTerm("\\exists s x; p(x)")));
         Sequent seq = JavaDLSequentKit.createSuccSequent(semiseq);

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestMatchTaclet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestMatchTaclet.java
@@ -28,7 +28,7 @@ import org.key_project.prover.proof.rulefilter.IHTacletFilter;
 import org.key_project.prover.rules.instantiation.MatchResultInfo;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.DefaultImmutableSet;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,8 +137,8 @@ public class TestMatchTaclet {
         // therefore no match should be found
 
         Sequent seq = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(match.sub(0))),
-            ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(match.sub(0))),
+            ImmutableList.nil());
 
         assertEquals(0,
             NoPosTacletApp.createNoPosTacletApp(if_addrule_conflict)
@@ -148,8 +148,8 @@ public class TestMatchTaclet {
 
         // we bind the free variable now a match should be found
         seq = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(match)),
-            ImmutableSLList.nil());
+            ImmutableList.singleton(new SequentFormula(match)),
+            ImmutableList.nil());
 
         assertNotEquals(0,
             NoPosTacletApp.createNoPosTacletApp(if_addrule_conflict)
@@ -258,15 +258,15 @@ public class TestMatchTaclet {
         JTerm closeable_one = TacletForTests.parseTerm("\\forall testSort z; p(z)");
         JTerm closeable_two = TacletForTests.parseTerm("\\forall testSort y; p(y)");
         Sequent seq = JavaDLSequentKit.createSequent(
-            ImmutableSLList.singleton(new SequentFormula(closeable_one)),
-            ImmutableSLList.singleton(new SequentFormula(closeable_two)));
+            ImmutableList.singleton(new SequentFormula(closeable_one)),
+            ImmutableList.singleton(new SequentFormula(closeable_two)));
         TacletIndex index = TacletIndexKit.getKit().createTacletIndex();
         index.add(close_rule.taclet());
         PosInOccurrence pio =
             new PosInOccurrence(new SequentFormula(closeable_two), PosInTerm.getTopLevel(), false);
 
         TacletApp tacletApp =
-            index.getSuccedentTaclet(pio, new IHTacletFilter(true, ImmutableSLList.nil()), services)
+            index.getSuccedentTaclet(pio, new IHTacletFilter(true, ImmutableList.nil()), services)
                     .iterator().next();
         assertTrue(tacletApp.findIfFormulaInstantiations(seq, services).size() > 0,
             "Match should be possible(modulo renaming)");

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
@@ -25,7 +25,6 @@ import org.key_project.prover.rules.instantiation.MatchResultInfo;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.junit.jupiter.api.AfterEach;
@@ -51,10 +50,10 @@ public class TestSchemaModalOperators {
 
     private static ImmutableList<SequentFormula> parseTermForSemisequent(String t) {
         if ("".equals(t)) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
         SequentFormula cf0 = new SequentFormula(TacletForTests.parseTerm(t));
-        return ImmutableSLList.singleton(cf0);
+        return ImmutableList.singleton(cf0);
     }
 
     @BeforeEach
@@ -145,7 +144,7 @@ public class TestSchemaModalOperators {
         rtb.setFind(find);
         rtb.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 replace));
 
         RewriteTaclet t = rtb.getRewriteTaclet();

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/inst/TestGenericSortInstantiations.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/inst/TestGenericSortInstantiations.java
@@ -181,7 +181,7 @@ public class TestGenericSortInstantiations {
     public static ImmutableList<GenericSort> sorts(
             ImmutableList<GenericSortCondition> p_conditions) {
         Iterator<GenericSortCondition> it = p_conditions.iterator();
-        ImmutableList<GenericSort> res = ImmutableSLList.nil();
+        ImmutableList<GenericSort> res = ImmutableList.nil();
 
         while (it.hasNext()) {
             res = res.prepend(it.next().getGenericSort());
@@ -202,7 +202,7 @@ public class TestGenericSortInstantiations {
         ImmutableList<GenericSortCondition> cs;
         GenericSortInstantiations gsi;
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A4));
 
         Services services = TacletForTests.services();
@@ -217,7 +217,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A4),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A2));
 
@@ -231,7 +231,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A4),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A6));
 
@@ -239,7 +239,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, JavaDLTheory.ANY),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, B1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, B5));
 
@@ -256,7 +256,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
 
@@ -264,7 +264,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1).put(G2, A2),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, B3));
 
@@ -272,7 +272,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1).put(G2, B3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, B3));
@@ -315,7 +315,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
 
@@ -323,7 +323,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1).put(G2, A2),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, D3));
 
@@ -331,7 +331,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1).put(G2, D3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, D3));
@@ -374,7 +374,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G3, A5));
@@ -384,7 +384,7 @@ public class TestGenericSortInstantiations {
             DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1).put(G2, A2).put(G3, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A5));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G3, A5));
@@ -394,7 +394,7 @@ public class TestGenericSortInstantiations {
             DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A5).put(G2, A2).put(G3, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A5));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G3, A5));
@@ -405,7 +405,7 @@ public class TestGenericSortInstantiations {
                 .put(G3, A3).put(G4, A1),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A5));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G3, A5));
@@ -417,7 +417,7 @@ public class TestGenericSortInstantiations {
                     .put(G3, JavaDLTheory.ANY).put(G4, B1),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, B2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G4, A5));
@@ -436,7 +436,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A4));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
@@ -449,7 +449,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A4),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A2));
 
@@ -459,7 +459,7 @@ public class TestGenericSortInstantiations {
         } catch (GenericSortException e) {
         }
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1));
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A2));
 
@@ -469,21 +469,21 @@ public class TestGenericSortInstantiations {
         } catch (GenericSortException e) {
         }
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H2, A3));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H2, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H2, A5));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H2, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H2, A4));
 
         try {
@@ -492,21 +492,21 @@ public class TestGenericSortInstantiations {
         } catch (GenericSortException e) {
         }
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H3, A1));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H3, A1),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H3, A1));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H3, A1),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H3, A6));
 
         try {
@@ -525,7 +525,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H1, A4));
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H2, A3));
 
@@ -533,7 +533,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H1, A4).put(H2, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H1, A6));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H2, A5));
 
@@ -542,7 +542,7 @@ public class TestGenericSortInstantiations {
             DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H1, JavaDLTheory.ANY).put(H2, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H2, A4));
         try {
             gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
@@ -551,7 +551,7 @@ public class TestGenericSortInstantiations {
         }
 
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H1, A2));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H2, A5));
 
@@ -559,7 +559,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H1, A3).put(H2, A3),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(H1, A2));
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H3, A5));
 
@@ -567,7 +567,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(H1, A3).put(H3, A5),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H1, A2));
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H3, A5));
 
@@ -577,7 +577,7 @@ public class TestGenericSortInstantiations {
         } catch (GenericSortException e) {
         }
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(H4, A6));
 
         try {
@@ -596,7 +596,7 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A4));
         cs = cs.prepend(GenericSortCondition.createForceInstantiationCondition(G4, true));
         cs = cs.prepend(GenericSortCondition.createForceInstantiationCondition(G3, false));
@@ -613,7 +613,7 @@ public class TestGenericSortInstantiations {
             DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A4).put(G4, A4).put(G3, A4),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createIdentityCondition(G1, A5));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G2, A2));
         cs = cs.prepend(GenericSortCondition.createForceInstantiationCondition(G3, false));
@@ -630,7 +630,7 @@ public class TestGenericSortInstantiations {
                 .put(G3, A3).put(G4, A5),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createForceInstantiationCondition(H3, true));
 
         gsi = GenericSortInstantiations.create(sorts(cs), cs, services);
@@ -646,10 +646,10 @@ public class TestGenericSortInstantiations {
 
         Services services = TacletForTests.services();
         Sort nullSort = new NullSort(services.getJavaInfo().objectSort());
-        services.getNamespaces().sorts().add(ImmutableSLList.<Sort>nil().prepend(A1OBJ)
+        services.getNamespaces().sorts().add(ImmutableList.<Sort>singleton(A1OBJ)
                 .prepend(A2OBJ).prepend(A3OBJ).prepend(A4OBJ).prepend(A5OBJ).prepend(A6OBJ));
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1OBJ));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, nullSort));
 
@@ -663,7 +663,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A3OBJ),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, nullSort));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, A1OBJ));
 
@@ -671,7 +671,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, A1OBJ),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, C1));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, nullSort));
 
@@ -679,7 +679,7 @@ public class TestGenericSortInstantiations {
         assertEquals(DefaultImmutableMap.<GenericSort, Sort>nilMap().put(G1, JavaDLTheory.ANY),
             gsi.getAllInstantiations(), "Instantiations should be equal");
 
-        cs = ImmutableSLList.nil();
+        cs = ImmutableList.nil();
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, nullSort));
         cs = cs.prepend(GenericSortCondition.createSupersortCondition(G1, C1));
 

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/tacletbuilder/TestTacletBuild.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/tacletbuilder/TestTacletBuild.java
@@ -22,7 +22,7 @@ import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +63,7 @@ public class TestTacletBuild {
         sb.setFind(t1);
         sb.addTacletGoalTemplate(
             new RewriteTacletGoalTemplate(JavaDLSequentKit.getInstance().getEmptySequent(),
-                ImmutableSLList.nil(),
+                ImmutableList.nil(),
                 t2));
         boolean thrown = false;
         try {
@@ -86,7 +86,7 @@ public class TestTacletBuild {
             NO_SUBTERMS);
         JTerm t1 = tb.all((QuantifiableVariable) u, A);
         Sequent seq =
-            JavaDLSequentKit.createSuccSequent(ImmutableSLList.singleton(new SequentFormula(t1)));
+            JavaDLSequentKit.createSuccSequent(ImmutableList.singleton(new SequentFormula(t1)));
         JTerm t2 = tb.ex((QuantifiableVariable) u, A);
         SuccTacletBuilder sb = new SuccTacletBuilder();
         sb.setAssumesSequent(seq);
@@ -109,7 +109,7 @@ public class TestTacletBuild {
         JTerm t1 = tb.all((QuantifiableVariable) u, A);
         JTerm t2 = tb.ex((QuantifiableVariable) u, A);
         Sequent seq = JavaDLSequentKit
-                .createSuccSequent(ImmutableSLList.singleton(new SequentFormula(t2))
+                .createSuccSequent(ImmutableList.singleton(new SequentFormula(t2))
                         .prepend(new SequentFormula(t1)));
         SuccTacletBuilder sb = new SuccTacletBuilder();
         sb.setAssumesSequent(seq);

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/ContractFactoryTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/ContractFactoryTest.java
@@ -21,7 +21,6 @@ import de.uka.ilkd.key.speclang.translation.SLTranslationException;
 import de.uka.ilkd.key.util.HelperClassForTests;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -167,7 +166,7 @@ public class ContractFactoryTest {
         JMLSpecFactory jsf = new JMLSpecFactory(services);
         ImmutableList<TextualJMLConstruct> constructs = preParser.parseClassLevel(contractStr);
 
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
         signature = signature.append(javaInfo.getKeYJavaType(PrimitiveType.JAVA_INT));
         IProgramMethod pm = javaInfo.getProgramMethod(testClassType, "m", signature, testClassType);
 

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/SetStatementTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/SetStatementTest.java
@@ -23,7 +23,6 @@ import de.uka.ilkd.key.speclang.njml.JmlParser;
 import de.uka.ilkd.key.util.HelperClassForTests;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Assertions;
@@ -86,7 +85,7 @@ public class SetStatementTest {
                 .context(Context.inClass(testClassType, false, services.getTermBuilder()))
                 .selfVar(selfVar)
                 .parameters(
-                    ImmutableSLList.<LocationVariable>nil().append(ghostLocal, normalLocal));
+                    ImmutableList.of(ghostLocal, normalLocal));
     }
 
     @Test

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLTranslator.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/TestJMLTranslator.java
@@ -25,7 +25,6 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.op.Operator;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -153,7 +152,7 @@ public class TestJMLTranslator {
     public void testParenExpression() {
         ProgramElementName classPEN = new ProgramElementName("o");
         LocationVariable var = new LocationVariable(classPEN, testClassType);
-        jmlIO.parameters(ImmutableSLList.singleton(var)).parseExpression("(o.i)");
+        jmlIO.parameters(ImmutableList.singleton(var)).parseExpression("(o.i)");
     }
 
     @Test
@@ -168,7 +167,7 @@ public class TestJMLTranslator {
     public void testSimpleQuery() {
         ProgramVariable selfVar = buildSelfVarAsProgVar();
         IProgramMethod getOne = javaInfo.getProgramMethod(testClassType, "getOne",
-            ImmutableSLList.nil(), testClassType);
+            ImmutableList.nil(), testClassType);
         JTerm result = jmlIO.parseExpression("this.getOne()");
         assertNotNull(result);
         assertTrue(termContains(result, selfVar));
@@ -319,7 +318,7 @@ public class TestJMLTranslator {
     public void testResultVar() {
         LocationVariable excVar = buildExcVar();
 
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
 
         IProgramMethod pm =
             javaInfo.getProgramMethod(testClassType, "getOne", signature, testClassType);
@@ -367,7 +366,7 @@ public class TestJMLTranslator {
 
     @Test
     public void testComplexQueryResolving1() {
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
         signature = signature.append(javaInfo.getKeYJavaType(PrimitiveType.JAVA_INT));
 
         IProgramMethod pm = javaInfo.getProgramMethod(testClassType, "m", signature, testClassType);
@@ -382,7 +381,7 @@ public class TestJMLTranslator {
 
     @Test
     public void testComplexQueryResolving2() {
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
         signature = signature.append(javaInfo.getKeYJavaType(PrimitiveType.JAVA_LONG));
 
         IProgramMethod pm = javaInfo.getProgramMethod(testClassType, "m", signature, testClassType);
@@ -397,7 +396,7 @@ public class TestJMLTranslator {
 
     @Test
     public void testComplexQueryResolving3() {
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
         signature = signature.append(javaInfo.getKeYJavaType(PrimitiveType.JAVA_INT));
 
         IProgramMethod pm = javaInfo.getProgramMethod(testClassType, "m", signature, testClassType);
@@ -412,7 +411,7 @@ public class TestJMLTranslator {
 
     @Test
     public void testStaticQueryResolving() {
-        ImmutableList<KeYJavaType> signature = ImmutableSLList.nil();
+        ImmutableList<KeYJavaType> signature = ImmutableList.nil();
 
         IProgramMethod pm =
             javaInfo.getProgramMethod(testClassType, "staticMethod", signature, testClassType);

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/ExpressionTranslatorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/ExpressionTranslatorTest.java
@@ -13,7 +13,7 @@ import de.uka.ilkd.key.logic.ProgramElementName;
 import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.rule.TacletForTests;
 
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +55,7 @@ public class ExpressionTranslatorTest {
         JmlParser.ExpressionContext ctx = parser.expressionEOF().expression();
         Assertions.assertEquals(0, parser.getNumberOfSyntaxErrors());
         Translator et = new Translator(services, kjt, self, SpecMathMode.defaultMode(),
-            ImmutableSLList.nil(), result, exc, new HashMap<>(), new HashMap<>());
+            ImmutableList.nil(), result, exc, new HashMap<>(), new HashMap<>());
         LOGGER.debug("{}", ctx.accept(et));
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/strategy/feature/TestNonDuplicateAppFeature.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/strategy/feature/TestNonDuplicateAppFeature.java
@@ -24,7 +24,6 @@ import org.key_project.prover.strategy.costbased.RuleAppCost;
 import org.key_project.prover.strategy.costbased.TopRuleAppCost;
 import org.key_project.prover.strategy.costbased.feature.Feature;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -48,10 +47,10 @@ public class TestNonDuplicateAppFeature {
 
     /** Root sequent {@code ==> A -> B, B -> A} (two distinct succedent formulas). */
     private static Sequent twoImplications() {
-        ImmutableList<SequentFormula> succ = ImmutableSLList.<SequentFormula>nil()
+        ImmutableList<SequentFormula> succ = ImmutableList.<SequentFormula>nil()
                 .append(new SequentFormula(TacletForTests.parseTerm("A -> B")))
                 .append(new SequentFormula(TacletForTests.parseTerm("B -> A")));
-        return JavaDLSequentKit.createSequent(ImmutableSLList.nil(), succ);
+        return JavaDLSequentKit.createSequent(ImmutableList.nil(), succ);
     }
 
     private static Goal goalFor(Node n, TacletIndex idx) {
@@ -128,7 +127,7 @@ public class TestNonDuplicateAppFeature {
         Proof proof = new Proof("TestNonDuplicateAppFeature", TacletForTests.initConfig());
         SequentFormula conj = new SequentFormula(TacletForTests.parseTerm("(A -> B) & (A -> B)"));
         Node root = new Node(proof,
-            JavaDLSequentKit.createSequent(ImmutableSLList.nil(), ImmutableSLList.singleton(conj)));
+            JavaDLSequentKit.createSequent(ImmutableList.nil(), ImmutableList.singleton(conj)));
         proof.setRoot(root);
 
         TacletIndex idx = TacletIndexKit.getKit().createTacletIndex();

--- a/key.core/src/test/java/de/uka/ilkd/key/util/TestSearchNodePreorderIterator.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/TestSearchNodePreorderIterator.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.proof.init.AbstractProfile;
 import de.uka.ilkd.key.proof.init.InitConfig;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.Test;
 
@@ -111,7 +110,7 @@ public class TestSearchNodePreorderIterator {
     protected void assertRoot(Node root) {
         // List children
         NodePreorderIterator iter = new NodePreorderIterator(root);
-        ImmutableList<Node> childList = ImmutableSLList.nil();
+        ImmutableList<Node> childList = ImmutableList.nil();
         while (iter.hasNext()) {
             Node next = iter.next();
             childList = childList.append(next);
@@ -119,7 +118,7 @@ public class TestSearchNodePreorderIterator {
         // Test each child
         while (!childList.isEmpty()) {
             assertPreorder(childList.head(), childList);
-            childList = childList.take(1);
+            childList = childList.tail();
         }
     }
 
@@ -135,7 +134,7 @@ public class TestSearchNodePreorderIterator {
         while (iter.hasNext()) {
             Node previous = iter.next();
             assertEquals(previous, expectedChildList.head());
-            expectedChildList = expectedChildList.take(1); // Remove head
+            expectedChildList = expectedChildList.tail(); // Remove head
         }
         assertTrue(expectedChildList.isEmpty(),
             "Child list still contains " + expectedChildList.size() + " elements.");

--- a/key.core/src/test/java/de/uka/ilkd/key/util/TestSearchNodeReversePreorderIterator.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/TestSearchNodeReversePreorderIterator.java
@@ -11,7 +11,6 @@ import de.uka.ilkd.key.proof.init.AbstractProfile;
 import de.uka.ilkd.key.proof.init.InitConfig;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +109,7 @@ public class TestSearchNodeReversePreorderIterator {
      */
     protected void assertRoot(Node root) {
         NodePreorderIterator iter = new NodePreorderIterator(root);
-        ImmutableList<Node> reverseList = ImmutableSLList.nil();
+        ImmutableList<Node> reverseList = ImmutableList.nil();
         while (iter.hasNext()) {
             Node next = iter.next();
             reverseList = reverseList.prepend(next);
@@ -131,7 +130,7 @@ public class TestSearchNodeReversePreorderIterator {
         while (reverseIter.hasPrevious()) {
             Node previous = reverseIter.previous();
             assertEquals(previous, expectedReverseList.head());
-            expectedReverseList = expectedReverseList.take(1); // Remove head
+            expectedReverseList = expectedReverseList.tail(); // Remove head
         }
         assertTrue(expectedReverseList.isEmpty(),
             "Reverse still contains " + expectedReverseList.size() + " elements.");

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/indexing/FormulaTagManager.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/indexing/FormulaTagManager.java
@@ -10,7 +10,6 @@ import org.key_project.logic.PosInTerm;
 import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -267,7 +266,7 @@ public final class FormulaTagManager {
         public final long age;
 
         public FormulaInfo(PosInOccurrence pio, long age) {
-            this(pio, ImmutableSLList.nil(), age);
+            this(pio, ImmutableList.nil(), age);
         }
 
         private FormulaInfo(PosInOccurrence pio, ImmutableList<FormulaChangeInfo> modifications,

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/rules/TacletExecutor.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/rules/TacletExecutor.java
@@ -15,7 +15,6 @@ import org.key_project.prover.rules.instantiation.MatchResultInfo;
 import org.key_project.prover.rules.instantiation.SVInstantiations;
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.jspecify.annotations.NonNull;
@@ -75,7 +74,7 @@ public abstract class TacletExecutor<Goal extends @NonNull ProofGoal<Goal>, App 
                     }
 
                     if (res == null) {
-                        res = ImmutableSLList.nil();
+                        res = ImmutableList.nil();
                         for (int j = 0; j < p_numberOfNewGoals + 1; j++) {
                             // noinspection unchecked
                             res = res.prepend(
@@ -106,7 +105,7 @@ public abstract class TacletExecutor<Goal extends @NonNull ProofGoal<Goal>, App 
         }
 
         if (res == null) {
-            res = ImmutableSLList.nil();
+            res = ImmutableList.nil();
             for (int j = 0; j < p_numberOfNewGoals; j++) {
                 // noinspection unchecked
                 res = res.prepend(SequentChangeInfo.createSequentChangeInfo(p_goal.sequent()));
@@ -325,7 +324,7 @@ public abstract class TacletExecutor<Goal extends @NonNull ProofGoal<Goal>, App 
     protected ImmutableList<SequentFormula> instantiateSemisequent(Semisequent semi,
             PosInOccurrence applicationPosInOccurrence, MatchResultInfo matchCond, Goal goal,
             App tacletApp, LogicServices services, Object... instantiationInfo) {
-        ImmutableList<SequentFormula> replacements = ImmutableSLList.nil();
+        ImmutableList<SequentFormula> replacements = ImmutableList.nil();
 
         for (final SequentFormula sf : semi) {
             replacements = replacements.append(instantiateReplacement(sf, services,

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/Semisequent.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/Semisequent.java
@@ -6,7 +6,6 @@ package org.key_project.prover.sequent;
 import java.util.Iterator;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -29,12 +28,12 @@ public abstract class Semisequent implements Iterable<SequentFormula> {
 
     /// used by inner class Empty
     protected Semisequent() {
-        seqList = ImmutableSLList.nil();
+        seqList = ImmutableList.nil();
     }
 
     /// creates a new [Semisequent] with the [Semisequent] elements in seqList
     private Semisequent(SequentFormula seqFormula) {
-        this(ImmutableSLList.singleton(seqFormula));
+        this(ImmutableList.singleton(seqFormula));
     }
 
     /// inserts an element at a specified index performing redundancy checks, this may result in
@@ -117,7 +116,7 @@ public abstract class Semisequent implements Iterable<SequentFormula> {
         final var orig = semiCI.getFormulaList();
         pos = Math.min(idx, orig.size());
 
-        searchList = semiCI.getFormulaList().take(pos).prepend(sequentFormula);
+        searchList = semiCI.getFormulaList().skip(pos).prepend(sequentFormula);
 
         while (pos > 0) {
             --pos;
@@ -182,7 +181,7 @@ public abstract class Semisequent implements Iterable<SequentFormula> {
         if (idx < 0 || idx >= seqList.size()) {
             throw new IndexOutOfBoundsException();
         }
-        return seqList.take(idx).head();
+        return seqList.get(idx);
     }
 
     /// @return the first [SequentFormula] of this [Semisequent]

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/SemisequentChangeInfo.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/SemisequentChangeInfo.java
@@ -4,20 +4,19 @@
 package org.key_project.prover.sequent;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 public class SemisequentChangeInfo {
     /// contains the added formulas to the semisequent
-    private ImmutableList<SequentFormula> added = ImmutableSLList.nil();
+    private ImmutableList<SequentFormula> added = ImmutableList.nil();
     /// contains the removed formulas from the semisequent
-    private ImmutableList<SequentFormula> removed = ImmutableSLList.nil();
+    private ImmutableList<SequentFormula> removed = ImmutableList.nil();
     /// contains the modified formulas from the semisequent
-    private ImmutableList<FormulaChangeInfo> modified = ImmutableSLList.nil();
+    private ImmutableList<FormulaChangeInfo> modified = ImmutableList.nil();
     /// stores the redundance free formula list of the semisequent
-    private ImmutableList<SequentFormula> modifiedSemisequent = ImmutableSLList.nil();
+    private ImmutableList<SequentFormula> modifiedSemisequent = ImmutableList.nil();
     /// contains formulas that have been tried to add, but which have been rejected due to already
     /// existing formulas in the sequent subsuming these formulas
-    private ImmutableList<SequentFormula> rejected = ImmutableSLList.nil();
+    private ImmutableList<SequentFormula> rejected = ImmutableList.nil();
 
     ///
     private int lastFormulaIndex = -1;

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/Sequent.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/sequent/Sequent.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import org.key_project.logic.SyntaxElement;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -419,7 +418,7 @@ public abstract class Sequent implements Iterable<SequentFormula>, SyntaxElement
 
         @Override
         public @NonNull Iterator<SequentFormula> iterator() {
-            return ImmutableSLList.<SequentFormula>nil().iterator();
+            return ImmutableList.<SequentFormula>nil().iterator();
         }
     }
 

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/feature/instantiator/BackTrackingManager.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/feature/instantiator/BackTrackingManager.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.key_project.prover.rules.RuleApp;
-import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.collection.ImmutableList;
 
 import org.jspecify.annotations.Nullable;
 
@@ -148,7 +148,7 @@ public final class BackTrackingManager {
     }
 
     private void cancelChoicePoint() {
-        pushChoices(ImmutableSLList.<CPBranch>nil().iterator(), null);
+        pushChoices(ImmutableList.<CPBranch>nil().iterator(), null);
     }
 
 

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termgenerator/SubtermGenerator.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termgenerator/SubtermGenerator.java
@@ -15,7 +15,6 @@ import org.key_project.prover.strategy.costbased.TopRuleAppCost;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.termfeature.TermFeature;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.NonNull;
 
@@ -78,7 +77,7 @@ public abstract class SubtermGenerator<Goal extends ProofGoal<@NonNull Goal>>
         protected final LogicServices services;
 
         protected SubIterator(Term t, MutableState mState, LogicServices services) {
-            termStack = ImmutableSLList.<Term>nil().prepend(t);
+            termStack = ImmutableList.<Term>singleton(t);
             this.mState = mState;
             this.services = services;
         }

--- a/key.ui/examples/standard_key/pred_log/count.key.proof
+++ b/key.ui/examples/standard_key/pred_log/count.key.proof
@@ -89,12 +89,12 @@
 }
 
 \proof {
-(keyLog "0" (keyUser "bubel" ) (keyVersion "2adca9ec049c92ef6637857798b152e80f8dc971"))
+(keyLog "0" (keyUser "weigl" ) (keyVersion "818f1480eb586a735ccec080221b21748cbbb435"))
 
-(autoModeTime "3")
+(autoModeTime "11")
 
 (branch "dummy ID"
-(rule "impRight" (formula "1") (newnames "heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,heapAtPre,savedHeapAtPre,vAtPre"))
+(rule "impRight" (formula "1") (newnames "heapAtPre,savedHeapAtPre,arg0AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,vAtPre"))
 (rule "andLeft" (formula "1"))
 (rule "polySimp_addComm0" (formula "1") (term "0,1,0"))
 (rule "nnf_imp2or" (formula "1") (term "0"))

--- a/key.ui/examples/standard_key/pred_log/equalities2.key.proof
+++ b/key.ui/examples/standard_key/pred_log/equalities2.key.proof
@@ -86,12 +86,12 @@
 }
 
 \proof {
-(keyLog "0" (keyUser "bubel" ) (keyVersion "2adca9ec049c92ef6637857798b152e80f8dc971"))
+(keyLog "0" (keyUser "weigl" ) (keyVersion "818f1480eb586a735ccec080221b21748cbbb435"))
 
-(autoModeTime "3")
+(autoModeTime "13")
 
 (branch "dummy ID"
-(rule "impRight" (formula "1") (newnames "heapAtPre,savedHeapAtPre,arg0AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,vAtPre"))
+(rule "impRight" (formula "1") (newnames "heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,arg1AtPre,heapAtPre,savedHeapAtPre,arg0AtPre,heapAtPre,savedHeapAtPre,vAtPre"))
 (rule "andLeft" (formula "1"))
 (rule "eqSymm" (formula "1"))
 (rule "polySimp_homoEq" (formula "2"))

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/InvariantConfigurator.java
@@ -31,7 +31,6 @@ import de.uka.ilkd.key.util.InfFlowSpec;
 import org.key_project.logic.sort.Sort;
 import org.key_project.prover.rules.RuleAbortException;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import static java.lang.String.format;
 
@@ -1007,10 +1006,10 @@ public class InvariantConfigurator {
                 // TODO: allow more than one term
                 JTerm newObjects = parser.parseExpression(newObjectsAsString);
 
-                return ImmutableSLList.<InfFlowSpec>nil()
-                        .append(new InfFlowSpec(ImmutableSLList.<JTerm>nil().append(preExps),
-                            ImmutableSLList.<JTerm>nil().append(postExps),
-                            ImmutableSLList.<JTerm>nil().append(newObjects)));
+                return ImmutableList.<InfFlowSpec>nil()
+                        .append(new InfFlowSpec(ImmutableList.<JTerm>nil().append(preExps),
+                            ImmutableList.<JTerm>nil().append(postExps),
+                            ImmutableList.<JTerm>nil().append(newObjects)));
             }
 
             protected JTerm parseVariant() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/RunStrategyOnNodeUserAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/RunStrategyOnNodeUserAction.java
@@ -9,7 +9,6 @@ import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * User action to start auto mode on a specific goal.
@@ -58,7 +57,7 @@ public class RunStrategyOnNodeUserAction extends ProofModifyingUserAction {
             // which implements the functionality.
             // No functionality is allowed in this method body!
             mediator.getUI().getProofControl().startAutoMode(r.getSelectedProof(),
-                ImmutableSLList.<Goal>nil().prepend(invokedGoal));
+                ImmutableList.<Goal>singleton(invokedGoal));
         }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/mergerule/MergePartnerSelectionDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/mergerule/MergePartnerSelectionDialog.java
@@ -30,7 +30,6 @@ import de.uka.ilkd.key.util.mergerule.MergeRuleUtils;
 
 import org.key_project.prover.sequent.*;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 
 /**
@@ -327,7 +326,7 @@ public class MergePartnerSelectionDialog extends JDialog {
      * @return All chosen merge partners.
      */
     public ImmutableList<MergePartner> getChosenCandidates() {
-        ImmutableSLList<MergePartner> result = ImmutableSLList.nil();
+        ImmutableList<MergePartner> result = ImmutableList.nil();
 
         if (chosenGoals != null) {
             return result.append(chosenGoals);
@@ -433,7 +432,7 @@ public class MergePartnerSelectionDialog extends JDialog {
         final TermBuilder tb = services.getTermBuilder();
 
         Sequent toProve = JavaDLSequentKit.createSequent(seq.antecedent().asList(),
-            ImmutableSLList.singleton(new SequentFormula(formulaToProve)));
+            ImmutableList.singleton(new SequentFormula(formulaToProve)));
 
         for (SequentFormula succedentFormula : seq.succedent()) {
             final JTerm formula = (JTerm) succedentFormula.formula();
@@ -451,7 +450,7 @@ public class MergePartnerSelectionDialog extends JDialog {
      * @return An ImmutableList consisting of the elements in it.
      */
     private <T> ImmutableList<T> immutableListFromIterabe(Iterable<T> it) {
-        ImmutableList<T> result = ImmutableSLList.nil();
+        ImmutableList<T> result = ImmutableList.nil();
         for (T t : it) {
             result = result.prepend(t);
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalViewMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/CurrentGoalViewMenu.java
@@ -42,7 +42,6 @@ import org.key_project.prover.rules.RuleSet;
 import org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.java.StringUtil;
 
 import org.jspecify.annotations.NonNull;
@@ -120,7 +119,7 @@ public final class CurrentGoalViewMenu extends SequentViewMenu<CurrentGoalView> 
             ImmutableList<TacletApp> list) {
         return list.stream()
                 .filter(app -> !app.rule().name().toString().equals(INTRODUCE_AXIOM_TACLET_NAME))
-                .collect(ImmutableSLList.toImmutableList());
+                .collect(ImmutableList.collector());
     }
 
     /**
@@ -130,7 +129,7 @@ public final class CurrentGoalViewMenu extends SequentViewMenu<CurrentGoalView> 
      * @return list without RewriteTaclets
      */
     public static ImmutableList<TacletApp> removeRewrites(ImmutableList<TacletApp> list) {
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
 
         for (TacletApp tacletApp : list) {
             Taclet taclet = tacletApp.taclet();
@@ -323,7 +322,7 @@ public final class CurrentGoalViewMenu extends SequentViewMenu<CurrentGoalView> 
      */
     public static ImmutableList<TacletApp> sort(ImmutableList<TacletApp> finds,
             TacletAppComparator comp) {
-        ImmutableList<TacletApp> result = ImmutableSLList.nil();
+        ImmutableList<TacletApp> result = ImmutableList.nil();
 
         List<TacletApp> list = new ArrayList<>(finds.size());
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/DragNDropInstantiator.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/DragNDropInstantiator.java
@@ -34,7 +34,6 @@ import org.key_project.prover.rules.tacletbuilder.TacletGoalTemplate;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * <p>
@@ -184,7 +183,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
         final Sequent sequent = seqView.getMediator().getSelectedGoal().sequent();
 
 
-        ImmutableList<PosTacletApp> applicableApps = ImmutableSLList.nil();
+        ImmutableList<PosTacletApp> applicableApps = ImmutableList.nil();
         if (targetPos.isSequent()) {
             // collects all applicable taclets at the source position
             // which have an addrule section
@@ -220,7 +219,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
     private ImmutableList<PosTacletApp> getDirectionDependentApps(final PosInSequent sourcePos,
             final PosInSequent targetPos, final Services services, final Sequent sequent) {
 
-        ImmutableList<PosTacletApp> applicableApps = ImmutableSLList.nil();
+        ImmutableList<PosTacletApp> applicableApps = ImmutableList.nil();
         // all applicable taclets where the drag source has been interpreted
         // as
         // the find part and the drop position as the one of the
@@ -286,10 +285,10 @@ public class DragNDropInstantiator extends DropTargetAdapter {
             TacletFilter filter, Services services) {
 
         if (findPos == null || findPos.isSequent()) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
-        ImmutableList<TacletApp> allTacletsAtFindPosition = ImmutableSLList.nil();
+        ImmutableList<TacletApp> allTacletsAtFindPosition = ImmutableList.nil();
         KeYMediator r = seqView.getMediator();
 
         // if in replaceWithMode only apps that contain at least one replacewith
@@ -318,7 +317,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
     private ImmutableList<PosTacletApp> addPositionInformation(ImmutableList<TacletApp> tacletApps,
             PosInOccurrence findPos, Services services) {
 
-        ImmutableList<PosTacletApp> applicableApps = ImmutableSLList.nil();
+        ImmutableList<PosTacletApp> applicableApps = ImmutableList.nil();
         for (TacletApp tacletApp : tacletApps) {
             TacletApp app = tacletApp;
             if (app instanceof NoPosTacletApp) {
@@ -349,7 +348,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
     private ImmutableList<PosTacletApp> completeIfInstantiations(ImmutableList<PosTacletApp> apps,
             Sequent seq, PosInOccurrence assumesPIO, Services services) {
 
-        ImmutableList<PosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<PosTacletApp> result = ImmutableList.nil();
 
         final ImmutableList<AssumesFormulaInstantiation> assumesFormulaInstantiations;
 
@@ -361,7 +360,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
             final AssumesFormulaInstSeq assumesInstantiationInSeq =
                 new AssumesFormulaInstSeq(seq, assumesPIO.isInAntec(),
                     assumesPIO.sequentFormula());
-            assumesFormulaInstantiations = ImmutableSLList.<AssumesFormulaInstantiation>nil()
+            assumesFormulaInstantiations = ImmutableList.<AssumesFormulaInstantiation>nil()
                     .prepend(assumesInstantiationInSeq);
         }
 
@@ -377,7 +376,7 @@ public class DragNDropInstantiator extends DropTargetAdapter {
                 } else if (assumesFormulaInstantiations == null) {
                     // as either all taclets have an assumes-sequent or none
                     // we can exit here
-                    return ImmutableSLList.nil();
+                    return ImmutableList.nil();
                 } else {
                     // the right side is not checked in tacletapp
                     // not sure where to incorporate the check...
@@ -414,9 +413,9 @@ public class DragNDropInstantiator extends DropTargetAdapter {
     private ImmutableList<PosTacletApp> completeInstantiations(ImmutableList<PosTacletApp> apps,
             PosInOccurrence missingSVPIO, Services services) {
 
-        ImmutableList<PosTacletApp> result = ImmutableSLList.nil();
+        ImmutableList<PosTacletApp> result = ImmutableList.nil();
         if (missingSVPIO == null) {
-            return ImmutableSLList.nil();
+            return ImmutableList.nil();
         }
 
         for (PosTacletApp app1 : apps) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/nodeviews/SequentView.java
@@ -36,7 +36,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -761,7 +760,7 @@ public abstract class SequentView extends JEditorPane {
                 for (int j = 0; j < max_age && j < sortedArray.length; ++j) {
                     if (sortedArray[j].equals(entry)) {
                         Color color = computeColorForAge(max_age, j);
-                        ImmutableSLList<Integer> list = (ImmutableSLList<Integer>) ImmutableSLList
+                        ImmutableList<Integer> list = (ImmutableList<Integer>) ImmutableList
                                 .<Integer>nil().prepend(0).append(i);
                         Range r = ipt.rangeForPath(list);
                         // Off-by-one: siehe updateUpdateHighlights bzw in InnerNodeView.
@@ -780,7 +779,7 @@ public abstract class SequentView extends JEditorPane {
                     form, max_age + 2);
                 if (age < max_age) {
                     Color color = computeColorForAge(max_age, age);
-                    ImmutableSLList<Integer> list = (ImmutableSLList<Integer>) ImmutableSLList
+                    ImmutableList<Integer> list = (ImmutableList<Integer>) ImmutableList
                             .<Integer>nil().prepend(0).append(i);
                     Range r = ipt.rangeForPath(list);
                     // Off-by-one: siehe updateUpdateHighlights bzw in InnerNodeView. rangeForPath

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/OriginTermLabelVisualizer.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/originlabels/OriginTermLabelVisualizer.java
@@ -36,7 +36,6 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import bibliothek.gui.dock.common.DefaultSingleCDockable;
 
@@ -503,7 +502,7 @@ public final class OriginTermLabelVisualizer extends NodeInfoVisualizer {
     private ImmutableList<Integer> getPosTablePath(
             PosInOccurrence pos) {
         if (pos == null) {
-            return ImmutableSLList.<Integer>nil().prepend(0);
+            return ImmutableList.<Integer>singleton(0);
         }
 
         InitialPositionTable posTable = view.posTable;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/MatchInfoPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/MatchInfoPanel.java
@@ -28,7 +28,6 @@ import org.key_project.logic.Term;
 import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Overview of how the selected taclet matched the sequent: the schematic find pattern, the concrete
@@ -260,7 +259,7 @@ public class MatchInfoPanel extends JPanel {
         for (SvSpan span : spans) {
             // the initial position table roots the printed term at path [0]; the sub-term path
             // follows below it
-            ImmutableList<Integer> p = ImmutableSLList.<Integer>nil().append(0);
+            ImmutableList<Integer> p = ImmutableList.singleton(0);
             for (int idx : span.path()) {
                 p = p.append(idx);
             }

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
@@ -46,7 +46,6 @@ import org.key_project.prover.engine.TaskFinishedInfo;
 import org.key_project.prover.engine.TaskStartedInfo;
 import org.key_project.prover.engine.TaskStartedInfo.TaskKind;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.parsing.Location;
 
@@ -63,7 +62,7 @@ public class ConsoleUserInterfaceControl extends AbstractMediatorUserInterfaceCo
     private static final String PROGRESS_MARK = ">";
 
     // Substitute for TaskTree (GUI) to facilitate side proofs in console mode
-    ImmutableList<Proof> proofStack = ImmutableSLList.nil();
+    ImmutableList<Proof> proofStack = ImmutableList.nil();
 
     final KeYMediator mediator;
 

--- a/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
+++ b/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
@@ -40,7 +40,7 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
     }
 
     protected DefaultImmutableSet() {
-        elementList = ImmutableSLList.nil();
+        elementList = ImmutableList.nil();
     }
 
     /**
@@ -49,7 +49,7 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
      * @param element of type <T> the new Set contains
      */
     private DefaultImmutableSet(T element) {
-        elementList = (ImmutableSLList.<T>nil()).prepend(element);
+        elementList = ImmutableList.<T>singleton(element);
     }
 
     /**
@@ -155,7 +155,7 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
             return (ImmutableSet<T>) set;
         }
 
-        ImmutableList<T> intersectElements = ImmutableSLList.nil();
+        ImmutableList<T> intersectElements = ImmutableList.nil();
         for (T el : set) {
             if (contains(el)) {
                 intersectElements = intersectElements.prepend(el);
@@ -353,7 +353,7 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
         /** @return Iterator<T> of the set */
         @Override
         public Iterator<T> iterator() {
-            return ImmutableSLList.<T>nil().iterator();
+            return ImmutableList.<T>nil().iterator();
         }
 
         /** @return true iff this set is subset of set s */

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableArray.java
@@ -13,11 +13,14 @@ import org.key_project.util.Strings;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * @deprecated weigl: Deprecated in favor of {@link ImmutableList} and the new list and array-based
+ *             implementation.
+ *             Use {@link ImmutableList} and {@link ImmutableList#of(Object[])}.
+ */
+@Deprecated(since = "3.0.0 / June 2026")
 public class ImmutableArray<S extends @Nullable Object>
         implements java.lang.Iterable<S>, java.io.Serializable {
-
-    private static final long serialVersionUID = -9041545065066866250L;
-
     private final S[] content;
 
     /**
@@ -93,7 +96,9 @@ public class ImmutableArray<S extends @Nullable Object>
     }
 
 
-    /** @return size of the array */
+    /**
+     * @return size of the array
+     */
     public int size() {
         return content.length;
     }
@@ -206,7 +211,7 @@ public class ImmutableArray<S extends @Nullable Object>
      * @return This element converted to an {@link ImmutableList}.
      */
     public ImmutableList<S> toImmutableList() {
-        ImmutableList<S> ret = ImmutableSLList.nil();
+        ImmutableList<S> ret = ImmutableList.nil();
         for (S s : this) {
             ret = ret.prepend(s);
         }

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableList.java
@@ -3,275 +3,460 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.collection;
 
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.jspecify.annotations.Nullable;
 
-/**
- * List interface to be implemented by non-destructive lists
- */
+/// List interface to be implemented by non-destructive immutable lists.
+///
+/// This interface provides a functional, immutable alternative to [java.util.List].
+/// All operations that would modify a list instead return new [ImmutableList] instances,
+/// preserving the original list unchanged. Operations are optimized for performance, typically
+/// achieving `O(1)` complexity by constructing views of the original list rather than
+/// copying data.
+///
+/// ## Key Features
+///
+/// - **Immutability:** Once created, lists cannot be modified
+/// - **Structural sharing:** New lists share structure with existing lists when possible
+/// - **Lazily evaluated views:** Operations like [#reverse()], [#skip(int)],
+/// and [#take(int)] create views without copying elements
+///
+/// ## Factory Methods
+///
+/// Use the static factory methods to create instances:
+///
+/// - [#of()] - empty list
+/// - [#of(Object)] - singleton list
+/// - [#of(Object...)] - list from varargs
+/// - [#fromList(List)] - list from Java List
+/// - [#fromArray(Object\[\])] - list from array
+///
+/// @param <T> the type of elements in this list (may be nullable)
+/// @see ImmutableListSubList view of a sub-list
+/// @see ImmutableListArray base implementation using arrays
+/// @see ImmutableListConcat concatenated view of two lists
+/// @see ImmutableListReverse reverse view of a list
+/// @see ImmutableListList base implementation using java.util.List
+/// @see ImmutableSLList base implementation using cons/nil structure
+@SuppressWarnings("unchecked")
 public interface ImmutableList<T extends @Nullable Object>
         extends Iterable<T>, java.io.Serializable {
 
-    /**
-     * Returns a Collector that accumulates the input elements into a new ImmutableList.
-     *
-     * @return a Collector that accumulates the input elements into a new ImmutableList.
-     */
+    /// Returns a [Collector] that accumulates the input elements into a new [ImmutableList]
+    /// using a [LinkedList]. If you know the capacity in advance, use [#collector(int)]
     @SuppressWarnings("nullness") // it seems some annotations are missing on Collector.of ...
     static <T extends @Nullable Object> Collector<T, List<T>, ImmutableList<T>> collector() {
         return Collector.of(LinkedList::new, List::add, (list1, list2) -> {
             list1.addAll(list2);
             return list1;
-        }, ImmutableList::fromList);
+        }, ImmutableListList::createDirectlyWithoutImmutableGuarantee);
     }
 
-    /**
-     * Creates an ImmutableList from a List.
-     *
-     * @param list a List.
-     * @return an ImmutableList containing the same elements as the specified list.
-     */
+    /// Returns a [Collector] that accumulates the input elements into a new [ImmutableList].
+    ///
+    /// @param initialCapacity the initial capacity of the [ArrayList] used to collect the elements
+    @SuppressWarnings("nullness")
+    static <T extends @Nullable Object> Collector<T, List<T>, ImmutableList<T>> collector(
+            int initialCapacity) {
+        return Collector.of(() -> new ArrayList<>(initialCapacity), List::add, (list1, list2) -> {
+            list1.addAll(list2);
+            return list1;
+        }, ImmutableListList::createDirectlyWithoutImmutableGuarantee);
+    }
+
+    /// Creates an [ImmutableList] from an [Iterable].
+    ///
+    /// This method is not recommended for use as space overhead is required.
+    /// Prefer [#fromList(List)] or [#fromArray(Object\[\])] when possible,
+    /// as [Iterable] have an unknown size.
+    ///
+    /// This method is idempotent, if `list` is an [ImmutableList].
+    ///
+    /// @param list an Iterable to convert
+    /// @param <T> the element type
+    /// @return an ImmutableList containing the same elements as the specified iterable
+    /// @see #fromList(List)
+    /// @see #fromArray(Object[])
     static <T extends @Nullable Object> ImmutableList<T> fromList(Iterable<? extends T> list) {
-        ImmutableList<T> result = ImmutableSLList.nil();
-
-        for (T el : list) {
-            result = result.append(el);
+        // Short-cuts, iterables are often lists, if so use them and try to avoid copy.
+        if (list instanceof ImmutableList<?> ilist) {
+            return (ImmutableList<T>) ilist;
         }
 
-        return result;
+        if (list instanceof List<?> ilist) {
+            return fromList((List<T>) ilist);
+        }
+
+        List<T> seq = new ArrayList<>(64);
+        for (var t : list) {
+            seq.add(t);
+        }
+        return fromList(seq);
     }
 
-    /**
-     * Return an empty immutable list.
-     *
-     * @return empty immutable list.
-     * @param <T> the entry type of the list.
-     */
+    /// Creates an [ImmutableList] from a [List].
+    ///
+    /// This method wraps the given list in an immutable wrapper. The input list is
+    /// copied to ensure immutability guarantees are maintained.
+    ///
+    /// @param <T> the element type
+    /// @param list the list to wrap
+    /// @return an ImmutableList containing the elements of the input list
+    static <T extends @Nullable Object> ImmutableList<T> fromList(List<T> list) {
+        return new ImmutableListList<>(list);
+    }
+
+    /// Creates an [ImmutableList] from an array.
+    ///
+    /// This method wraps the given array in an immutable wrapper. The input array is
+    /// copied to ensure immutability guarantees are maintained.
+    ///
+    /// @param <T> the element type
+    /// @param array the array to wrap
+    /// @return an ImmutableList containing the elements of the input array
+    static <T extends @Nullable Object> ImmutableList<T> fromArray(T[] array) {
+        return new ImmutableListArray<>(array);
+    }
+
+
+    /// Return an empty immutable list.
+    ///
+    /// @param <T> the entry type of the list.
+    /// @return empty immutable list.
     static <T extends @Nullable Object> ImmutableList<T> of() {
-        return ImmutableSLList.nil();
+        return nil();
     }
 
-    /**
-     * Return a singleton immutable list.
-     *
-     * @param e1 the element to put into the list
-     * @return singleton immutable list.
-     * @param <T> the entry type of the list.
-     */
+    /// Return a singleton immutable list.
+    ///
+    /// @param e1 the element to put into the list
+    /// @param <T> the entry type of the list.
+    /// @return singleton immutable list.
     static <T extends @Nullable Object> ImmutableList<T> of(T e1) {
-        return ImmutableSLList.singleton(e1);
+        return singleton(e1);
     }
 
-    /**
-     * Return an immutable list with two elements.
-     * The iteration order is: e1 then e2
-     *
-     * @param e1 the element to put into the list
-     * @param e2 the element to put into the list
-     * @return (e1, e2) as immutable list
-     * @param <T> the entry type of the list.
-     */
-    static <T extends @Nullable Object> ImmutableList<T> of(T e1, T e2) {
-        return ImmutableSLList.singleton(e2).prepend(e1);
-    }
-
-    /**
-     * Return an immutable list with three elements.
-     * The iteration order is: e1 then e2 then e3
-     *
-     * @param e1 the element to put into the list
-     * @param e2 the element to put into the list
-     * @param e3 the element to put into the list
-     * @return (e1, e2, e3) as immutable list
-     * @param <T> the entry type of the list.
-     */
-    static <T extends @Nullable Object> ImmutableList<T> of(T e1, T e2, T e3) {
-        return ImmutableSLList.singleton(e3).prepend(e2).prepend(e1);
-    }
-
-    /**
-     * Return an immutable list with the iterated elements.
-     * The iteration order is the order of the arguments
-     *
-     * @param es the elements to put into the list
-     * @return (e1, e2, e3, ...) as immutable list
-     * @param <T> the entry type of the list.
-     */
+    /// Return an immutable list with the iterated elements.
+    /// The iteration order is the order of the arguments.
+    ///
+    /// Optimization for `n=0` and `n=1`.
+    ///
+    /// @param es the elements to put into the list
+    /// @param <T> the entry type of the list.
+    /// @return (e1, e2, e3, ...) as immutable list
     static <T extends @Nullable Object> ImmutableList<T> of(T... es) {
-        ImmutableList<T> result = ImmutableSLList.nil();
-        for (int i = es.length - 1; i >= 0; i--) {
-            result = result.prepend(es[i]);
+        if (es.length == 0) {
+            return of();
         }
-        return result;
+
+        if (es.length == 1) {
+            return of(es[0]);
+        }
+
+        return new ImmutableListArray<>(es);
     }
 
-    /**
-     * prepends element to the list (non-destructive)
-     *
-     * @param element the head of the created list
-     * @return IList<T> with the new element as head and this list as tail
-     */
-    ImmutableList<T> prepend(T element);
+    /// the empty list
+    static <T extends @Nullable Object> ImmutableList<T> nil() {
+        return (ImmutableSLList<T>) ImmutableSLList.NIL.NIL;
+    }
 
-    /**
-     * prepends a whole list (non-destructive)
-     *
-     * @param list the list to be prepended
-     * @return IList<T> list++this
-     */
+    /// Creates an [ImmutableList] containing a single element.
+    ///
+    /// @param <T> the element type
+    /// @param obj the element to put in the list
+    /// @return a singleton list containing only the specified element
+    static <T extends @Nullable Object> ImmutableList<T> singleton(T obj) {
+        return new ImmutableSLList.Cons<>(obj, nil());
+    }
 
-    ImmutableList<T> prepend(ImmutableList<T> list);
+    /// Returns a string representation of the given immutable list.
+    ///
+    /// The string representation consists of the elements enclosed in square brackets,
+    /// separated by ", ".
+    ///
+    /// @param <T> the element type
+    /// @param seq the list to convert to string
+    /// @return a string representation in the format "[e1, e2, ..., en]"
+    static <T extends @Nullable Object> String toString(ImmutableList<T> seq) {
+        return seq.stream().map(Objects::toString).collect(Collectors.joining(", ", "[", "]"));
+    }
 
-    /**
-     * prepends an immutable list in reverse order, i.e., [4,5,6].prepend([1,2,3]) will be
-     * [3,2,1,4,5,6] (more efficient than {@link ImmutableList#prepend(ImmutableList)})
-     *
-     * @return reverse(collection)++this
-     */
-    ImmutableList<T> prependReverse(ImmutableList<T> collection);
+    /// Computes a hash code for the given immutable list.
+    ///
+    /// The hash code is computed by iterating over all elements and combining
+    /// their hash codes using the formula: `hash = 31 * hash + elementHash`.
+    /// Null elements contribute 0 to the hash.
+    ///
+    /// @param <T> the element type
+    /// @param seq the list to compute hash for (may be null)
+    /// @return the hash code of the list, or 0 if the list is null
+    static <T extends @Nullable Object> int hash(@Nullable ImmutableList<T> seq) {
+        int hash = 0;
+        if (seq != null) {
+            for (var e : seq) {
+                hash = 31 * hash + (e == null ? 0 : e.hashCode());
+            }
+        }
+        return hash;
+    }
 
-    /**
-     * prepends an iterable collection in reverse order, i.e., [4,5,6].prepend([1,2,3]) will be
-     * [3,2,1,4,5,6]
-     *
-     * @return reverse(collection)++this
-     */
-    ImmutableList<T> prependReverse(Iterable<T> collection);
+    /// Prepends a single element to this list.
+    ///
+    /// @param element the element to prepend
+    /// @return a new list with the element at the beginning
+    default ImmutableList<T> prepend(T element) {
+        return new ImmutableListConcat<>(ImmutableList.singleton(element), this);
+    }
 
-    /**
-     * prepends array (O(n))
-     *
-     * @param array the array of the elements to be prepended
-     * @return IList<T> the new list
-     */
-    ImmutableList<T> prepend(@SuppressWarnings("unchecked") T... array);
+    /// Prepends another list to this list.
+    ///
+    /// @param list the list to prepend
+    /// @return a new list with the given list's elements at the beginning
+    default ImmutableList<T> prepend(ImmutableList<T> list) {
+        return new ImmutableListConcat<>(list, this);
+    }
 
-    /**
-     * appends element to the list (non-destructive)
-     *
-     * @param element to be added at the end
-     * @return IList<T> with the new element at the end
-     */
-    ImmutableList<T> append(T element);
+    /// Prepends a reversed collection to this list.
+    ///
+    /// @param collection the collection to reverse and prepend
+    /// @return a new list with the reversed collection's elements at the beginning
+    default ImmutableList<T> prependReverse(ImmutableList<T> collection) {
+        return new ImmutableListConcat<>(collection.reverse(), this);
+    }
 
-    /**
-     * appends a whole list (non-destructive)
-     *
-     * @param list the list to be appended
-     * @return IList<T> this++list
-     */
-    ImmutableList<T> append(ImmutableList<T> list);
+    /// Prepends a reversed iterable to this list.
+    ///
+    /// @param collection the iterable to reverse and prepend
+    /// @return a new list with the reversed iterable's elements at the beginning
+    default ImmutableList<T> prependReverse(Iterable<T> collection) {
+        return new ImmutableListConcat<>(ImmutableList.fromList(collection).reverse(), this);
+    }
 
-    /**
-     * appends an iterable collection
-     */
-    ImmutableList<T> append(Iterable<T> collection);
+    /// Prepends an array to this list.
+    ///
+    /// @param array the array to prepend
+    /// @return a new list with the array's elements at the beginning
+    default ImmutableList<T> prepend(T... array) {
+        return new ImmutableListConcat<>(ImmutableList.fromArray(array), this);
+    }
 
-    /**
-     * appends element at end (non-destructive) (O(n))
-     *
-     * @param array the array to be appended
-     * @return IList<T> the new list
-     */
-    ImmutableList<T> append(@SuppressWarnings("unchecked") T... array);
+    /// Appends a single element to this list.
+    ///
+    /// @param element the element to append
+    /// @return a new list with the element at the end
+    default ImmutableList<T> append(T element) {
+        return new ImmutableListConcat<>(this, of(element));
+    }
 
-    /**
-     * @return <T> the first element in list
-     */
-    T head();
+    /// Appends another list to this list.
+    ///
+    /// @param list the list to append
+    /// @return a new list with the given list's elements at the end
+    default ImmutableList<T> append(ImmutableList<T> list) {
+        return new ImmutableListConcat<>(this, list);
+    }
 
-    /**
-     * return true if predicate is fullfilled for at least one element
-     *
-     * @param predicate the predicate
-     * @return true if predicate is fullfilled for at least one element
-     */
-    boolean exists(Predicate<? super T> predicate);
+    /// Appends an iterable collection to this list.
+    ///
+    /// @param collection the iterable to append
+    /// @return a new list with the iterable's elements at the end
+    default ImmutableList<T> append(Iterable<T> collection) {
+        return new ImmutableListConcat<>(this, ImmutableList.fromList(collection));
+    }
 
-    /**
-     * @return IList<T> tail of list
-     */
+    /// Appends an array to this list (non-destructive) in O(1).
+    ///
+    /// @param array the array to append
+    /// @return a new list with the array's elements at the end
+    default ImmutableList<T> append(T... array) {
+        return new ImmutableListConcat<>(this, ImmutableList.fromArray(array));
+    }
 
-    ImmutableList<T> tail();
+    /// Returns the first element of this list.
+    ///
+    /// @return the first element in the list
+    default T head() {
+        return get(0);
+    }
 
-    /**
-     * @return IList<T> this list without the first <code>n</code> elements
-     */
-    ImmutableList<T> take(int n);
+    /// Returns true if the predicate is fulfilled for at least one element.
+    ///
+    /// The default implementation is based on the [#stream()] functionality.
+    ///
+    /// @param predicate the predicate to test
+    /// @return true if predicate is fulfilled for at least one element
+    /// @see #stream()
+    /// @see #spliterator()
+    default boolean exists(Predicate<? super T> predicate) {
+        return stream().anyMatch(predicate);
+    }
 
-    /**
-     * Reverses this list
-     */
-    ImmutableList<T> reverse();
+    /// Returns the list without its head element.
+    ///
+    /// @return a new list without the first element
+    /// @see #skip(int)
+    default ImmutableList<T> tail() {
+        return skip(1);
+    }
 
-    /**
-     * @return Iterator<T> of this list
-     */
+    /// Returns the list without the first `n` elements.
+    ///
+    /// The default implementation takes `O(1)` time and avoids copying
+    /// the underlying data structure by creating a view.
+    ///
+    /// For any integer `k`, the following invariant holds:
+    /// `concat(seq.take(k), seq.skip(k)) == seq`
+    ///
+    /// @param n the number of elements to skip
+    /// @return a new list without the first n elements
+    /// @see #take(int)
+    /// @see ImmutableListSubList
+    default ImmutableList<T> skip(int n) {
+        return new ImmutableListSubList<>(this, n);
+    }
+
+    /// Returns a list containing the first `n` elements.
+    ///
+    /// The default implementation takes `O(1)` time and avoids copying
+    /// the underlying data structure by creating a view.
+    ///
+    /// @param n the number of elements to take
+    /// @return a new list containing the first n elements
+    /// @see #skip(int)
+    /// @see ImmutableListSubList
+    default ImmutableList<T> take(int n) {
+        if (n == 0) {
+            return nil();
+        }
+        return new ImmutableListSubList<>(this, 0, n);
+    }
+
+    /// Returns a reversed view of this list.
+    ///
+    /// @return a new list with elements in reverse order
+    default ImmutableList<T> reverse() {
+        return new ImmutableListReverse<>(this);
+    }
+
+    /// Returns an [Iterator] walking through the elements by
+    /// increasing position.
+    ///
+    /// The default implementation uses an iterator based on [#get(int)] and [#size()].
+    ///
+    /// @return Iterator of this list
     @Override
-    Iterator<T> iterator();
+    default Iterator<T> iterator() {
+        return new Iterator<>() {
+            int cursor = 0;
 
-    /**
-     * @return boolean is true iff. obj is in List
-     */
-    boolean contains(@Nullable Object obj);
+            @Override
+            public boolean hasNext() {
+                return cursor < size();
+            }
 
-    /**
-     * @return int representing number of elements in list
-     */
+            @Override
+            public T next() {
+                return get(cursor++);
+            }
+        };
+    }
 
+    /// Checks if this list contains the specified element.
+    ///
+    /// @param obj the element to search for
+    /// @return true if and only if obj is in this list
+    default boolean contains(@Nullable Object obj) {
+        return exists(it -> Objects.equals(obj, it));
+    }
+
+    /// Returns the number of elements in this list.
+    ///
+    /// @return int representing number of elements in list
     int size();
 
-    /**
-     * @return true iff the list is empty
-     */
-    // not true: @EnsuresNonNullIf(expression = {"head()"}, result = false)
+    /// Checks if this list is empty.
+    ///
+    /// @return true if and only if the list is empty
     boolean isEmpty();
 
-    /**
-     * removes first occurrence of obj
-     *
-     * @return new list
-     */
+    /// Removes the first occurrence of the specified element from this list.
+    ///
+    /// @param obj the element to remove
+    /// @return a new list with the first occurrence of obj removed
     ImmutableList<T> removeFirst(T obj);
 
-    /**
-     * removes all occurrences of obj
-     *
-     * @return new list
-     */
+    /// Removes all occurrences of the specified element from this list.
+    ///
+    /// @param obj the element to remove
+    /// @return a new list with all occurrences of obj removed
     ImmutableList<T> removeAll(T obj);
 
-    /**
-     * Convert the list to a Java array (O(n))
-     */
-    <S extends @Nullable Object> S[] toArray(S[] array);
+    /// Converts the list to a Java array in `O(n)` time based on the
+    /// [#iterator()] implementation.
+    ///
+    /// If you can convert faster, feel free to override this method.
+    ///
+    /// @param <S> the component type of the array
+    /// @param array the array into which to store the elements, or used for type hint
+    /// @return an array containing all elements in this list
+    /// @see #iterator()
+    @SuppressWarnings("unchecked")
+    default <S extends @Nullable Object> S[] toArray(S[] array) {
+        S[] result;
+        if (array.length < size()) {
+            Class<? extends Object[]> arrayClass = array.getClass();
+            assert arrayClass.isArray()
+                    : "@AssumeAssertion(nullness): This has indeed a component type";
+            result = (S[]) Array.newInstance(arrayClass.getComponentType(), size());
+        } else {
+            result = array;
+        }
 
-    /**
-     * Convert the list to a Java array (O(n))
-     */
-    <S extends @Nullable Object> S[] toArray(Class<S> type);
+        int pos = 0;
+        for (var item : this) {
+            result[pos++] = (S) item;
+        }
+        return result;
+    }
+
+    /// Converts the list to a Java array in `O(n)` time using the given component type.
+    ///
+    /// @param <S> the component type of the array
+    /// @param type the class of the type
+    /// @return an array of the specified type containing all elements in this list
+    /// @see #iterator()
+    default <S extends @Nullable Object> S[] toArray(Class<S> type) {
+        S[] result = (S[]) Array.newInstance(type, size());
+        int pos = 0;
+        for (var head : this) {
+            // Somehow the nullness checker needs this cast to be explicit.
+            result[pos++] = (S) type.cast(head);
+        }
+        return result;
+    }
 
 
-    /**
-     * A stream object for this collection.
-     *
-     * @return a non-null stream object
-     */
+    /// A stream object for this collection containing all elements of this collection.
+    ///
+    /// @return a non-null stream object
+    /// @see #spliterator()
+    /// @see #iterator()
     default Stream<T> stream() {
         return StreamSupport.stream(this.spliterator(), false);
     }
 
-    /**
-     * Convert an {@link ImmutableList} to a {@link List}.
-     *
-     * @return This element converted to a {@link List}.
-     */
+    /// Convert an [ImmutableList] to a [List].
+    ///
+    /// @return This element converted to a [List].
     default List<T> toList() {
         List<T> result = new ArrayList<>();
         for (T t : this) {
@@ -280,36 +465,32 @@ public interface ImmutableList<T extends @Nullable Object>
         return result;
     }
 
-    /**
-     * Returns an immutable list consisting of the elements of this list that match
-     * the given predicate.
-     *
-     * @param predicate a non-interfering, stateless
-     *        predicate to apply to each element to determine if it
-     *        should be included
-     *
-     * @return the filtered list
-     */
+    /// Returns an immutable list consisting of the elements of this list that match
+    /// the given predicate.
+    ///
+    /// @param predicate a non-interfering, stateless
+    /// predicate to apply to each element to determine if it
+    /// should be included
+    /// @return the filtered list
     default ImmutableList<T> filter(Predicate<? super T> predicate) {
         return Immutables.filter(this, predicate);
     }
 
-    /**
-     * Returns an immutable list consisting of the results of applying the given
-     * function to the elements of this list.
-     *
-     * @param <R> The element type of the result list
-     * @param function a non-interfering, stateless function to apply to each element
-     * @return the mapped list of the same length as this
-     */
+    /// Returns an immutable list consisting of the results of applying the given
+    /// function to the elements of this list.
+    ///
+    /// @param <R> The element type of the result list
+    /// @param function a non-interfering, stateless function to apply to each element
+    /// @return the mapped list of the same length as this
     default <R extends @Nullable Object> ImmutableList<R> map(Function<? super T, R> function) {
         return Immutables.map(this, function);
     }
 
-    /**
-     * @param other prefix to check for
-     * @return whether this list starts with the elements of the provided prefix
-     */
+    /// Returns whether this list starts with the elements of the provided prefix.
+    ///
+    /// The current implementation is not good, using recursion.
+    ///
+    /// @param other prefix to check for
     default boolean hasPrefix(ImmutableList<? extends T> other) {
         if (other.size() > this.size()) {
             return false;
@@ -324,13 +505,11 @@ public interface ImmutableList<T extends @Nullable Object>
         }
     }
 
-    /**
-     * Remove a prefix from this list.
-     *
-     * @param prefix prefix to remove
-     * @return new list with the prefix removed
-     * @throws IllegalArgumentException if the provided prefix is not a prefix of this list
-     */
+    /// Remove a prefix from this list.
+    ///
+    /// @param prefix prefix to remove
+    /// @return new list with the prefix removed
+    /// @throws IllegalArgumentException if the provided prefix is not a prefix of this list
     default ImmutableList<T> stripPrefix(ImmutableList<? extends T> prefix) {
         if (prefix.isEmpty()) {
             return this;
@@ -341,35 +520,44 @@ public interface ImmutableList<T extends @Nullable Object>
         return this.tail().stripPrefix(prefix.tail());
     }
 
-    /**
-     * Get the last element of this list.
-     * Time complexity: O(n).
-     *
-     * @return last element of this list
-     */
-    default T last() {
+    /// Get the last element of this list.
+    /// The time complexity differs, for {@link ImmutableList} and {@link ImmutableListArray} it is
+    /// in `O(1)`;
+    /// for {@link ImmutableSLList} in `O(n)`.
+    ///
+    /// @return last element of this list
+    default T last() throws NoSuchElementException {
         if (isEmpty()) {
-            throw new IllegalStateException("last() called on empty list");
+            throw new NoSuchElementException("last() called on empty list");
         }
-        ImmutableList<T> remainder = this;
-        while (!remainder.tail().isEmpty()) {
-            remainder = remainder.tail();
-        }
-        T result = remainder.head();
-        assert result != null : "@AssumeAssertion(nullness): this should never be null";
-        return result;
+        return get(size() - 1);
     }
 
-    /**
-     * Get the n-th element of this list.
-     *
-     * @param idx the 0-based index of the element
-     * @return the element at index idx.
-     * @throws IndexOutOfBoundsException if idx is less than 0 or at
-     *         least {@link #size()}.
-     */
-    default T get(int idx) {
-        return take(idx).head();
-    }
+    /// Get the n-th element of this list.
+    ///
+    /// @param idx the 0-based index of the element
+    /// @return the element at index idx.
+    /// @throws IndexOutOfBoundsException if idx is less than 0 or at least [#size()].
+    T get(int idx);
 
+    /// Compares two [ImmutableList] instances for content equality.
+    ///
+    /// Two lists are considered equal if they have the same size and contain
+    /// equal elements at corresponding positions.
+    ///
+    /// @param seq1 the first list to compare
+    /// @param seq2 the second list to compare
+    /// @return true if both lists contain the same elements in the same order
+    static boolean equals(ImmutableList<?> seq1, ImmutableList<?> seq2) {
+        final var size = seq1.size();
+        if (size == seq2.size()) {
+            for (int i = 0; i < size; i++) {
+                if (!Objects.equals(seq1.get(i), seq2.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
 }

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableListArray.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableListArray.java
@@ -1,0 +1,176 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (25.04.26)
+ */
+final class ImmutableListArray<T extends @Nullable Object> implements ImmutableList<T> {
+    private final T[] data;
+
+    public ImmutableListArray(T[] data) {
+        this.data = data;
+    }
+
+    @Override
+    public T head() {
+        try {
+            return data[0];
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new NoSuchElementException("head() called on empty list");
+        }
+    }
+
+    @Override
+    public boolean exists(Predicate<? super T> predicate) {
+        for (var datum : data) {
+            if (predicate.test(datum)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<>() {
+            int pos = 0;
+
+            @Override
+            public boolean hasNext() {
+                return pos < data.length;
+            }
+
+            @Override
+            public T next() {
+                return data[pos++];
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return data.length;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return data.length == 0;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ImmutableList<T> removeFirst(T obj) {
+        int pos = -1;
+        for (int i = 0; i < data.length; i++) {
+            var datum = data[i];
+            if (Objects.equals(obj, datum)) {
+                pos = i;
+                break;
+            }
+        }
+
+        if (pos != -1) {
+            if (size() == 1) {
+                // spare all the stupid copying
+                return ImmutableList.nil();
+            }
+
+            T[] newData = (T[]) new Object[data.length - 1];
+            System.arraycopy(data, 0, newData, 0, pos);
+            System.arraycopy(data, pos + 1, newData, pos, data.length - pos - 1);
+            return new ImmutableListArray<>(newData);
+        }
+
+        return this;
+    }
+
+    @Override
+    public ImmutableList<T> removeAll(T obj) {
+        return stream().filter(it -> !Objects.equals(it, obj)).collect(ImmutableList.collector());
+    }
+
+    @SuppressWarnings({ "unchecked", "argument.type.incompatible" })
+    @Override
+    public <S extends @Nullable Object> S[] toArray(S[] array) {
+        if (array.length == size()) {
+            System.arraycopy(data, 0, array, 0, data.length);
+            return array;
+        } else {
+            return (S[]) toArray(array.getClass().getComponentType());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <S extends @Nullable Object> S[] toArray(Class<S> type) {
+        return toArray((S[]) Array.newInstance(type, size()));
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return Arrays.stream(data);
+    }
+
+    @Override
+    public ImmutableList<T> filter(Predicate<? super T> predicate) {
+        return stream().filter(predicate).collect(ImmutableList.collector());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R extends @Nullable Object> ImmutableList<R> map(Function<? super T, R> function) {
+        var newData = (R[]) new Object[size()];
+        for (var i = 0; i < data.length; i++) {
+            newData[i] = function.apply(data[i]);
+        }
+        return new ImmutableListArray<>(newData);
+    }
+
+    @Override
+    public T last() {
+        try {
+            return data[data.length - 1];
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new NoSuchElementException("last() called on empty list");
+        }
+    }
+
+    @Override
+    public T get(int idx) {
+        if (idx < 0 || idx >= size()) {
+            throw new IndexOutOfBoundsException();
+        }
+        return data[idx];
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (o instanceof ImmutableListArray<?> that) {
+            return Arrays.equals(data, that.data);
+        }
+        if (o instanceof ImmutableList<?> that) {
+            return ImmutableList.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
+    }
+}

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableListConcat.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableListConcat.java
@@ -1,0 +1,109 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+
+/// Represents a concatenated immutable list composed of two sub-lists.
+///
+/// This class implements the [ImmutableList] interface using a lazy concatenation
+/// approach. Instead of physically merging two lists, it maintains references to both
+/// the left and right sub-lists and performs operations by delegating to them appropriately.
+///
+/// **You should never ever need to use this class directly.** Use the interface.
+///
+/// @param <T> the type of elements in this list (may be nullable)
+/// @author Alexander Weigl
+/// @version 1 (25.04.26)
+final class ImmutableListConcat<T extends @Nullable Object>
+        implements ImmutableList<T> {
+    private final ImmutableList<T> left;
+    private final ImmutableList<T> right;
+
+    ImmutableListConcat(ImmutableList<T> left, ImmutableList<T> right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public boolean exists(Predicate<? super T> predicate) {
+        return left.exists(predicate) || right.exists(predicate);
+    }
+
+    @Override
+    public int size() {
+        return left.size() + right.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return left.isEmpty() && right.isEmpty();
+    }
+
+    @Override
+    public ImmutableList<T> removeFirst(T obj) {
+        // This is the tricky part. Removing first of an object, removes it either from the
+        // first list if present or from the second if not present in the first list.
+
+        if (left.isEmpty() && right.isEmpty()) {
+            return ImmutableList.nil();
+        }
+
+        if (left.isEmpty()) {
+            return right.removeFirst(obj);
+        }
+
+        if (right.isEmpty()) {
+            return left.removeFirst(obj);
+        }
+
+        if (left.exists((it) -> Objects.equals(obj, it))) {
+            return new ImmutableListConcat<>(left.removeFirst(obj), right);
+        } else {
+            return new ImmutableListConcat<>(left, right.removeFirst(obj));
+        }
+    }
+
+    @Override
+    public ImmutableList<T> removeAll(T obj) {
+        return new ImmutableListConcat<>(left.removeAll(obj), right.removeAll(obj));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this)
+            return true;
+        if (obj instanceof ImmutableList<?> other) {
+            return ImmutableList.equals(this, other);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return ImmutableList.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return stream().map(Objects::toString).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public T get(int idx) {
+        if (idx < 0 || idx >= size()) {
+            throw new IndexOutOfBoundsException("Index: " + idx + ", Size: " + size());
+        }
+
+        if (idx < left.size()) {
+            return left.get(idx);
+        }
+
+        return right.get(idx - left.size());
+    }
+}

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableListList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableListList.java
@@ -1,0 +1,142 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.Nullable;
+
+/// Represents an immutable list backed by a standard Java [List].
+///
+/// This class provides an immutable wrapper around a collection, implementing the
+/// [ImmutableList] interface. The underlying data is stored in an unmodifiable
+/// [ArrayList], ensuring that all operations preserve immutability.
+///
+/// **You should never ever need to use this class directly.** Use the interface.
+///
+/// @param <T> the type of elements in this list (may be nullable)
+/// @author Alexander Weigl
+/// @version 1 (25.04.26)
+@SuppressWarnings("unchecked")
+final class ImmutableListList<T extends @Nullable Object> implements ImmutableList<T> {
+    private final List<T> data;
+
+    private ImmutableListList(List<T> data) {
+        this.data = data;
+    }
+
+    public ImmutableListList(Collection<T> data) {
+        this(Collections.unmodifiableList(new ArrayList<>(data)));
+    }
+
+    /// **Danger:** This factory does not guarantee immutability if data has leaked!
+    /// Use with care!
+    static <T> ImmutableListList<T> createDirectlyWithoutImmutableGuarantee(List<T> data) {
+        return new ImmutableListList<>(data);
+    }
+
+    @Override
+    public T head() {
+        return data.getFirst();
+    }
+
+    @Override
+    public boolean exists(Predicate<? super T> predicate) {
+        for (var datum : data) {
+            if (predicate.test(datum)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return data.iterator();
+    }
+
+    @Override
+    public int size() {
+        return data.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return data.isEmpty();
+    }
+
+    @Override
+    public ImmutableList<T> removeFirst(T obj) {
+        int pos = -1;
+        for (int i = 0; i < data.size(); i++) {
+            var datum = data.get(i);
+            if (Objects.equals(obj, datum)) {
+                pos = i;
+                break;
+            }
+        }
+
+        if (pos != -1) {
+            var newData = new ArrayList<>(data);
+            newData.remove(pos);
+            return new ImmutableListList<>(newData);
+        }
+
+        return this;
+    }
+
+    @Override
+    public ImmutableList<T> removeAll(T obj) {
+        return stream().filter(it -> !Objects.equals(it, obj)).collect(ImmutableList.collector());
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return data.stream();
+    }
+
+    @Override
+    public ImmutableList<T> filter(Predicate<? super T> predicate) {
+        return ImmutableList.super.filter(predicate);
+    }
+
+    @Override
+    public T last() {
+        return data.getLast();
+    }
+
+    @Override
+    public T get(int idx) {
+        if (idx < 0 || idx >= data.size()) {
+            throw new IndexOutOfBoundsException("Given index out of bounds.");
+        }
+        return data.get(idx);
+    }
+
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (o == null)
+            return false;
+        if (o instanceof ImmutableListList<?> that) {
+            return Objects.equals(data, that.data);
+        }
+        if (o instanceof ImmutableList<?> that) {
+            return ImmutableList.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return ImmutableList.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return ImmutableList.toString(this);
+    }
+}

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableListReverse.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableListReverse.java
@@ -1,0 +1,98 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.jspecify.annotations.Nullable;
+
+/// Represents a reversed view of an immutable list.
+///
+/// This class provides a lazy reversed view of another [ImmutableList]. Instead of
+/// physically reversing the elements, it wraps an existing list and delegates operations
+/// with appropriate index/value transformations to present a reversed order.
+///
+/// **You should never ever need to use this class directly.** Use the interface.
+///
+/// @param <T> the type of elements in this list (may be nullable)
+/// @author Alexander Weigl
+/// @version 1 (25.04.26)
+final class ImmutableListReverse<T extends @Nullable Object> implements ImmutableList<T> {
+    private final ImmutableList<T> inner;
+
+    ImmutableListReverse(ImmutableList<T> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public T head() {
+        return inner.last();
+    }
+
+    @Override
+    public boolean exists(Predicate<? super T> predicate) {
+        return inner.exists(predicate);
+    }
+
+    /// Extra fast: reverse(reverse(list)) is idempotent!
+    @Override
+    public ImmutableList<T> reverse() {
+        return inner;
+    }
+
+    @Override
+    public int size() {
+        return inner.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return inner.isEmpty();
+    }
+
+    @Override
+    public ImmutableList<T> removeFirst(T obj) {
+        // TODO this is hard to implement
+        return new ImmutableListReverse<>(inner.removeFirst(obj));
+    }
+
+    @Override
+    public ImmutableList<T> removeAll(T obj) {
+        return new ImmutableListReverse<>(inner.removeAll(obj));
+    }
+
+    @Override
+    public T get(int idx) {
+        if (idx < 0 || idx >= size()) {
+            throw new IndexOutOfBoundsException("Index: " + idx + ", Size: " + size());
+        }
+        return inner.get(size() - 1 - idx);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this)
+            return true;
+        if (obj instanceof ImmutableListReverse<?> other)
+            return Objects.equals(this.inner, other.inner);
+
+        if (obj instanceof ImmutableList<?> other)
+            return ImmutableList.equals(this, other);
+
+        return false;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return ImmutableList.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return ImmutableList.toString(this);
+    }
+
+}

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableListSubList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableListSubList.java
@@ -1,0 +1,124 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/// Represents a view of a portion / span of an immutable list.
+///
+/// This class provides a lazy sub-list view of another [ImmutableList]. Instead of
+/// copying elements, it wraps an existing list with start and end indices to present a
+/// restricted view of the underlying data.
+///
+/// **You should never ever need to use this class directly.** Use the interface.
+///
+/// @param <T> the type of elements in this list (may be nullable)
+/// @author Alexander Weigl
+/// @version 1 (25.04.26)
+final class ImmutableListSubList<T extends @Nullable Object>
+        implements ImmutableList<T> {
+
+    private final ImmutableList<T> list;
+    private final int start;
+    private final int end;
+
+    public ImmutableListSubList(ImmutableList<T> ts, int startInclusive) {
+        this(ts, startInclusive, ts.size());
+    }
+
+    ImmutableListSubList(ImmutableList<T> list, int start, int end) {
+        if (end > list.size()) {
+            throw new IllegalArgumentException("The 'end' is larger than the size of the list");
+        }
+
+        if (start < 0) {
+            throw new IllegalArgumentException(
+                "The 'start' needs to be positive. Negative indices are not allowed.");
+        }
+
+        if (start > end) {
+            throw new IllegalArgumentException(
+                "The 'start' is larger than the given 'end' of the list");
+        }
+        this.list = list;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<>() {
+            int pos = start;
+
+            @Override
+            public boolean hasNext() {
+                return pos < end;
+            }
+
+            @Override
+            public T next() {
+                return list.get(pos++);
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return end - start;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public ImmutableList<T> removeFirst(T obj) {
+        var list = new ArrayList<T>();
+        for (var t : this) {
+            if (!Objects.equals(t, obj)) {
+                list.add(t);
+            }
+        }
+        return ImmutableList.fromList(list);
+    }
+
+    @Override
+    public ImmutableList<T> removeAll(T obj) {
+        return stream().filter(it -> !Objects.equals(obj, it)).collect(ImmutableList.collector());
+    }
+
+    @Override
+    public T get(int idx) {
+        var realIdx = start + idx;
+        if (0 <= realIdx && realIdx < end) {
+            return list.get(realIdx);
+        }
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this)
+            return true;
+        if (obj instanceof ImmutableList<?> other) {
+            return ImmutableList.equals(this, other);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return ImmutableList.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return ImmutableList.toString(this);
+    }
+}

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.collection;
 
-import java.lang.reflect.Array;
 import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Collector;
 
 import org.key_project.util.Strings;
@@ -22,7 +17,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Simple implementation of a non-destructive (unmodifiable) list. The list implementation allows
  * list sharing of sublists.
- *
+ * <p>
  * The costs of the different operations are O(1) for prepending one element, O(m) for prepending a
  * list with m elements, O(n) for appending an element to this list(size n) O(n) for appending a
  * list with m elements to this list (size n) head() has O(1) tail has O(1) size has O(1) ATTENTION
@@ -30,22 +25,8 @@ import org.slf4j.LoggerFactory;
  * and head with amortized O(1). This will be done later (if necessary).
  */
 @SuppressWarnings({ "unchecked" })
-public abstract class ImmutableSLList<T extends @Nullable Object> implements ImmutableList<T> {
-
-    /**
-     * generated serial id
-     */
-    private static final long serialVersionUID = 8717813038177120287L;
-    private static final Logger log = LoggerFactory.getLogger(ImmutableSLList.NIL.class);
-
-    /** the empty list */
-    public static <T extends @Nullable Object> ImmutableSLList<T> nil() {
-        return (ImmutableSLList<T>) NIL.NIL;
-    }
-
-    public static <T extends @Nullable Object> ImmutableSLList<T> singleton(T obj) {
-        return new Cons<>(obj, nil());
-    }
+abstract class ImmutableSLList<T extends @Nullable Object> implements ImmutableList<T> {
+    private static final Logger log = LoggerFactory.getLogger(ImmutableSLList.class);
 
     /**
      * Reverses this list (O(N))
@@ -57,51 +38,12 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
         }
 
         ImmutableList<T> rest = this;
-        ImmutableList<T> rev = nil();
+        ImmutableList<T> rev = ImmutableList.nil();
         while (!rest.isEmpty()) {
             rev = rev.prepend(rest.head());
             rest = rest.tail();
         }
         return rev;
-    }
-
-    /**
-     * Convert the list to a Java array (O(n))
-     */
-    @Override
-    public <S extends @Nullable Object> S[] toArray(S[] array) {
-        S[] result;
-        if (array.length < size()) {
-            Class<? extends Object[]> arrayClass = array.getClass();
-            assert arrayClass.isArray()
-                    : "@AssumeAssertion(nullness): This has indeed a component type";
-            result = (S[]) Array.newInstance(arrayClass.getComponentType(), size());
-        } else {
-            result = array;
-        }
-        ImmutableList<T> rest = this;
-        for (int i = 0, sz = size(); i < sz; i++) {
-            result[i] = (S) rest.head();
-            rest = rest.tail();
-        }
-        return result;
-    }
-
-    /**
-     * Convert the list to a Java array (O(n))
-     */
-    @Override
-    public <S extends @Nullable Object> S[] toArray(Class<S> type) {
-        S[] result = (S[]) Array.newInstance(type, size());
-        ImmutableList<T> rest = this;
-        for (int i = 0, sz = size(); i < sz; i++) {
-            // @ assert !rest.isEmpty();
-            T head = rest.head();
-            // Somehow the nullness checker needs this cast to be explicit.
-            result[i] = (S) type.cast(head);
-            rest = rest.tail();
-        }
-        return result;
     }
 
 
@@ -152,14 +94,20 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
     }
 
 
-    /**
-     * first <code>n</code> elements of the list are truncated
-     *
-     * @param n an int specifying the number of elements to be truncated
-     * @return IList<T> this list without the first <code>n</code> elements
-     */
     @Override
     public ImmutableList<T> take(int n) {
+        int elems = Math.min(size(), n);
+        List<T> seq = new ArrayList<>(elems);
+        ImmutableList<T> list = this;
+        for (int i = 0; i < elems; i++) {
+            seq.add(list.head());
+            list = tail();
+        }
+        return ImmutableList.fromList(seq);
+    }
+
+    @Override
+    public ImmutableList<T> skip(int n) {
         if (n < 0 || n > size()) {
             throw new IndexOutOfBoundsException(
                 "Unable to take " + n + " elements from list " + this);
@@ -175,18 +123,24 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
     }
 
 
-    private static class Cons<S extends @Nullable Object> extends ImmutableSLList<S> {
+    static class Cons<S extends @Nullable Object> extends ImmutableSLList<S> {
 
         /**
          *
          */
         private static final long serialVersionUID = 2377644880764534935L;
 
-        /** the first element */
+        /**
+         * the first element
+         */
         private final S element;
-        /** reference to the next element (equiv.to the tail of list) */
-        private final ImmutableSLList<S> cons;
-        /** size of the list */
+        /**
+         * reference to the next element (equiv.to the tail of list)
+         */
+        private final ImmutableList<S> cons;
+        /**
+         * size of the list
+         */
         private final int size;
 
         /**
@@ -196,7 +150,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
          */
         Cons(S element) {
             this.element = element;
-            cons = nil();
+            cons = ImmutableList.nil();
             size = 1;
         }
 
@@ -206,7 +160,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
          * @param element a <T> stored in the head element of the list
          * @param cons tail of the list
          */
-        Cons(S element, ImmutableSLList<S> cons) {
+        Cons(S element, ImmutableList<S> cons) {
             this.element = element;
             this.cons = cons;
             size = cons.size() + 1;
@@ -321,16 +275,20 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
          */
         @Override
         public ImmutableList<S> append(S... array) {
-            return ((ImmutableList<S>) nil()).prepend(array).prepend(this);
+            return ImmutableList.<S>nil().prepend(array).prepend(this);
         }
 
-        /** @return <T> first element in list */
+        /**
+         * @return <T> first element in list
+         */
         @Override
         public S head() {
             return element;
         }
 
-        /** @return IList<T> tail of the list */
+        /**
+         * @return IList<T> tail of the list
+         */
         @Override
         public ImmutableList<S> tail() {
             return cons;
@@ -356,19 +314,25 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
         }
 
 
-        /** @return iterator through list */
+        /**
+         * @return iterator through list
+         */
         @Override
         public Iterator<S> iterator() {
             return new SLListIterator<>(this);
         }
 
-        /** @return int the number of elements in list */
+        /**
+         * @return int the number of elements in list
+         */
         @Override
         public int size() {
             return size;
         }
 
-        /** @return boolean true iff. obj in list */
+        /**
+         * @return boolean true iff. obj in list
+         */
         @Override
         public boolean contains(@Nullable Object obj) {
             ImmutableList<S> list = this;
@@ -383,7 +347,9 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
             return false;
         }
 
-        /** @return true iff the list is empty */
+        /**
+         * @return true iff the list is empty
+         */
         @Override
         public boolean isEmpty() {
             return false;
@@ -442,29 +408,35 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
             return unmodifiedTail.prepend(res, i - unmodifiedTail.size());
         }
 
-
         @Override
-        public boolean equals(@Nullable Object o) {
-            if (!(o instanceof ImmutableList)) {
-                return false;
-            }
-            final ImmutableList<S> o1 = (ImmutableList<S>) o;
-            if (o1.size() != size()) {
-                return false;
-            }
-
-            final Iterator<S> p = iterator();
-            final Iterator<S> q = o1.iterator();
-            while (p.hasNext()) {
-                S ep = p.next();
-                S eq = q.next();
-                if ((ep == null && eq != null) || (ep != null && !ep.equals(eq))) {
-                    return false;
-                }
-            }
-            return true;
+        public S get(int idx) {
+            return skip(idx).head();
         }
 
+
+        @Override
+        public final boolean equals(@Nullable Object o) {
+            if (this == o)
+                return true;
+
+            if (o instanceof ImmutableList<?> other) {
+                if (other.size() != size()) {
+                    return false;
+                }
+
+                final Iterator<?> p = iterator();
+                final Iterator<?> q = other.iterator();
+                while (p.hasNext()) {
+                    var ep = p.next();
+                    var eq = q.next();
+                    if (!Objects.equals(ep, eq)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
 
         @Override
         public String toString() {
@@ -472,10 +444,14 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
         }
     }
 
-    /** iterates through a none destructive list */
+    /**
+     * iterates through a none destructive list
+     */
     private static class SLListIterator<T extends @Nullable Object> implements Iterator<T> {
 
-        /** the list of remaining elements */
+        /**
+         * the list of remaining elements
+         */
         private ImmutableList<T> list;
 
         /**
@@ -487,7 +463,9 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
             this.list = list;
         }
 
-        /** @return next element in list */
+        /**
+         * @return next element in list
+         */
         @Override
         public T next() {
             // TODO Perhaps add a RT and throw NuSuchElement to make type checker happy.
@@ -517,7 +495,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
     }
 
 
-    private static class NIL<S> extends ImmutableSLList<S> {
+    static class NIL<S> extends ImmutableSLList<S> {
 
         final static ImmutableList<?> NIL = new NIL<>();
 
@@ -536,7 +514,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
          * replaced by the singleton.
          */
         private Object readResolve() throws java.io.ObjectStreamException {
-            return nil();
+            return ImmutableList.nil();
         }
 
         @Override
@@ -546,7 +524,12 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
 
         @Override
         public boolean equals(@Nullable Object o) {
-            return o instanceof NIL<?>;
+            if (o == this)
+                return true;
+            if (o instanceof ImmutableList<?> other) {
+                return other.size() == size();
+            }
+            return false;
         }
 
         @Override
@@ -612,9 +595,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
 
         @Override
         public S head() {
-            NoSuchElementException ex = new NoSuchElementException();
-            log.error("head on NIL!", ex);
-            throw ex;
+            throw new NoSuchElementException("No element in NIL()");
         }
 
         @Override
@@ -628,6 +609,11 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
         }
 
         @Override
+        public S get(int idx) {
+            throw new NoSuchElementException("No element in NIL()");
+        }
+
+        @Override
         public ImmutableList<S> removeFirst(S obj) {
             return this;
         }
@@ -637,15 +623,20 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
             return "[]";
         }
 
-        /** iterates through the a none destructive NIL list */
+        /**
+         * iterates through the a none destructive NIL list
+         */
         private class SLNilListIterator implements Iterator<S> {
 
             /**
              * creates the NIL list iterator
              */
-            public SLNilListIterator() {}
+            public SLNilListIterator() {
+            }
 
-            /** @return next element in list */
+            /**
+             * @return next element in list
+             */
             @Override
             public S next() {
                 throw new NoSuchElementException();
@@ -698,7 +689,7 @@ public abstract class ImmutableSLList<T extends @Nullable Object> implements Imm
 
         @Override
         public Function<List<T>, ImmutableList<T>> finisher() {
-            return list -> ImmutableSLList.<T>nil().append(list);
+            return list -> ImmutableList.<T>nil().append(list);
         }
 
         @Override

--- a/key.util/src/main/java/org/key_project/util/collection/Immutables.java
+++ b/key.util/src/main/java/org/key_project/util/collection/Immutables.java
@@ -79,7 +79,7 @@ public final class Immutables {
             return list;
         }
 
-        ImmutableList<ImmutableList<T>> stack = ImmutableSLList.nil();
+        ImmutableList<ImmutableList<T>> stack = ImmutableList.nil();
 
         while (!list.isEmpty()) {
             stack = stack.prepend(list);
@@ -87,7 +87,7 @@ public final class Immutables {
         }
 
         HashSet<T> alreadySeen = new HashSet<>();
-        ImmutableList<T> result = ImmutableSLList.nil();
+        ImmutableList<T> result = ImmutableList.nil();
 
         while (!stack.isEmpty()) {
             ImmutableList<T> top = stack.head();
@@ -165,7 +165,7 @@ public final class Immutables {
      */
     public static <T extends @Nullable Object> ImmutableList<T> createListFrom(
             Iterable<? extends T> iterable) {
-        ImmutableList<T> result = ImmutableSLList.nil();
+        ImmutableList<T> result = ImmutableList.nil();
         for (T t : iterable) {
             result = result.prepend(t);
         }
@@ -186,17 +186,20 @@ public final class Immutables {
      */
     public static <T extends @Nullable Object> ImmutableList<T> filter(ImmutableList<T> ts,
             Predicate<? super T> predicate) {
+        return ts.stream().filter(predicate).collect(ImmutableList.collector());
         // This must be a loop. A tail recursive implementation is not optimised
         // by the compiler and quickly leads to a stack overlow.
-        ImmutableList<T> acc = ImmutableSLList.nil();
-        while (!ts.isEmpty()) {
-            T hd = ts.head();
-            if (predicate.test(hd)) {
-                acc = acc.prepend(hd);
-            }
-            ts = ts.tail();
-        }
-        return acc.reverse();
+        /*
+         * ImmutableList<T> acc = ImmutableList.nil();
+         * while (!ts.isEmpty()) {
+         * T hd = ts.head();
+         * if (predicate.test(hd)) {
+         * acc = acc.prepend(hd);
+         * }
+         * ts = ts.tail();
+         * }
+         * return acc.reverse();
+         */
     }
 
     /**
@@ -210,14 +213,17 @@ public final class Immutables {
      */
     public static <T extends @Nullable Object, R extends @Nullable Object> ImmutableList<R> map(
             ImmutableList<T> ts, Function<? super T, R> function) {
-        // This must be a loop. A tail recursive implementation is not optimised
-        // by the compiler and quickly leads to a stack overflow.
-        ImmutableList<R> acc = ImmutableSLList.nil();
-        while (!ts.isEmpty()) {
-            T hd = ts.head();
-            acc = acc.prepend(function.apply(hd));
-            ts = ts.tail();
-        }
-        return acc.reverse();
+        return ts.stream().map(function).collect(ImmutableList.collector());
+        /*
+         * // This must be a loop. A tail recursive implementation is not optimised
+         * // by the compiler and quickly leads to a stack overflow.
+         * ImmutableList<R> acc = ImmutableList.nil();
+         * while (!ts.isEmpty()) {
+         * T hd = ts.head();
+         * acc = acc.prepend(function.apply(hd));
+         * ts = ts.tail();
+         * }
+         * return acc.reverse();
+         */
     }
 }

--- a/key.util/src/test/java/org/key_project/util/collection/ImmutableListArrayTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/ImmutableListArrayTest.java
@@ -1,0 +1,242 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (16.05.26)
+ */
+class ImmutableListArrayTest {
+    private final ImmutableListArray<Integer> list123 =
+        (ImmutableListArray<Integer>) ImmutableList.of(1, 2, 3);
+    private final ImmutableListArray<Integer> listEmpty = new ImmutableListArray<>(new Integer[0]);
+    private final ImmutableListArray<Integer> listVeryLong =
+        (ImmutableListArray<Integer>) ImmutableList.of(create(1024));
+    private final ImmutableListArray<Integer> list10 =
+        (ImmutableListArray<Integer>) ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    public static Integer[] create(int i) {
+        return IntStream.range(1, i + 1).boxed().toArray(Integer[]::new);
+    }
+
+
+    @Test
+    void size() {
+        assertThat(list123.size()).isEqualTo(3);
+        assertThat(listEmpty.size()).isEqualTo(0);
+        assertThat(listVeryLong.size()).isEqualTo(1024);
+        assertThat(list10.size()).isEqualTo(10);
+    }
+
+    @Test
+    void head() {
+        assertThat(list123.head()).isEqualTo(1);
+        assertThat(listVeryLong.head()).isEqualTo(1);
+        assertThat(list10.head()).isEqualTo(1);
+
+        Assertions.assertThrows(NoSuchElementException.class,
+            () -> assertThat(listEmpty.head()).isEqualTo(-1));
+    }
+
+
+    @Test
+    void last() {
+        assertThat(list123.last()).isEqualTo(3);
+        assertThat(listVeryLong.last()).isEqualTo(1024);
+        assertThat(list10.last()).isEqualTo(10);
+
+        Assertions.assertThrows(NoSuchElementException.class,
+            () -> assertThat(listEmpty.last()).isEqualTo(-1));
+    }
+
+
+    @Test
+    void exists() {
+        assertThat(list123.exists(a -> a == -1)).isEqualTo(false);
+        assertThat(listVeryLong.exists(a -> a == -1)).isEqualTo(false);
+        assertThat(list10.exists(a -> a == -1)).isEqualTo(false);
+
+        assertThat(listEmpty.exists(a -> true)).isEqualTo(false);
+
+        assertThat(list123.exists(a -> a == 1)).isEqualTo(true);
+        assertThat(listVeryLong.exists(a -> a == 1023)).isEqualTo(true);
+        assertThat(list10.exists(a -> a == 5)).isEqualTo(true);
+    }
+
+
+    @Test
+    void toArray() {
+        assertThat(list123.toArray(new Integer[0]))
+                .isEqualTo(create(3));
+
+        assertThat(listVeryLong.toArray(new Integer[0]))
+                .isEqualTo(create(1024));
+
+        assertThat(list10.toArray(new Integer[0]))
+                .isEqualTo(create(10));
+
+        assertThat(listEmpty.toArray(new Integer[0]))
+                .isEqualTo(new Integer[0]);
+
+        assertThat(list123.toArray(Integer.class))
+                .isEqualTo(create(3));
+
+        assertThat(listVeryLong.toArray(Integer.class))
+                .isEqualTo(create(1024));
+
+        assertThat(list10.toArray(Integer.class))
+                .isEqualTo(create(10));
+
+        assertThat(list10.toArray(new Integer[10]))
+                .isEqualTo(create(10));
+
+        assertThat(listEmpty.toArray(Integer.class))
+                .isEqualTo(new Integer[0]);
+    }
+
+    @Test
+    void stream() {
+        assertThat(listEmpty.stream().toList()).isEmpty();
+
+        assertThat(list123.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(3));
+
+        assertThat(listVeryLong.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(1024));
+
+        assertThat(list10.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(10));
+    }
+
+
+    @Test
+    void isEmpty() {
+        assertThat(listEmpty.isEmpty()).isTrue();
+        assertThat(list123.isEmpty()).isFalse();
+        assertThat(listVeryLong.isEmpty()).isFalse();
+        assertThat(list10.isEmpty()).isFalse();
+    }
+
+    @Test
+    void removeFirst() {
+        removeFirst(listEmpty);
+        removeFirst(list123);
+        removeFirst(list10);
+        removeFirst(listVeryLong);
+
+        assertThat(listEmpty.removeFirst(0))
+                .isEqualTo(listEmpty);
+
+        assertThat(list123.removeFirst(1))
+                .containsExactly(2, 3);
+
+        assertThat(list123.removeFirst(1).removeFirst(3))
+                .containsExactly(2);
+
+        assertThat(list123.removeFirst(1).removeFirst(3).removeFirst(2))
+                .isEmpty();
+    }
+
+    void removeFirst(ImmutableList<Integer> seq) {
+        while (!seq.isEmpty()) {
+            int pivot = seq.get(seq.size() / 2);
+            seq = seq.removeFirst(pivot);
+            assertThat(seq).doesNotContain(pivot);
+        }
+    }
+
+    @Test
+    void removeAll() {
+        removeAll(listEmpty);
+        removeAll(listVeryLong);
+        removeAll(list123);
+        removeAll(list10);
+
+        assertThat(listEmpty.removeFirst(0))
+                .isEqualTo(listEmpty);
+
+
+        assertThat(
+            new ImmutableListArray<>(
+                new Integer[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })
+                    .removeAll(0))
+                .isEqualTo(listEmpty)
+                .isEmpty();
+    }
+
+    void removeAll(ImmutableList<Integer> seq) {
+        while (!seq.isEmpty()) {
+            int pivot = seq.get(seq.size() / 2);
+            seq = seq.removeAll(pivot);
+            assertThat(seq).doesNotContain(pivot);
+        }
+    }
+
+
+    @Test
+    void testToArray() {
+    }
+
+    @Test
+    void iterator() {
+        assertThat(listEmpty).doesNotContain(0);
+
+        assertThat(list123)
+                .isNotEmpty()
+                .containsExactly(create(3));
+
+        assertThat(listVeryLong)
+                .isNotEmpty()
+                .containsExactly(create(1024));
+
+        assertThat(list10)
+                .isNotEmpty()
+                .containsExactly(create(10));
+    }
+
+    @Test
+    void filter() {
+        assertThat(listEmpty.filter((a) -> true)).isEmpty();
+        assertThat(listEmpty.filter((a) -> false)).isEmpty();
+
+
+        assertThat(list10.filter((a) -> false)).isEmpty();
+        assertThat(list10.filter((a) -> true))
+                .isEqualTo(list10);
+    }
+
+    @Test
+    void map() {
+        assertThat(list123.map((a) -> a + 1))
+                .containsExactly(2, 3, 4);
+
+        assertThat(listEmpty.map((a) -> a + 1))
+                .isEmpty();
+    }
+
+    @Test
+    void get() {
+        for (int i = 0; i < list10.size(); i++) {
+            assertThat(list10.get(i)).isEqualTo(i + 1);
+        }
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> list10.get(list10.size()));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> list10.get(-1));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> listEmpty.get(0));
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/ImmutableListConcatTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/ImmutableListConcatTest.java
@@ -1,0 +1,112 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (16.05.26)
+ */
+class ImmutableListConcatTest {
+    private final ImmutableListConcat<Integer> data = new ImmutableListConcat<>(
+        new ImmutableListArray<>(ImmutableListArrayTest.create(5)),
+        new ImmutableListList<>(ImmutableListListTest.createList(5)));
+    private final ImmutableListConcat<Integer> listEmpty = new ImmutableListConcat<>(
+        new ImmutableListArray<>(new Integer[0]), new ImmutableListList<>(List.of()));
+    private final ImmutableListConcat<Integer> listEmptyEmpty = new ImmutableListConcat<>(
+        listEmpty, listEmpty);
+    private final ImmutableList list123 = new ImmutableListList<Integer>(List.of(1, 2, 3));
+    private final ImmutableListConcat<Integer> listFirstEmpty123 =
+        new ImmutableListConcat<>(listEmptyEmpty, list123);
+
+
+    @Test
+    void get() {
+        assertThat(list123.get(0)).isEqualTo(1);
+        assertThat(list123.get(1)).isEqualTo(2);
+        assertThat(list123.get(2)).isEqualTo(3);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+            () -> listEmpty.get(0));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+            () -> listEmptyEmpty.get(0));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+            () -> list123.get(4));
+    }
+
+    @Test
+    void exists() {
+        assertThat(data.exists((i) -> i == 1)).isTrue();
+        assertThat(data.exists((i) -> i == 5)).isTrue();
+        assertThat(data.exists((i) -> i == 10)).isFalse();
+        assertThat(data.exists((i) -> i == 0)).isFalse();
+
+        assertThat(listEmpty.exists((i) -> true)).isFalse();
+        assertThat(listEmptyEmpty.exists((i) -> true)).isFalse();
+    }
+
+    @Test
+    void testEquals() {
+        assertThat(listEmptyEmpty).isEqualTo(listEmpty);
+        assertThat(listFirstEmpty123).isEqualTo(list123);
+        assertThat(list123).isEqualTo(listFirstEmpty123);
+    }
+
+    @Test
+    void size() {
+        assertThat(data.size()).isEqualTo(10);
+        assertThat(listEmpty.size()).isEqualTo(0);
+        assertThat(listEmptyEmpty.size()).isEqualTo(0);
+    }
+
+    @Test
+    void isEmpty() {
+        assertThat(data.isEmpty()).isFalse();
+        assertThat(listEmpty.isEmpty()).isTrue();
+        assertThat(listEmptyEmpty.isEmpty()).isTrue();
+    }
+
+    @Test
+    void removeFirst() {
+        System.out.println(data);
+        assertThat(data)
+                .containsExactly(1, 2, 3, 4, 5, 1, 2, 3, 4, 5);
+
+        assertThat(data.removeFirst(1))
+                .containsExactly(2, 3, 4, 5, 1, 2, 3, 4, 5);
+
+        assertThat(data.removeFirst(1).removeFirst(1))
+                .containsExactly(2, 3, 4, 5, 2, 3, 4, 5);
+
+        assertThat(listFirstEmpty123.removeFirst(1))
+                .containsExactly(2, 3);
+
+        assertThat(listFirstEmpty123.removeFirst(1).removeFirst(3))
+                .containsExactly(2);
+
+
+        assertThat(listEmpty.removeFirst(0)).isEqualTo(listEmpty);
+        assertThat(listEmptyEmpty.removeFirst(0)).isEqualTo(listEmpty);
+    }
+
+    @Test
+    void removeAll() {
+        assertThat(data.removeAll(1))
+                .containsExactly(2, 3, 4, 5, 2, 3, 4, 5);
+
+    }
+
+    @Test
+    void iterator() {
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/ImmutableListListTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/ImmutableListListTest.java
@@ -1,0 +1,251 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.key_project.util.collection.ImmutableListArrayTest.create;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (16.05.26)
+ */
+class ImmutableListListTest {
+    private final ImmutableListList<Integer> list123 = new ImmutableListList<>(createList(3));
+    private final ImmutableListList<Integer> listEmpty =
+        new ImmutableListList<>(Collections.emptyList());
+    private final ImmutableListList<Integer> listVeryLong =
+        new ImmutableListList<>(createList(1024));
+    private final ImmutableListList<Integer> list10 = new ImmutableListList<>(createList(10));
+
+    public static List<Integer> createList(int i) {
+        return IntStream.range(1, i + 1).boxed().toList();
+    }
+
+    @Test
+    void content() {
+        assertThat(list123).containsExactly(1, 2, 3);
+        assertThat(list10).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    void size() {
+        assertThat(list123.size()).isEqualTo(3);
+        assertThat(listEmpty.size()).isEqualTo(0);
+        assertThat(listVeryLong.size()).isEqualTo(1024);
+        assertThat(list10.size()).isEqualTo(10);
+    }
+
+    @Test
+    void head() {
+        assertThat(list123.head()).isEqualTo(1);
+        assertThat(listVeryLong.head()).isEqualTo(1);
+        assertThat(list10.head()).isEqualTo(1);
+
+        Assertions.assertThrows(NoSuchElementException.class,
+            () -> assertThat(listEmpty.head()).isEqualTo(-1));
+    }
+
+
+    @Test
+    void last() {
+        assertThat(list123.last()).isEqualTo(3);
+        assertThat(listVeryLong.last()).isEqualTo(1024);
+        assertThat(list10.last()).isEqualTo(10);
+
+        Assertions.assertThrows(NoSuchElementException.class,
+            () -> assertThat(listEmpty.last()).isEqualTo(-1));
+    }
+
+
+    @Test
+    void exists() {
+        assertThat(list123.exists(a -> a == -1)).isEqualTo(false);
+        assertThat(listVeryLong.exists(a -> a == -1)).isEqualTo(false);
+        assertThat(list10.exists(a -> a == -1)).isEqualTo(false);
+
+        assertThat(listEmpty.exists(a -> true)).isEqualTo(false);
+
+        assertThat(list123.exists(a -> a == 1)).isEqualTo(true);
+        assertThat(listVeryLong.exists(a -> a == 1023)).isEqualTo(true);
+        assertThat(list10.exists(a -> a == 5)).isEqualTo(true);
+    }
+
+
+    @Test
+    void toArray() {
+        Integer[] array = list123.toArray(new Integer[0]);
+        Integer[] array2 = create(3);
+
+        assertThat(array).isEqualTo(array2);
+
+        assertThat(listVeryLong.toArray(new Integer[0]))
+                .isEqualTo(create(1024));
+
+        assertThat(list10.toArray(new Integer[0]))
+                .isEqualTo(create(10));
+
+        assertThat(listEmpty.toArray(new Integer[0]))
+                .isEqualTo(new Integer[0]);
+
+        assertThat(list123.toArray(Integer.class))
+                .isEqualTo(create(3));
+
+        assertThat(listVeryLong.toArray(Integer.class))
+                .isEqualTo(create(1024));
+
+        assertThat(list10.toArray(Integer.class))
+                .isEqualTo(create(10));
+
+        assertThat(list10.toArray(new Integer[10]))
+                .isEqualTo(create(10));
+
+        assertThat(listEmpty.toArray(Integer.class))
+                .isEqualTo(new Integer[0]);
+    }
+
+    @Test
+    void stream() {
+        assertThat(listEmpty.stream().toList()).isEmpty();
+
+        assertThat(list123.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(3));
+
+        assertThat(listVeryLong.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(1024));
+
+        assertThat(list10.stream().toList())
+                .isNotEmpty()
+                .containsExactly(create(10));
+    }
+
+
+    @Test
+    void isEmpty() {
+        assertThat(listEmpty.isEmpty()).isTrue();
+        assertThat(list123.isEmpty()).isFalse();
+        assertThat(listVeryLong.isEmpty()).isFalse();
+        assertThat(list10.isEmpty()).isFalse();
+    }
+
+    @Test
+    void removeFirst() {
+        removeFirst(listEmpty);
+        removeFirst(list123);
+        removeFirst(list10);
+        removeFirst(listVeryLong);
+
+        assertThat(listEmpty.removeFirst(0))
+                .isEqualTo(listEmpty);
+
+        assertThat(list123.removeFirst(1))
+                .containsExactly(2, 3);
+
+        assertThat(list123.removeFirst(1).removeFirst(3))
+                .containsExactly(2);
+
+        assertThat(list123.removeFirst(1).removeFirst(3).removeFirst(2))
+                .isEmpty();
+    }
+
+    void removeFirst(ImmutableList<Integer> seq) {
+        while (!seq.isEmpty()) {
+            int pivot = seq.get(seq.size() / 2);
+            seq = seq.removeFirst(pivot);
+            assertThat(seq).doesNotContain(pivot);
+        }
+    }
+
+    @Test
+    void removeAll() {
+        removeAll(listEmpty);
+        removeAll(listVeryLong);
+        removeAll(list123);
+        removeAll(list10);
+
+        assertThat(listEmpty.removeFirst(0))
+                .isEqualTo(listEmpty);
+
+
+        assertThat(
+            new ImmutableListArray<>(
+                new Integer[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })
+                    .removeAll(0))
+                .isEqualTo(listEmpty)
+                .isEmpty();
+    }
+
+    void removeAll(ImmutableList<Integer> seq) {
+        while (!seq.isEmpty()) {
+            int pivot = seq.get(seq.size() / 2);
+            seq = seq.removeAll(pivot);
+            assertThat(seq).doesNotContain(pivot);
+        }
+    }
+
+
+    @Test
+    void testToArray() {
+    }
+
+    @Test
+    void iterator() {
+        assertThat(listEmpty).doesNotContain(0);
+
+        assertThat(list123)
+                .isNotEmpty()
+                .containsExactly(create(3));
+
+        assertThat(listVeryLong)
+                .isNotEmpty()
+                .containsExactly(create(1024));
+
+        assertThat(list10)
+                .isNotEmpty()
+                .containsExactly(create(10));
+    }
+
+    @Test
+    void filter() {
+        assertThat(listEmpty.filter((a) -> true)).isEmpty();
+        assertThat(listEmpty.filter((a) -> false)).isEmpty();
+
+
+        assertThat(list10.filter((a) -> false)).isEmpty();
+        assertThat(list10.filter((a) -> true))
+                .isEqualTo(list10);
+    }
+
+    @Test
+    void map() {
+        assertThat(list123.map((a) -> a + 1))
+                .containsExactly(2, 3, 4);
+
+        assertThat(listEmpty.map((a) -> a + 1))
+                .isEmpty();
+    }
+
+    @Test
+    void get() {
+        for (int i = 0; i < list10.size(); i++) {
+            assertThat(list10.get(i)).isEqualTo(i + 1);
+        }
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> list10.get(list10.size()));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> list10.get(-1));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> listEmpty.get(0));
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/ImmutableListReverseTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/ImmutableListReverseTest.java
@@ -1,0 +1,40 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (16.05.26)
+ */
+class ImmutableListReverseTest {
+    private final ImmutableList<Integer> seq =
+        new ImmutableListArray<>(ImmutableListArrayTest.create(5));
+
+    @Test
+    void reverse() {
+        assertThat(seq).containsExactly(1, 2, 3, 4, 5);
+        assertThat(seq.reverse())
+                .hasSize(5)
+                .containsExactly(5, 4, 3, 2, 1);
+
+        assertThat(seq.reverse().reverse())
+                .hasSize(5)
+                .containsExactly(1, 2, 3, 4, 5);
+
+
+        assertThat(seq.prepend().reverse().prepend())
+                .hasSize(5)
+                .containsExactly(5, 4, 3, 2, 1);
+
+        assertThat(seq.reverse().take(3).reverse())
+                .hasSize(3)
+                .isEqualTo(seq.skip(2));
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/ImmutableListSubListTest.java
+++ b/key.util/src/test/java/org/key_project/util/collection/ImmutableListSubListTest.java
@@ -1,0 +1,41 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.collection;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (16.05.26)
+ */
+class ImmutableListSubListTest {
+    private final ImmutableList<Integer> seq =
+        new ImmutableListArray<>(ImmutableListArrayTest.create(5));
+    private final ImmutableListConcat<Integer> data = new ImmutableListConcat<>(
+        seq,
+        new ImmutableListList<>(ImmutableListListTest.createList(5)));
+    private final ImmutableListConcat<Integer> listEmpty = new ImmutableListConcat<>(
+        new ImmutableListArray<>(new Integer[0]), new ImmutableListList<>(List.of()));
+
+    @Test
+    void test() {
+        assertThat(data.take(1)).containsExactly(1);
+        assertThat(data.take(0)).isEqualTo(listEmpty);
+
+        assertThat(data.take(5))
+                .hasSize(5)
+                .containsExactly(1, 2, 3, 4, 5)
+                .isEqualTo(seq);
+
+        assertThat(data.skip(5))
+                .hasSize(5)
+                .containsExactly(1, 2, 3, 4, 5)
+                .isEqualTo(seq);
+    }
+}

--- a/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
+++ b/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
@@ -12,7 +12,7 @@ public class TestImmutables {
 
     @Test
     public void testRemoveDuplicatesLarge() {
-        ImmutableList<Integer> l = ImmutableSLList.nil();
+        ImmutableList<Integer> l = ImmutableList.nil();
         for (int i = 0; i < 100; i++) {
             l = l.prepend((i * 2) % 160);
         }
@@ -44,7 +44,7 @@ public class TestImmutables {
 
         for (int i = 0; i < a.length; i++) {
             ImmutableList<@Nullable String> l =
-                ImmutableSLList.<@Nullable String>nil().prepend(a[i]).reverse();
+                ImmutableList.<@Nullable String>nil().prepend(a[i]).reverse();
 
             assertFalse(Immutables.isDuplicateFree(l));
 
@@ -60,7 +60,7 @@ public class TestImmutables {
     @Test
     public void testRemoveDuplicatesIdentical() {
         String[] a = { "a", "b", "c", "d", "e" };
-        ImmutableList<String> l = ImmutableSLList.<String>nil().prepend(a);
+        ImmutableList<String> l = ImmutableList.<String>nil().prepend(a);
 
         ImmutableList<String> cleaned = Immutables.removeDuplicates(l);
 
@@ -75,7 +75,7 @@ public class TestImmutables {
         for (@Nullable
         String[] strings : a) {
             ImmutableList<@Nullable String> l =
-                ImmutableSLList.<@Nullable String>nil().prepend(strings);
+                ImmutableList.<@Nullable String>nil().prepend(strings);
             assertTrue(Immutables.isDuplicateFree(l));
         }
 
@@ -86,7 +86,7 @@ public class TestImmutables {
         for (@Nullable
         String[] strings : b) {
             ImmutableList<@Nullable String> l =
-                ImmutableSLList.<@Nullable String>nil().prepend(strings);
+                ImmutableList.<@Nullable String>nil().prepend(strings);
             assertFalse(Immutables.isDuplicateFree(l));
         }
 
@@ -139,7 +139,7 @@ public class TestImmutables {
     @Test
     public void testEqualityEmpty() {
         ImmutableSet<Object> s1 = DefaultImmutableSet.nil();
-        ImmutableSet<Object> s2 = DefaultImmutableSet.fromImmutableList(ImmutableSLList.nil());
+        ImmutableSet<Object> s2 = DefaultImmutableSet.fromImmutableList(ImmutableList.nil());
         assertEquals(0, s1.size());
         assertEquals(0, s2.size());
 
@@ -180,7 +180,7 @@ public class TestImmutables {
     public void testFilterStackoverflow() {
         // With the original tail recursive implementation, this would give
         // an overflow --> made it a loop.
-        ImmutableList<Integer> l = ImmutableSLList.nil();
+        ImmutableList<Integer> l = ImmutableList.nil();
         for (int i = 0; i < 1_000_000; i++) {
             l = l.prepend(i);
         }
@@ -200,7 +200,7 @@ public class TestImmutables {
     public void testMapStackoverflow() {
         // With the original tail recursive implementation, this would give
         // an overflow --> made it a loop.
-        ImmutableList<Integer> l = ImmutableSLList.nil();
+        ImmutableList<Integer> l = ImmutableList.nil();
         for (int i = 0; i < 1_000_000; i++) {
             l = l.prepend(i);
         }
@@ -213,7 +213,7 @@ public class TestImmutables {
     public void testExistsStackoverflow() {
         // With a tail recursive implementation, this would give
         // an overflow --> it is a loop.
-        ImmutableList<Integer> l = ImmutableSLList.nil();
+        ImmutableList<Integer> l = ImmutableList.nil();
         for (int i = 0; i < 1_000_000; i++) {
             l = l.prepend(i);
         }

--- a/key.util/src/test/java/org/key_project/util/testcase/collection/TestLeftistHeapOfInteger.java
+++ b/key.util/src/test/java/org/key_project/util/testcase/collection/TestLeftistHeapOfInteger.java
@@ -11,7 +11,6 @@ import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableHeap;
 import org.key_project.util.collection.ImmutableLeftistHeap;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,9 +28,9 @@ public class TestLeftistHeapOfInteger {
 
     @BeforeEach
     public void setUp() {
-        a = ImmutableSLList.<Integer>nil().prepend(13).prepend(20).prepend(5).prepend(7).prepend(16)
+        a = ImmutableList.<Integer>nil().prepend(13).prepend(20).prepend(5).prepend(7).prepend(16)
                 .prepend(60).prepend(20).prepend(-34);
-        b = ImmutableSLList.<Integer>nil().prepend(-1000).prepend(1000).prepend(8);
+        b = ImmutableList.<Integer>nil().prepend(-1000).prepend(1000).prepend(8);
     }
 
     @Test
@@ -102,7 +101,7 @@ public class TestLeftistHeapOfInteger {
         assertTrue(equals(h.sortedIterator(), elements.iterator()),
             "Unsorted heap iterator does not return the right elements");
 
-        ImmutableList<Integer> list = ImmutableSLList.nil();
+        ImmutableList<Integer> list = ImmutableList.nil();
         lastElement = null;
 
         while (!h.isEmpty()) {
@@ -131,8 +130,8 @@ public class TestLeftistHeapOfInteger {
     public void testInsertIterator() {
         ImmutableHeap<Integer> h = ImmutableLeftistHeap.nilHeap();
 
-        h = h.insert(ImmutableSLList.<Integer>nil().iterator());
-        checkHeap(ImmutableSLList.nil(), h);
+        h = h.insert(ImmutableList.<Integer>nil().iterator());
+        checkHeap(ImmutableList.nil(), h);
         assertTrue(h.isEmpty() && h.size() == 0, "Empty heap should be empty");
 
         h = h.insert(a.iterator());
@@ -141,7 +140,7 @@ public class TestLeftistHeapOfInteger {
         h = h.insert(a.iterator());
         checkHeap(a.prepend(a), h);
 
-        h = h.insert(ImmutableSLList.<Integer>nil().iterator());
+        h = h.insert(ImmutableList.<Integer>nil().iterator());
         checkHeap(a.prepend(a), h);
 
         h = h.insert(h.iterator());
@@ -174,7 +173,7 @@ public class TestLeftistHeapOfInteger {
         ImmutableHeap<Integer> h = ImmutableLeftistHeap.nilHeap();
 
         // Test removal of all elements (from empty heap)
-        checkHeap(ImmutableSLList.nil(), removeAll(h, a.iterator()));
+        checkHeap(ImmutableList.nil(), removeAll(h, a.iterator()));
 
         h = h.insert(a.iterator());
         checkHeap(a, h);
@@ -183,7 +182,7 @@ public class TestLeftistHeapOfInteger {
         checkHeap(a.removeAll(a.head()), h.removeAll(a.head()));
 
         // Test removal of all elements
-        checkHeap(ImmutableSLList.nil(), removeAll(h, a.iterator()));
+        checkHeap(ImmutableList.nil(), removeAll(h, a.iterator()));
 
         // Test removal of non-existing elements
         assertSame(h, removeAll(h, b.iterator()), "Heap should not be different");
@@ -192,7 +191,7 @@ public class TestLeftistHeapOfInteger {
     @Test
     public void testLargeHeap() {
         ImmutableHeap<Integer> h = ImmutableLeftistHeap.nilHeap();
-        ImmutableList<Integer> l = ImmutableSLList.nil();
+        ImmutableList<Integer> l = ImmutableList.nil();
 
         int i = 1000;
         while (i-- != 0) {

--- a/key.util/src/test/java/org/key_project/util/testcase/collection/TestSLListOfString.java
+++ b/key.util/src/test/java/org/key_project/util/testcase/collection/TestSLListOfString.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.Objects;
 
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,14 +36,14 @@ public class TestSLListOfString {
 
     @BeforeEach
     public void setUp() {
-        a = ImmutableSLList.<String>nil().prepend("C").prepend("B").prepend("A");
-        a1 = ImmutableSLList.<String>nil().prepend("C").prepend("B").prepend("A");
-        b = ImmutableSLList.<String>nil().prepend("B").prepend("A");
-        c = ImmutableSLList.<String>nil().prepend("D").prepend("C").prepend("B").prepend("A");
-        d = ImmutableSLList.<String>nil().prepend("A").prepend("B").prepend("A");
-        e = ImmutableSLList.<@Nullable String>nil().prepend((String) null).prepend("B")
+        a = ImmutableList.<String>nil().prepend("C").prepend("B").prepend("A");
+        a1 = ImmutableList.<String>nil().prepend("C").prepend("B").prepend("A");
+        b = ImmutableList.<String>nil().prepend("B").prepend("A");
+        c = ImmutableList.<String>nil().prepend("D").prepend("C").prepend("B").prepend("A");
+        d = ImmutableList.<String>nil().prepend("A").prepend("B").prepend("A");
+        e = ImmutableList.<@Nullable String>nil().prepend((String) null).prepend("B")
                 .prepend("A");
-        e1 = ImmutableSLList.<@Nullable String>nil().prepend((String) null).prepend("B")
+        e1 = ImmutableList.<@Nullable String>nil().prepend((String) null).prepend("B")
                 .prepend("A");
     }
 
@@ -53,7 +52,7 @@ public class TestSLListOfString {
     public void testPrepend() {
         @SuppressWarnings("unchecked")
         ImmutableList<String>[] newList = new ImmutableList[str.length + 1];
-        newList[0] = ImmutableSLList.nil();
+        newList[0] = ImmutableList.nil();
 
         for (int i = 1; i < str.length + 1; i++) {
             newList[i] = newList[i - 1].prepend(str[i - 1]);
@@ -91,7 +90,7 @@ public class TestSLListOfString {
     public void testAppend() {
         @SuppressWarnings("unchecked")
         ImmutableList<String>[] newList = new ImmutableList[str.length + 1];
-        newList[0] = ImmutableSLList.nil();
+        newList[0] = ImmutableList.nil();
 
         for (int i = 1; i < str.length + 1; i++) {
             newList[i] = newList[i - 1].append(str[i - 1]);
@@ -130,7 +129,7 @@ public class TestSLListOfString {
     public void testHeadTail() {
         @SuppressWarnings("unchecked")
         ImmutableList<String>[] newList = new ImmutableList[str.length + 1];
-        newList[0] = ImmutableSLList.nil();
+        newList[0] = ImmutableList.nil();
 
         for (int i = 1; i < str.length + 1; i++) {
             newList[i] = newList[i - 1].prepend(str[i - 1]);
@@ -145,7 +144,7 @@ public class TestSLListOfString {
     // tests contains
     @Test
     public void testContains() {
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
 
         for (int i = 1; i < str.length + 1; i++) {
             newList = newList.append(str[i - 1]);
@@ -160,7 +159,7 @@ public class TestSLListOfString {
     // tests removeAll
     @Test
     public void testRemoveAll() {
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
 
         newList = newList.append(str[0]);
         for (int i = 1; i < str.length + 1; i++) {
@@ -174,7 +173,7 @@ public class TestSLListOfString {
 
     @Test
     public void testRemoveFirst() {
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
 
         newList = newList.prepend(str[0]);
         for (int i = 1; i < str.length + 1; i++) {
@@ -211,7 +210,7 @@ public class TestSLListOfString {
 
     @Test
     public void testToString() {
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
         for (String aStr : str) {
             newList = newList.append(aStr);
         }
@@ -221,7 +220,7 @@ public class TestSLListOfString {
 
     public static void performanceTest(int n) {
         LOGGER.info("Performance Test for " + n + " elements");
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
         LOGGER.info("Create list with prepend.");
         long start = System.currentTimeMillis();
         for (int i = 0; i < n; i++) {
@@ -245,7 +244,7 @@ public class TestSLListOfString {
 
 
     public static void main(String[] args) {
-        ImmutableList<String> newList = ImmutableSLList.nil();
+        ImmutableList<String> newList = ImmutableList.nil();
         newList.prepend("a");
 
         performanceTest(10);

--- a/keyext.slicing/src/main/java/org/key_project/slicing/analysis/AnalysisResults.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/analysis/AnalysisResults.java
@@ -25,7 +25,6 @@ import org.key_project.slicing.graph.DependencyGraph;
 import org.key_project.slicing.graph.GraphNode;
 import org.key_project.slicing.util.ExecutionTime;
 import org.key_project.util.collection.ImmutableList;
-import org.key_project.util.collection.ImmutableSLList;
 
 /**
  * Results of the dependency analysis algorithm.
@@ -166,7 +165,7 @@ public final class AnalysisResults {
 
     private ImmutableList<SequentFormula> reduce(ImmutableList<SequentFormula> semi, Node node,
             boolean antec) {
-        ImmutableList<SequentFormula> semiList = ImmutableSLList.nil();
+        ImmutableList<SequentFormula> semiList = ImmutableList.nil();
         for (SequentFormula sf : semi) {
             var graphNode = dependencyGraph.getGraphNode(node.proof(), node.getBranchLocation(),
                 new PosInOccurrence(sf, PosInTerm.getTopLevel(), antec));


### PR DESCRIPTION
## Issue

We currently have two implementations of immutable sequences with `ImmutableList` and `ImmutableArray`. This requires conversions sometimes, but mainly it leads to confusion about which implementation should be taken. 

## Intended Change

This PR unifies everything under `ImmutableList`. 

There are two fresh children classes: `ImmutableListArray` and `ImmutableListList`. Both behave like `ImmutableList`, but use different data storage (`T[]` or `List<T>`) in the background. 

Some operations from `ImmutableList` are quite expensive on this data storages, e.g., `tail()` or `reverse()`. Therefore, I introduced views that emulate these operations, without copying the data, i.e.,

* `ImmutableListConcat` as `ImmutableList#prepend(other)`
* `ImmutableListReverse` for `ImmutableList#reverse()`
* `ImmutableListSubList` for `ImmutableList#take(n)`, `ImmutableList#skip(n)`, `ImmutableList#tail()`

These operations are now in $O(1)$. 

The class `ImmutableArray` should be considered obsolete. 

**Developers** should use only the methods and functions of `ImmutableList`. Implementation may override them if there is a faster implementation, e.g, `tail()` on `ImmutableSList`. 


## Plan

* [x] Renaming `ImmutableSList` to `ImmutableList`.
* [x] More, even more test cases, coverage is not so bad, but could be better.
* [x] Update the JavaDoc documentation

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- New feature (non-breaking change which adds functionality)

- There are changes to the (Java) code

## Ensuring quality
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).

