### PR TITLE
Optimize NonDuplicateEqApp-features

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractNonDuplicateAppFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractNonDuplicateAppFeature.java
@@ -125,9 +125,17 @@ public abstract class AbstractNonDuplicateAppFeature extends BinaryTacletAppFeat
         final Node node = goal.node();
         final AppliedRuleAppsNameCache cache =
             node.proof().getServices().getCaches().getAppliedRuleAppsNameCache();
-        List<RuleApp> apps = cache.get(node, app.rule().name());
+        // A duplicate must agree on the focus term up to term labels (every comparePio variant,
+        // including the modulo-position one, implies this), so it shares the candidate's focus-term
+        // fingerprint and can only be in that bucket. A find-less application (pos == null) lands
+        // in
+        // bucket 0, where all find-less applications of this name live (a taclet name is either
+        // find
+        // or find-less, never both).
+        final int fingerprint = pos == null ? 0 : pos.subTerm().hashCode();
+        List<RuleApp> apps = cache.get(node, app.rule().name(), fingerprint);
 
-        // Check all rules with this name
+        // Check all rules with this name in the same fingerprint bucket
         for (RuleApp a : apps) {
             if (sameApplication(a, app, pos)) {
                 return false;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AppliedRuleAppsNameCache.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AppliedRuleAppsNameCache.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.util.AssertionFailure;
 
 import org.key_project.logic.Name;
 import org.key_project.prover.rules.RuleApp;
+import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.util.LRUCache;
 
 import org.jspecify.annotations.NonNull;
@@ -18,12 +19,25 @@ import org.jspecify.annotations.NonNull;
 /**
  * Establishes a cache for the applied rule apps to query them by name.
  * See the get method for additional required constraints for correctness.
+ * <p>
+ * Within a rule name the applied apps are additionally bucketed by an application
+ * <em>fingerprint</em>: the hash code of the application's focus term ({@code pos.subTerm()}), or
+ * {@code 0} for find-less apps. This turns the duplicate search in
+ * {@link AbstractNonDuplicateAppFeature} from a linear scan over all same-named applications on the
+ * branch into an O(1) bucket lookup. It is sound for every duplicate check because each one's
+ * {@code comparePio} implies the two focus terms are equal up to term labels:
+ * {@link NonDuplicateAppFeature} (equal positions), {@link EqNonDuplicateAppFeature} (equal
+ * positions modulo formula renaming) and {@link NonDuplicateAppModPositionFeature} (equal focus
+ * terms modulo irrelevant labels). As {@code TermImpl.hashCode} ignores term labels, focus terms
+ * that are equal up to labels always share a fingerprint, so a duplicate can only ever live in the
+ * candidate's own bucket -- including for the modulo-position variant, which deliberately matches
+ * the same focus term at different sequent positions.
  *
  * @author Julian Wiesler
  */
 public class AppliedRuleAppsNameCache {
-    /** cache of all applied rules by name of a node */
-    private final LRUCache<Node, HashMap<Name, List<RuleApp>>> cache =
+    /** cache of all applied rules of a node, by rule name and then by application fingerprint */
+    private final LRUCache<Node, HashMap<Name, HashMap<Integer, List<RuleApp>>>> cache =
         new LRUCache<>(32);
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -33,20 +47,39 @@ public class AppliedRuleAppsNameCache {
     public AppliedRuleAppsNameCache() {}
 
     /**
+     * @return the fingerprint of a rule application: the hash code of its focus term, or {@code 0}
+     *         for a find-less application. The hash ignores term labels (as does
+     *         {@code TermImpl.hashCode}); see the class comment for why this is sound for all
+     *         duplicate checks. A find-less app uses {@code 0}; should a focus term also hash to
+     *         {@code 0} the only effect is a shared bucket, which the {@code sameApplication} scan
+     *         resolves.
+     */
+    private static int fingerprint(RuleApp app) {
+        final PosInOccurrence pio = app.posInOccurrence();
+        return pio == null ? 0 : pio.subTerm().hashCode();
+    }
+
+    private static void add(HashMap<Name, HashMap<Integer, List<RuleApp>>> nodeCache, RuleApp app) {
+        nodeCache.computeIfAbsent(app.rule().name(), k -> new HashMap<>())
+                .computeIfAbsent(fingerprint(app), k -> new ArrayList<>())
+                .add(app);
+    }
+
+    /**
      * Fills the cache value of this instance for node
      *
      * @param node the node
      * @return the value
      */
-    private @NonNull HashMap<Name, List<RuleApp>> fillCacheForNode(
+    private @NonNull HashMap<Name, HashMap<Integer, List<RuleApp>>> fillCacheForNode(
             Node node) {
-        HashMap<Name, List<RuleApp>> nodeCache;
+        HashMap<Name, HashMap<Integer, List<RuleApp>>> nodeCache;
         try {
             writeLock.lock();
             nodeCache = cache.get(node);
             if (nodeCache == null) {
                 // Try to use parent cache to initialize the new cache
-                HashMap<Name, List<RuleApp>> parentCache =
+                HashMap<Name, HashMap<Integer, List<RuleApp>>> parentCache =
                     node.root() ? null : cache.get(node.parent());
                 nodeCache = new HashMap<>();
 
@@ -56,19 +89,21 @@ public class AppliedRuleAppsNameCache {
                         nodeCache = parentCache;
                     } else {
                         // Copy the parent cache
-                        for (Map.Entry<Name, List<RuleApp>> entry : parentCache
+                        for (Map.Entry<Name, HashMap<Integer, List<RuleApp>>> entry : parentCache
                                 .entrySet()) {
-                            nodeCache.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+                            HashMap<Integer, List<RuleApp>> buckets = new HashMap<>();
+                            for (Map.Entry<Integer, List<RuleApp>> bucket : entry.getValue()
+                                    .entrySet()) {
+                                buckets.put(bucket.getKey(), new ArrayList<>(bucket.getValue()));
+                            }
+                            nodeCache.put(entry.getKey(), buckets);
                         }
                     }
 
                     // Parent did not have a rule applied when we calculated this, add the rule
                     // applied
                     // there
-                    RuleApp parentApp =
-                        node.parent().getAppliedRuleApp();
-                    nodeCache.computeIfAbsent(parentApp.rule().name(), k -> new ArrayList<>())
-                            .add(parentApp);
+                    add(nodeCache, node.parent().getAppliedRuleApp());
 
                     // If this is an inner node, we hope we will never revisit it, remove it from
                     // the
@@ -81,10 +116,7 @@ public class AppliedRuleAppsNameCache {
                     Node current = node;
                     while (!current.root()) {
                         final Node par = current.parent();
-
-                        RuleApp a = par.getAppliedRuleApp();
-                        nodeCache.computeIfAbsent(a.rule().name(), k -> new ArrayList<>()).add(a);
-
+                        add(nodeCache, par.getAppliedRuleApp());
                         current = par;
                     }
                 }
@@ -99,7 +131,8 @@ public class AppliedRuleAppsNameCache {
     }
 
     /**
-     * Gets rule apps applied to any node before the given node with the given name.
+     * Gets rule apps applied to any node before the given node with the given name and the given
+     * application fingerprint (see {@link #fingerprint(RuleApp)}).
      * <p>
      * Multiple assumptions about nodes:
      * * The given node is a leaf, no children, no applied rule
@@ -109,15 +142,16 @@ public class AppliedRuleAppsNameCache {
      *
      * @param node the node
      * @param name the name
+     * @param fingerprint the application fingerprint to restrict to
      * @return rule apps
      */
     public @NonNull List<RuleApp> get(@NonNull Node node,
-            @NonNull Name name) {
+            @NonNull Name name, int fingerprint) {
         if (node.getAppliedRuleApp() != null || node.childrenCount() != 0) {
             throw new AssertionFailure("Expected an empty leaf node");
         }
 
-        HashMap<Name, List<RuleApp>> nodeCache;
+        HashMap<Name, HashMap<Integer, List<RuleApp>>> nodeCache;
         try {
             readLock.lock();
             nodeCache = cache.get(node);
@@ -129,7 +163,11 @@ public class AppliedRuleAppsNameCache {
             nodeCache = fillCacheForNode(node);
         }
 
-        List<RuleApp> apps = nodeCache.get(name);
+        HashMap<Integer, List<RuleApp>> byFingerprint = nodeCache.get(name);
+        if (byFingerprint == null) {
+            return Collections.emptyList();
+        }
+        List<RuleApp> apps = byFingerprint.get(fingerprint);
         return apps == null ? Collections.emptyList() : Collections.unmodifiableList(apps);
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/strategy/feature/TestNonDuplicateAppFeature.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/strategy/feature/TestNonDuplicateAppFeature.java
@@ -1,0 +1,165 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.strategy.feature;
+
+import de.uka.ilkd.key.proof.BuiltInRuleAppIndex;
+import de.uka.ilkd.key.proof.BuiltInRuleIndex;
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Node;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.TacletIndex;
+import de.uka.ilkd.key.proof.TacletIndexKit;
+import de.uka.ilkd.key.proof.calculus.JavaDLSequentKit;
+import de.uka.ilkd.key.rule.TacletApp;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.key_project.logic.PosInTerm;
+import org.key_project.prover.proof.rulefilter.TacletFilter;
+import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.sequent.Sequent;
+import org.key_project.prover.sequent.SequentFormula;
+import org.key_project.prover.strategy.costbased.MutableState;
+import org.key_project.prover.strategy.costbased.RuleAppCost;
+import org.key_project.prover.strategy.costbased.TopRuleAppCost;
+import org.key_project.prover.strategy.costbased.feature.Feature;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSLList;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests duplicate detection of {@link NonDuplicateAppFeature} and {@link EqNonDuplicateAppFeature},
+ * which go through the fingerprint-bucketed {@link AppliedRuleAppsNameCache}. The two key
+ * properties: an application already performed on the branch is rejected (cost
+ * {@link TopRuleAppCost}), and the fingerprint bucketing never hides a real duplicate nor invents
+ * one for the same taclet applied at a <em>different</em> position (a different bucket).
+ */
+public class TestNonDuplicateAppFeature {
+
+    @BeforeAll
+    public static void setUp() {
+        TacletForTests.parse();
+    }
+
+    /** Root sequent {@code ==> A -> B, B -> A} (two distinct succedent formulas). */
+    private static Sequent twoImplications() {
+        ImmutableList<SequentFormula> succ = ImmutableSLList.<SequentFormula>nil()
+                .append(new SequentFormula(TacletForTests.parseTerm("A -> B")))
+                .append(new SequentFormula(TacletForTests.parseTerm("B -> A")));
+        return JavaDLSequentKit.createSequent(ImmutableSLList.nil(), succ);
+    }
+
+    private static Goal goalFor(Node n, TacletIndex idx) {
+        return new Goal(n, idx, new BuiltInRuleAppIndex(new BuiltInRuleIndex()),
+            n.proof().getServices());
+    }
+
+    private static PosInOccurrence topSucc(Node n, int idx) {
+        return new PosInOccurrence(n.sequent().succedent().get(idx), PosInTerm.getTopLevel(),
+            false);
+    }
+
+    private static TacletApp appAt(Goal goal, PosInOccurrence pos) {
+        return goal.ruleAppIndex().getTacletAppAt(TacletFilter.TRUE, pos, null).head();
+    }
+
+    /**
+     * Build {@code root --(imp_right at succedent #applyIdx)--> child(leaf)} and return the feature
+     * cost of applying imp_right at succedent #candIdx on the child leaf.
+     */
+    private static RuleAppCost cost(Feature feature, int applyIdx, int candIdx) {
+        Proof proof = new Proof("TestNonDuplicateAppFeature", TacletForTests.initConfig());
+        Node root = new Node(proof, twoImplications());
+        proof.setRoot(root);
+
+        TacletIndex idx = TacletIndexKit.getKit().createTacletIndex();
+        idx.add(TacletForTests.lookupTaclet("imp_right"));
+        Goal rootGoal = goalFor(root, idx);
+
+        final PosInOccurrence applyPos = topSucc(root, applyIdx);
+        final PosInOccurrence candPos = topSucc(root, candIdx);
+        final TacletApp applied = appAt(rootGoal, applyPos);
+        final TacletApp candidate = candIdx == applyIdx ? applied : appAt(rootGoal, candPos);
+
+        root.setAppliedRuleApp(applied);
+        Node child = new Node(proof, root.sequent(), root);
+        root.add(child);
+
+        return feature.computeCost(candidate, candPos, goalFor(child, idx), new MutableState());
+    }
+
+    @Test
+    public void nonDuplicateRejectsAlreadyAppliedApp() {
+        assertSame(TopRuleAppCost.INSTANCE, cost(NonDuplicateAppFeature.INSTANCE, 0, 0),
+            "re-applying the same taclet at the same position must be rejected as a duplicate");
+    }
+
+    @Test
+    public void nonDuplicateAcceptsAppAtDifferentPosition() {
+        assertNotSame(TopRuleAppCost.INSTANCE, cost(NonDuplicateAppFeature.INSTANCE, 1, 0),
+            "the same taclet at a different position is not a duplicate (different fingerprint bucket)");
+    }
+
+    @Test
+    public void eqNonDuplicateRejectsAlreadyAppliedApp() {
+        assertSame(TopRuleAppCost.INSTANCE, cost(EqNonDuplicateAppFeature.INSTANCE, 0, 0),
+            "eqEquals variant must also reject an already-applied application");
+    }
+
+    @Test
+    public void eqNonDuplicateAcceptsAppAtDifferentPosition() {
+        assertNotSame(TopRuleAppCost.INSTANCE, cost(EqNonDuplicateAppFeature.INSTANCE, 1, 0),
+            "eqEquals variant must accept the same taclet at a different position");
+    }
+
+    /**
+     * Apply a rewrite (TestApplyTaclet_contradiction, {@code find(b->c)}) at one occurrence of
+     * {@code A -> B} in {@code ==> (A -> B) & (A -> B)}, then return the cost of applying it at the
+     * <em>other</em> occurrence: same focus term, different sequent position. This is the case the
+     * fingerprint must not get wrong -- the modulo-position variant treats it as a duplicate, the
+     * plain variant does not.
+     */
+    private static RuleAppCost crossPositionCost(Feature feature) {
+        Proof proof = new Proof("TestNonDuplicateAppFeature", TacletForTests.initConfig());
+        SequentFormula conj = new SequentFormula(TacletForTests.parseTerm("(A -> B) & (A -> B)"));
+        Node root = new Node(proof,
+            JavaDLSequentKit.createSequent(ImmutableSLList.nil(), ImmutableSLList.singleton(conj)));
+        proof.setRoot(root);
+
+        TacletIndex idx = TacletIndexKit.getKit().createTacletIndex();
+        idx.add(TacletForTests.lookupTaclet("TestApplyTaclet_contradiction"));
+        Goal rootGoal = goalFor(root, idx);
+
+        final SequentFormula f = root.sequent().succedent().get(0);
+        final PosInOccurrence leftConjunct =
+            new PosInOccurrence(f, PosInTerm.getTopLevel().down(0), false);
+        final PosInOccurrence rightConjunct =
+            new PosInOccurrence(f, PosInTerm.getTopLevel().down(1), false);
+
+        root.setAppliedRuleApp(appAt(rootGoal, leftConjunct));
+        Node child = new Node(proof, root.sequent(), root);
+        root.add(child);
+
+        return feature.computeCost(appAt(rootGoal, rightConjunct), rightConjunct,
+            goalFor(child, idx),
+            new MutableState());
+    }
+
+    @Test
+    public void modPositionRejectsSameFocusAtDifferentPosition() {
+        assertSame(TopRuleAppCost.INSTANCE,
+            crossPositionCost(NonDuplicateAppModPositionFeature.INSTANCE),
+            "modulo-position variant must treat the same focus term at a different position as a duplicate");
+    }
+
+    @Test
+    public void nonDuplicateAllowsSameFocusAtDifferentPosition() {
+        assertNotSame(TopRuleAppCost.INSTANCE, crossPositionCost(NonDuplicateAppFeature.INSTANCE),
+            "plain variant must not treat a different position as a duplicate even with equal focus term");
+    }
+}


### PR DESCRIPTION
This PR addresses the NonDuplicateEqApp family of features. The feature is rather expensive on large proofs as it moves up the proof tree to find whether a taclet with identical/same instantiation has already been applied. A cache for that already existed, but it was still necessary to compare all information.

This adds a filter via hashode (position, formula), so that the expensive equality checks need only to be done when the hashcode coincides. This leads to improvements for OSS enabled proof search but in particular for Non-OSS proof search.

The following numbers are when this PR is applied on top of #3828 (times in ms):


| straightline | OSS | PR #3828  | This PR | speedup |
|---|---|---|---|---|
| 1000 | on  | 2259   | 2131  | 1.06× |
| 1000 | off | 5428   | 5066  | 1.07× |
| 4000 | on  | 9457   | 7647  | 1.24× |
| 4000 | off | 31142  | 19193 | 1.62× |
| 8000 | on  | 25021  | 15737 | 1.59× |
| 8000 | off | 113771 | 42275 | **2.69×** |


## Intended Change

Improve performance on large proofs


## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality. There are now tests for NonDuplicateApp* features
- I have tested the feature as follows: Additional tests, behavior equivalence on subset of runAllProofs
- I have checked that runtime performance has not deteriorated. It actually improves

## Additional information and contact(s)

AI was used for this PR.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
