### PR TITLE
Collapsing proof search

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIBranchNode.java
@@ -63,11 +63,17 @@ class GUIBranchNode extends GUIAbstractTreeNode {
         }
 
         while (true) {
-            count++;
-            if (!dryRun) {
-                var newNode = getProofTreeModel().getProofTreeNode(n);
-                newNode.setParent(this);
-                childrenCache.add(newNode);
+            // While searching, hide intermediate proof steps that do not match the query
+            // (the subtree is still shown because it contains a match somewhere); this
+            // collapses the branch down to the matching steps. Branch nodes added below are
+            // always kept, as they are filtered by the global "contains match" check.
+            if (showStep(n)) {
+                count++;
+                if (!dryRun) {
+                    var newNode = getProofTreeModel().getProofTreeNode(n);
+                    newNode.setParent(this);
+                    childrenCache.add(newNode);
+                }
             }
             List<Node> nextN = findChild(n);
             if (nextN.isEmpty()) {
@@ -107,6 +113,15 @@ class GUIBranchNode extends GUIAbstractTreeNode {
             }
         }
         return count;
+    }
+
+    /**
+     * @param n a proof node on this branch's linear chain.
+     * @return whether the corresponding proof step should be shown. While the collapsing search
+     *         is active, only steps matching the query are shown; otherwise all steps are shown.
+     */
+    private static boolean showStep(Node n) {
+        return !ProofTreeViewFilter.SEARCH.isActive() || ProofTreeViewFilter.SEARCH.matches(n);
     }
 
     @Override

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIProofTreeModel.java
@@ -301,7 +301,7 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
      */
     @Override
     public synchronized Object getChild(Object parent, int index) {
-        if (activeNodeFilter == null) {
+        if (bypassNodeFilter()) {
             TreeNode guiParent = (TreeNode) parent;
             if (guiParent.getChildCount() > index) {
                 return guiParent.getChildAt(index);
@@ -310,6 +310,16 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
             return activeNodeFilter.getChild(parent, index);
         }
         return null;
+    }
+
+    /**
+     * @return whether the children should be read directly from the tree (whose branch nodes are
+     *         already search-filtered) instead of through the active {@link NodeFilter}. While the
+     *         collapsing search is active it takes precedence over an intermediate-step filter, so
+     *         that the latter does not additionally hide (or surface) nodes among the matches.
+     */
+    private boolean bypassNodeFilter() {
+        return activeNodeFilter == null || ProofTreeViewFilter.SEARCH.isActive();
     }
 
     /**
@@ -322,7 +332,7 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
      */
     @Override
     public synchronized int getChildCount(Object parent) {
-        if (activeNodeFilter == null) {
+        if (bypassNodeFilter()) {
             return ((TreeNode) parent).getChildCount();
         } else {
             return activeNodeFilter.getChildCount(parent);
@@ -340,7 +350,7 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
     @Override
     public synchronized int getIndexOfChild(Object parent, Object child) {
         TreeNode guiParent = (TreeNode) parent;
-        if (activeNodeFilter == null) {
+        if (bypassNodeFilter()) {
             for (int i = 0; i < guiParent.getChildCount(); i++) {
                 if (guiParent.getChildAt(i) == child) {
                     return i;
@@ -399,6 +409,15 @@ public class GUIProofTreeModel implements TreeModel, java.io.Serializable {
      * @param trn tree node to update.
      */
     private synchronized void updateTree(GUIAbstractTreeNode trn) {
+
+        // The proof may have changed; drop the search filter's memoized match information so the
+        // collapsing search reflects the new proof state. A changed match anywhere can also change
+        // which ancestor branches are shown (a branch that had no match may now contain one), so a
+        // partial update does not suffice: force a full rebuild.
+        if (ProofTreeViewFilter.SEARCH.isActive()) {
+            ProofTreeViewFilter.SEARCH.invalidateCache();
+            trn = null;
+        }
 
         // If possible, redraw only a certain subtree
         // starting from the lowermost parent of trn that is not hidden

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeSearchBar.java
@@ -5,6 +5,8 @@ package de.uka.ilkd.key.gui.prooftree;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
 import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 import javax.swing.text.Position;
@@ -21,14 +23,44 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
     private int startRow = 0;
     private int currentRow = 0;
 
+    /**
+     * When selected, searching collapses the proof tree to the matches (and the branch structure
+     * needed to reach them); when deselected, the search only highlights matches without hiding
+     * anything. Created in {@link #createUI()}.
+     */
+    private JToggleButton collapseToggle;
+
+    /** whether the {@link ProofTreeViewFilter#SEARCH} filter is currently applied to the model */
+    private boolean filterApplied = false;
+
+    /** whether a deferred re-expansion of the filtered tree is already pending */
+    private boolean reexpandScheduled = false;
+
     public ProofTreeSearchBar(ProofTreeView proofTreeView) {
         this.proofTreeView = proofTreeView;
     }
 
     @Override
+    public void createUI() {
+        super.createUI();
+        collapseToggle = new JToggleButton("Collapse", true);
+        collapseToggle.setToolTipText(
+            "Collapse the proof tree to the search matches (otherwise only highlight them)");
+        collapseToggle.setMargin(new java.awt.Insets(2, 4, 2, 4));
+        collapseToggle.addActionListener(e -> search());
+        add(collapseToggle);
+    }
+
+    @Override
     public void setVisible(boolean vis) {
         super.setVisible(vis);
-        if (!vis && proofTreeView != null) {
+        if (vis) {
+            // re-apply the collapsing filter for a search term kept from a previous opening
+            if (!searchField.getText().isEmpty()) {
+                search();
+            }
+        } else if (proofTreeView != null) {
+            updateCollapsingFilter("");
             proofTreeView.delegateView.requestFocusInWindow();
         }
     }
@@ -54,8 +86,44 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
     }
 
     public boolean search(@NonNull String searchString) {
+        updateCollapsingFilter(searchString);
         fillCache();
         return search(searchString, Position.Bias.Forward);
+    }
+
+    /**
+     * Updates the {@link ProofTreeViewFilter#SEARCH} filter with the given query, hiding subtrees
+     * (and intermediate steps) that contain no match so that the proof tree collapses to the
+     * relevant branches while searching. Does nothing but deactivate the filter when the
+     * {@link #collapseToggle} is off, so the search merely highlights matches.
+     *
+     * @param searchString the current content of the search field.
+     */
+    private void updateCollapsingFilter(@NonNull String searchString) {
+        GUIProofTreeModel delegateModel = this.proofTreeView.getDelegateModel();
+        if (delegateModel == null) {
+            return;
+        }
+        boolean collapse = collapseToggle != null && collapseToggle.isSelected()
+                && !searchString.isEmpty();
+        if (collapse) {
+            ProofTreeViewFilter.SEARCH.setQuery(searchString);
+            delegateModel.setFilter(ProofTreeViewFilter.SEARCH, true);
+            filterApplied = true;
+            // The filter just reset the tree structure (collapsing it); expand the now-small
+            // filtered tree so that all surviving matches are revealed without manual expansion.
+            proofTreeView.expandFilteredTree();
+        } else if (filterApplied) {
+            // Only remove the filter (rebuilding the tree) when it was actually applied, so the
+            // highlight-only mode does not rebuild on every keystroke. Clear the flag first so the
+            // structure change from removing the filter does not trigger a re-expansion (see
+            // reset()).
+            filterApplied = false;
+            ProofTreeViewFilter.SEARCH.setQuery("");
+            delegateModel.setFilter(ProofTreeViewFilter.SEARCH, false);
+            // The rebuild dropped the selection; restore it so e.g. the view filters stay usable.
+            proofTreeView.selectCurrentNodeInTree();
+        }
     }
 
     private synchronized boolean search(String searchString, Position.Bias direction) {
@@ -99,6 +167,18 @@ class ProofTreeSearchBar extends SearchBar implements TreeModelListener {
 
     public synchronized void reset() {
         cache = null;
+        // The proof tree changed (e.g. a strategy run added nodes). If the collapsing search is
+        // active, the rebuilt tree is collapsed again; re-expand it so newly matching nodes become
+        // visible. Deferred to run after the current tree-change event has been processed.
+        if (filterApplied && !reexpandScheduled) {
+            reexpandScheduled = true;
+            SwingUtilities.invokeLater(() -> {
+                reexpandScheduled = false;
+                if (filterApplied) {
+                    proofTreeView.expandFilteredTree();
+                }
+            });
+        }
     }
 
     private void addNodeToCache(GUIAbstractTreeNode node) {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -823,6 +823,26 @@ public class ProofTreeView extends JPanel implements TabPanel {
         proofTreeSearchPanel.setVisible(true);
     }
 
+    /**
+     * Expands all currently visible nodes. Used by the collapsing search to reveal the (few)
+     * surviving matching nodes after the tree has been filtered down to them.
+     */
+    void expandFilteredTree() {
+        ProofTreeExpansionState.expandAll(delegateView,
+            ProofTreePopupFactory.ossPathFilter(isExpandOSSNodes()));
+    }
+
+    /**
+     * Re-selects the currently selected proof node in the tree. Used by the collapsing search to
+     * restore a valid selection after it removed the filter and rebuilt the tree (the rebuild
+     * drops the selection, which other actions such as the view filters rely on).
+     */
+    void selectCurrentNodeInTree() {
+        if (mediator != null) {
+            makeNodeVisible(mediator.getSelectedNode());
+        }
+    }
+
     @Override
     public @NonNull String getTitle() {
         return "Proof";

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -327,6 +327,96 @@ public class ProofTreeView extends JPanel implements TabPanel {
             KeYGuiExtension.KeyboardShortcuts.PROOF_TREE_VIEW);
 
         setMediator(m);
+
+        // The view only listens to the mediator and the proof while its tab is actually
+        // showing — a hidden tab costs (almost) nothing. When the tab becomes visible
+        // again, activatePanel() catches up.
+        addHierarchyListener(e -> {
+            if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
+                if (isShowing()) {
+                    activatePanel();
+                } else {
+                    passivatePanel();
+                }
+            }
+        });
+        passivatePanel();
+    }
+
+    // ------------------------------------------------------------------- show/hide lifecycle
+
+    /** whether the tab is showing and the listeners are attached */
+    private boolean panelActive = true;
+    /** whether the proof changed while the tab was hidden */
+    private boolean dirtyWhileHidden = false;
+
+    /** minimal listener kept on the proof while hidden, only records "something changed" */
+    private final ProofTreeAdapter dirtyListener = new ProofTreeAdapter() {
+        @Override
+        public void proofExpanded(ProofTreeEvent e) {
+            dirtyWhileHidden = true;
+        }
+
+        @Override
+        public void proofPruned(ProofTreeEvent e) {
+            dirtyWhileHidden = true;
+        }
+
+        @Override
+        public void proofStructureChanged(ProofTreeEvent e) {
+            dirtyWhileHidden = true;
+        }
+
+        @Override
+        public void proofGoalRemoved(ProofTreeEvent e) {
+            dirtyWhileHidden = true;
+        }
+    };
+
+    private void activatePanel() {
+        if (panelActive) {
+            return;
+        }
+        panelActive = true;
+        register();
+        if (proof != null && !proof.isDisposed()) {
+            proof.removeProofTreeListener(dirtyListener);
+        }
+
+        Proof selected = mediator.getSelectedProof();
+        if (selected != proof) {
+            dirtyWhileHidden = false;
+            setProof(selected);
+        } else if (delegateModel != null) {
+            if (mediator.isInAutoMode()) {
+                // catch up in autoModeStopped, the dirty flag stays set until then
+                delegateModel.setAttentive(false);
+                return;
+            }
+            if (!delegateModel.isAttentive()) {
+                delegateModel.setAttentive(true);
+            }
+            if (dirtyWhileHidden) {
+                dirtyWhileHidden = false;
+                delegateModel.updateTree((Node) null);
+            }
+            makeNodeVisible(mediator.getSelectedNode());
+        }
+    }
+
+    private void passivatePanel() {
+        if (!panelActive) {
+            return;
+        }
+        panelActive = false;
+        unregister();
+        if (proof != null && !proof.isDisposed()) {
+            if (delegateModel != null && delegateModel.isAttentive()) {
+                delegateModel.setAttentive(false);
+            }
+            proof.removeProofTreeListener(dirtyListener);
+            proof.addProofTreeListener(dirtyListener);
+        }
     }
 
     public boolean isExpandOSSNodes() {
@@ -960,6 +1050,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
             }
             if (!delegateModel.isAttentive()) {
                 delegateModel.setAttentive(true);
+            }
+            if (dirtyWhileHidden) {
+                // the tab was (re-)activated while the strategy was running
+                dirtyWhileHidden = false;
+                delegateModel.updateTree((Node) null);
             }
             mediator.addKeYSelectionListenerChecked(proofListener);
             makeSelectedNodeVisible(mediator.getSelectedNode());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeViewFilter.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeViewFilter.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.gui.prooftree;
 
 import java.util.Arrays;
+import java.util.WeakHashMap;
 import javax.swing.tree.TreeNode;
 
 import de.uka.ilkd.key.proof.Goal;
@@ -47,11 +48,16 @@ public abstract class ProofTreeViewFilter {
         ONLY_INTERACTIVE, HIDE_CLOSED_SUBTREES, HIDE_INTERACTIVE_GOALS };
 
     /**
+     * Hides subtrees that do not contain a node matching the current search query.
+     */
+    static final TreeSearchFilter SEARCH = new TreeSearchFilter();
+
+    /**
      * All ProofTreeViewFilters that operate on whole subtrees, as opposed to {@link NodeFilter}s,
      * which operate on single nodes.
      */
     public final static ProofTreeViewFilter[] ALL_GLOBAL_FILTERS =
-        { HIDE_CLOSED_SUBTREES, HIDE_INTERACTIVE_GOALS };
+        { HIDE_CLOSED_SUBTREES, HIDE_INTERACTIVE_GOALS, SEARCH };
 
     /**
      *
@@ -365,6 +371,111 @@ public abstract class ProofTreeViewFilter {
 
             // Also show closed subtrees.
             return proof.getSubtreeGoals(node).isEmpty();
+        }
+    }
+
+    /**
+     * Hides subtrees that do not contain a node matching the current search query, so that
+     * typing into the proof tree's search bar incrementally collapses non-matching parts of the
+     * tree. The query is set via {@link #setQuery(String)}; the filter is active iff the query is
+     * non-empty.
+     */
+    static final class TreeSearchFilter extends ProofTreeViewFilter {
+
+        private String query = "";
+
+        /**
+         * Caches, for a node, whether its subtree contains a match for {@link #query}.
+         */
+        private final WeakHashMap<Node, Boolean> containsMatchCache = new WeakHashMap<>();
+
+        /**
+         * Sets the search query and clears the match cache. The filter becomes active iff
+         * {@code query} is non-empty.
+         *
+         * @param query the search query, as entered into the proof tree's search bar.
+         */
+        void setQuery(String query) {
+            this.query = query == null ? "" : query.toLowerCase();
+            containsMatchCache.clear();
+        }
+
+        /**
+         * Invalidates the memoized "contains a match" information. Must be called whenever the
+         * proof changed (e.g. after a strategy run added nodes), since a node previously cached as
+         * containing no match may now contain one in a newly added descendant.
+         */
+        void invalidateCache() {
+            containsMatchCache.clear();
+        }
+
+        /**
+         * @param node a node.
+         * @return the text that {@link #query} is matched against for {@code node}, consistent
+         *         with {@link GUIProofTreeNode#toString()} and {@link GUIBranchNode#toString()}.
+         */
+        private static String searchString(Node node) {
+            String text = node.serialNr() + ":" + node.name();
+            String branchLabel = node.getNodeInfo().getBranchLabel();
+            if (branchLabel != null) {
+                text += ":" + branchLabel;
+            }
+            return text;
+        }
+
+        /**
+         * @param node a node.
+         * @return whether {@code node} itself matches the current query. Used to hide
+         *         non-matching intermediate proof steps within a branch (the step-level
+         *         counterpart to {@link #showSubtree(Node)}).
+         */
+        boolean matches(Node node) {
+            return searchString(node).toLowerCase().contains(query);
+        }
+
+        private boolean containsMatch(Node node) {
+            Boolean cached = containsMatchCache.get(node);
+            if (cached != null) {
+                return cached;
+            }
+            boolean result = matches(node);
+            for (int i = 0; !result && i < node.childrenCount(); i++) {
+                result = containsMatch(node.child(i));
+            }
+            containsMatchCache.put(node, result);
+            return result;
+        }
+
+        @Override
+        public String name() {
+            return "Search";
+        }
+
+        @Override
+        public boolean showSubtree(Node node) {
+            return containsMatch(node);
+        }
+
+        @Override
+        public boolean isActive() {
+            return !query.isEmpty();
+        }
+
+        @Override
+        public boolean addToProofTreeView() {
+            return false;
+        }
+
+        @Override
+        void setActive(boolean active) {
+            if (!active) {
+                setQuery("");
+            }
+        }
+
+        @Override
+        boolean global() {
+            return true;
         }
     }
 }


### PR DESCRIPTION

## Intended Change

This PR adds a collapsing proof tree search. If in the proof tree search the collapse button is activated, the proof tree shows only the nodes with matching content.

The proof tree view was updated even if not shown. For large proofs that meant that the drawing costs were always present. This PR prevents the update if the view is not visible.

## Type of pull request

- New feature (non-breaking change which adds functionality)

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: extensive manual test to exclude changed behavior of previous elements (filtering of intermediate, non-interactive nodes), checked that proof tree is correctly updated once in view

## Additional information and contact(s)

This PR was developed with help of AI and extensively manually tested.


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
