### PR TITLE
Artifacts are now on mvn central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven { url = "https://git.key-project.org/api/v4/projects/35/packages/maven/" }
+        //maven { url = "https://git.key-project.org/api/v4/projects/35/packages/maven/" }
     }
 
     dependencies {


### PR DESCRIPTION
JavaParser fork for KeY was publish on Maven Central in version `3.28.0-K13.5`: ![Maven Central Version](https://img.shields.io/maven-central/v/org.key-project.proofjava/javaparser-core)

Waiting for its arrival. 

<img width="1100" height="565" alt="image" src="https://github.com/user-attachments/assets/d65ebfa6-2d1a-4661-9641-4c66088d3b87" />


## Related Issue

Reproducibility + Problems on Gitlab's package registry.

## Intended Change

Nothing.
