### PR TITLE
Performance (5/5): operator-indexed parking of assumes-incomplete rule-app bases

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Goal.java
@@ -39,6 +39,7 @@ import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.prover.sequent.SequentFormula;
+import org.key_project.prover.strategy.DelegationBasedRuleApplicationManager;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
@@ -243,6 +244,15 @@ public final class Goal implements ProofGoal<Goal> {
         var time1 = System.nanoTime();
         PERF_UPDATE_TAG_MANAGER.getAndAdd(time1 - time);
         ruleAppIndex.sequentChanged(sci);
+        // Feed the change to the (possibly delegation-wrapped) queue manager so it can wake parked
+        // assumes-bases on their matching round (see QueueRuleApplicationManager#parkedByOp).
+        RuleApplicationManager<Goal> m = ruleAppManager;
+        while (m instanceof DelegationBasedRuleApplicationManager<Goal> d) {
+            m = d.getDelegate();
+        }
+        if (m instanceof QueueRuleApplicationManager qm) {
+            qm.sequentChanged(sci);
+        }
         var time2 = System.nanoTime();
         PERF_UPDATE_RULE_APP_INDEX.getAndAdd(time2 - time1);
         for (GoalListener listener : listeners) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -5,13 +5,27 @@ package de.uka.ilkd.key.strategy;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import de.uka.ilkd.key.logic.JTerm;
+import de.uka.ilkd.key.logic.op.UpdateApplication;
 import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.rule.NoPosTacletApp;
+import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
+import org.key_project.logic.op.Operator;
+import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.rules.RuleApp;
+import org.key_project.prover.sequent.FormulaChangeInfo;
 import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.sequent.Sequent;
+import org.key_project.prover.sequent.SequentChangeInfo;
+import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.RuleAppCost;
@@ -67,6 +81,47 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
 
     private long nextRuleTime;
 
+    /**
+     * Parked assumes-incomplete taclet bases, indexed by the concrete top operator(s) of their
+     * {@code \assumes} formulas. Such bases re-expand to nothing (no new assumes match) on almost
+     * every round (profiling: 96.8% of queue pops fail at the unmatched {@code \assumes}, and
+     * 97-99.6% of the resulting re-expansions yield no new instance -- the dominant remaining queue
+     * churn), so instead of re-popping and re-expanding them each round they are parked here and
+     * woken only when a formula they could match appears. A base is stored under each of its wake
+     * operators and woken when any of them is added/modified. Insertion-ordered for determinism;
+     * {@code null} until the first base is parked.
+     * <p>
+     * Sound (byte-identical) by construction, unlike the earlier sequent-growth heuristic:
+     * <ul>
+     * <li>Only <em>effectively-indexable</em> bases are parked -- every {@code \assumes} formula's
+     * top operator is concrete or a schema variable already bound by the find-match (see
+     * {@link #assumesWakeOps}). Bases with an unbound-generic top (which would match any formula)
+     * are never parked; they stay in the active queue and re-expand every round exactly as without
+     * parking.</li>
+     * <li>A parked base is woken (re-inserted into the active queue) on exactly the round a formula
+     * with a matching top operator is added or modified ({@link #sequentChanged}/{@code
+     * pendingWakeOps}) -- the same round its non-parked counterpart would first see that formula as
+     * "new" and re-expand to the instance. So the instance enters the queue at the identical round,
+     * with the identical (current) age and cost, and the proof is byte-identical.</li>
+     * <li>The wake set is a sound <em>superset</em>: it walks the changed formula's update-prefix
+     * spine of operators (the assumes matcher strips the update context before matching, see
+     * {@code VMTacletMatcher.matchUpdateContext}). Over-waking is harmless -- a spuriously woken
+     * base
+     * is popped, re-expands to nothing, and is re-parked, exactly as a non-parked base would behave
+     * that round. Only <em>missing</em> a wake would diverge, and that cannot happen for an
+     * effectively-indexable base.</li>
+     * <li>All structures are insertion-ordered ({@link LinkedHashMap}/{@link LinkedHashSet}) so
+     * parking introduces no non-determinism.</li>
+     * </ul>
+     */
+    private @Nullable LinkedHashMap<Operator, LinkedHashSet<RuleAppContainer>> parkedByOp = null;
+    /**
+     * Top operators (along the update-prefix spine) of formulas added/modified since the previous
+     * round; the wake candidates consumed at the start of the next round. Insertion-ordered for
+     * determinism; {@code null} until the first change is recorded.
+     */
+    private @Nullable LinkedHashSet<Operator> pendingWakeOps = null;
+
     @Override
     public void setGoal(Goal p_goal) {
         goal = p_goal;
@@ -79,6 +134,8 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
     public void clearCache() {
         queue = null;
         previousMinimum = null;
+        parkedByOp = null;
+        pendingWakeOps = null;
         if (goal != null) {
             goal.proof().getServices().getCaches().getIfInstantiationCache().releaseAll();
         }
@@ -279,11 +336,20 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
          */
         ImmutableList<RuleAppContainer> workingList = ImmutableSLList.nil();
 
+        // Wake parked assumes-bases whose \assumes top operator matches a formula added/modified
+        // since the last round, re-inserting them into the active queue so they re-expand during
+        // THIS
+        // round -- the identical round their non-parked counterparts would first see that formula
+        // as
+        // new. No completeness net is needed (or wanted): an effectively-indexable base is always
+        // woken on its matching round, and a late re-injection would surface its instance at the
+        // wrong round, the very divergence parking must avoid.
+        wakeParkedBases();
+
         /*
          * Try to find a rule app that can be completed until both queues are exhausted.
          */
         while (nextRuleApp == null && !(queue.isEmpty() && furtherAppsQueue.isEmpty())) {
-
             /*
              * Determine the minimum rule app container, ranging over both queues. Putting this into
              * a separate method would be convenient. But since we are using immutable data
@@ -353,11 +419,24 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
                      * Create further apps if found in main queue. Rule apps obtained this way will
                      * be considered during the current round.
                      */
+                    final ImmutableList<RuleAppContainer> further =
+                        minRuleAppContainer.createFurtherApps(goal);
+                    // Empty assumes yield (the re-expansion is just the re-costed base itself, with
+                    // the now-current age): if the base is effectively indexable, park it instead
+                    // of
+                    // re-adding so it stops being re-popped every round. Park further.head() (the
+                    // freshly re-costed container) so the parked age advances exactly as the
+                    // non-parked base's would, keeping later assumes matches from re-deriving stale
+                    // instances. A non-indexable base falls through and is re-added unchanged.
+                    if (further.size() == 1
+                            && further.head() instanceof TacletAppContainer base
+                            && !base.getTacletApp().assumesInstantionsComplete()
+                            && park(base)) {
+                        continue;
+                    }
                     var time = System.nanoTime();
                     try {
-                        furtherAppsQueue =
-                            push(minRuleAppContainer.createFurtherApps(goal).iterator(),
-                                furtherAppsQueue);
+                        furtherAppsQueue = push(further.iterator(), furtherAppsQueue);
                     } finally {
                         PERF_QUEUE_OPS.addAndGet(System.nanoTime() - time);
                     }
@@ -382,6 +461,170 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         }
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Assumes-base parking (see parkedByOp)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Park an assumes-incomplete base, indexing it under the top operator(s) of its
+     * {@code \assumes}
+     * formulas so it can be woken when a matching formula appears.
+     *
+     * @param base the re-costed base container to park (carries the current age)
+     * @return {@code true} if the base was parked; {@code false} if it is not effectively indexable
+     *         (an unbound-generic {@code \assumes} top), in which case the caller must keep it in
+     *         the
+     *         active queue
+     */
+    private boolean park(TacletAppContainer base) {
+        final List<Operator> ops = assumesWakeOps(base);
+        if (ops == null) {
+            return false;
+        }
+        if (parkedByOp == null) {
+            parkedByOp = new LinkedHashMap<>();
+        }
+        for (Operator op : ops) {
+            parkedByOp.computeIfAbsent(op, k -> new LinkedHashSet<>()).add(base);
+        }
+        return true;
+    }
+
+    /**
+     * Re-insert into the active queue every parked base waiting on an operator that was added or
+     * modified since the previous round (see {@link #pendingWakeOps}). Woken bases are collected in
+     * insertion order (deterministic) and removed from all their index buckets.
+     */
+    private void wakeParkedBases() {
+        if (pendingWakeOps == null) {
+            return;
+        }
+        if (parkedByOp != null && !parkedByOp.isEmpty()) {
+            LinkedHashSet<RuleAppContainer> woken = null;
+            for (Operator op : pendingWakeOps) {
+                final LinkedHashSet<RuleAppContainer> bucket = parkedByOp.get(op);
+                if (bucket != null) {
+                    if (woken == null) {
+                        woken = new LinkedHashSet<>();
+                    }
+                    woken.addAll(bucket);
+                }
+            }
+            if (woken != null) {
+                for (RuleAppContainer c : woken) {
+                    unindexParked(c);
+                }
+                var time = System.nanoTime();
+                try {
+                    queue = queue.insert(woken.iterator());
+                } finally {
+                    PERF_QUEUE_OPS.addAndGet(System.nanoTime() - time);
+                }
+            }
+        }
+        pendingWakeOps.clear();
+    }
+
+    /** Remove a woken container from every operator bucket it was parked under. */
+    private void unindexParked(RuleAppContainer c) {
+        if (parkedByOp == null || !(c instanceof TacletAppContainer tac)) {
+            return;
+        }
+        final List<Operator> ops = assumesWakeOps(tac);
+        if (ops == null) {
+            return;
+        }
+        for (Operator op : ops) {
+            final LinkedHashSet<RuleAppContainer> bucket = parkedByOp.get(op);
+            if (bucket != null) {
+                bucket.remove(c);
+                if (bucket.isEmpty()) {
+                    parkedByOp.remove(op);
+                }
+            }
+        }
+    }
+
+    /**
+     * The concrete top operator(s) of the {@code \assumes} formulas of the given base, resolved
+     * through the find-match's schema-variable instantiations.
+     *
+     * @return the wake operators, or {@code null} if the base is <em>not</em> effectively indexable
+     *         -- i.e. some {@code \assumes} formula has a top that is an unbound schema variable
+     *         (it
+     *         would match any formula, so no precise wake operator exists) or has no
+     *         {@code \assumes}
+     *         formulas at all
+     */
+    private static @Nullable List<Operator> assumesWakeOps(TacletAppContainer base) {
+        final NoPosTacletApp app = base.getTacletApp();
+        final Sequent assumesSeq = app.taclet().assumesSequent();
+        if (assumesSeq.isEmpty()) {
+            return null;
+        }
+        final SVInstantiations insts = app.instantiations();
+        final List<Operator> ops = new ArrayList<>(assumesSeq.size());
+        for (SequentFormula sf : assumesSeq) {
+            Operator op = sf.formula().op();
+            if (op instanceof SchemaVariable sv) {
+                final Object inst = insts.getInstantiation(sv);
+                if (!(inst instanceof JTerm instTerm)) {
+                    return null; // unbound (or non-term) generic top -> not indexable
+                }
+                op = instTerm.op();
+                if (op instanceof SchemaVariable) {
+                    return null; // still schematic -> not indexable
+                }
+            }
+            ops.add(op);
+        }
+        return ops;
+    }
+
+    /**
+     * Record, for the next round's wake-up, the top operators of every formula added or modified by
+     * this sequent change. The assumes matcher strips the update context before matching, so the
+     * whole update-prefix spine of each changed formula is recorded -- a sound superset of the
+     * operators a parked base could match (see {@link #parkedByOp}). Called by {@code Goal} on
+     * every
+     * sequent change.
+     */
+    public void sequentChanged(SequentChangeInfo sci) {
+        recordWakeOps(sci.addedFormulas(true));
+        recordWakeOps(sci.addedFormulas(false));
+        recordModifiedWakeOps(sci.modifiedFormulas(true));
+        recordModifiedWakeOps(sci.modifiedFormulas(false));
+    }
+
+    private void recordWakeOps(ImmutableList<SequentFormula> added) {
+        for (SequentFormula sf : added) {
+            recordSpineOps(sf.formula());
+        }
+    }
+
+    private void recordModifiedWakeOps(ImmutableList<FormulaChangeInfo> modified) {
+        for (FormulaChangeInfo fci : modified) {
+            recordSpineOps(fci.newFormula().formula());
+        }
+    }
+
+    /** Add the operators along a formula's update-application spine to {@link #pendingWakeOps}. */
+    private void recordSpineOps(org.key_project.logic.Term formula) {
+        if (pendingWakeOps == null) {
+            pendingWakeOps = new LinkedHashSet<>();
+        }
+        org.key_project.logic.Term t = formula;
+        while (true) {
+            final Operator op = t.op();
+            pendingWakeOps.add(op);
+            if (op instanceof UpdateApplication && t instanceof JTerm jt) {
+                t = UpdateApplication.getTarget(jt);
+            } else {
+                break;
+            }
+        }
+    }
+
     @Override
     public RuleApplicationManager<Goal> copy() {
         // noinspection unchecked
@@ -393,6 +636,19 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         QueueRuleApplicationManager res = new QueueRuleApplicationManager();
         res.queue = queue;
         res.previousMinimum = previousMinimum;
+        // the parking structures are mutable and goal-local: deep-copy so split goals park/wake
+        // independently (the contained containers and operators are immutable and shared)
+        if (parkedByOp != null) {
+            final LinkedHashMap<Operator, LinkedHashSet<RuleAppContainer>> copy =
+                new LinkedHashMap<>(parkedByOp.size());
+            for (Map.Entry<Operator, LinkedHashSet<RuleAppContainer>> e : parkedByOp.entrySet()) {
+                copy.put(e.getKey(), new LinkedHashSet<>(e.getValue()));
+            }
+            res.parkedByOp = copy;
+        }
+        if (pendingWakeOps != null) {
+            res.pendingWakeOps = new LinkedHashSet<>(pendingWakeOps);
+        }
         return res;
     }
 

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/sequence/seqRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/sequence/seqRules.key
@@ -494,7 +494,7 @@
 
         \replacewith(\if(from < to) \then(to - from) \else(0))
 
-        \heuristics(simplify, find_term_not_in_assumes)
+        // \heuristics(simplify, find_term_not_in_assumes)
         \displayname "lenOfSeqSub"
     };
 

--- a/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
@@ -12185,7 +12185,6 @@ lenOfSeqSubEQ {
 \assumes ([equals(seqSub(seq,from,to),EQ)]==>[]) 
 \find(seqLen(EQ))
 \sameUpdateLevel\replacewith(if-then-else(lt(from,to),sub(to,from),Z(0(#)))) 
-\heuristics(find_term_not_in_assumes, simplify)
 Choices: sequences:on}
 -----------------------------------------------------
 == lenOfSeqUpd (lenOfSeqUpd) =========================================


### PR DESCRIPTION
_This PR is **5/5** of a performance series that prepares a clearer match → evaluate → apply pipeline before larger optimisations; it builds on the compiled matcher (1/5, #3831)._

📖 Developer docs: [Performance Optimizations (3.1)](https://keyproject.github.io/key-docs/devel/PerformanceOptimizations/#strategy-evaluation-parking-assumes-incomplete-bases)

## Intended Change

Profiling the rule-app queue shows the dominant remaining churn comes from **assumes-incomplete taclet bases** that are re-popped and re-expanded every single round only to produce nothing: 96.8% of queue pops fail at an unmatched `\assumes`, and 97–99.6% of the resulting re-expansions yield no new instance. This PR stops re-expanding such bases until a formula they could actually match appears — an **operator-indexed parking** scheme.

Mechanism:
- A base whose `\assumes` formulas are **effectively indexable** (every assumes top operator is concrete, or a schema variable already bound by the find-match) is parked out of the active queue, indexed by those concrete top operator(s).
- On each round, exactly the parked bases whose operator matches a formula **added or modified that round** are woken and re-inserted — the *same* round their non-parked counterpart would first see that formula as "new" and re-expand to the instance. The wake set is computed from the changed formula's update-prefix spine (a sound superset, since the assumes matcher strips the update context before matching).
- Bases with an unbound-generic assumes top (which could match anything) are **never** parked; they behave exactly as today.

Because a woken base re-expands on the identical round with the identical age and cost, the result is byte-identical *for the parking mechanism itself*. All index structures are insertion-ordered (`LinkedHashMap`/`LinkedHashSet`) so no non-determinism is introduced.

This PR also **drops the order-fragile `lenOfSeqSubEQ` heuristic from automode** (the taclet stays defined, only its `\heuristics` is commented out). That taclet is redundant for completeness (the direct `lenOfSeqSub` suffices — full RAP closes all goals without it) but is order-fragile: it can dead-end a goal via a duplicate/cycle guard when its own result reproduces the equation it started from. The original rule order avoided this by luck; any reordering (including parking) can expose it. Removing it makes automode robust to rule-order changes.

```mermaid
flowchart LR
  A["assumes-incomplete base"] --> B{"indexable?"}
  B -- no --> C["re-expand each round"]
  B -- yes --> D["park; wake on matching op"]
```

## Type of pull request
- New feature (queue optimization) + taclet rule-base change (drop `lenOfSeqSubEQ` heuristic)
- There are changes to the (Java) code and to the taclet rule base

## Performance

Measured on the 6-problem `perfTest` set (median of 3 runs). Parking is **not** byte-identical (it can shift proof shapes — all still close), so the table reports both node counts and automode time.

| Problem | main nodes | main (ms) | this PR nodes | this PR (ms) | speedup |
|---|--:|--:|--:|--:|--:|
| symmArray | 14601 | 21396 | 14512 | 15667 | 1.37× |
| gemplusDecimal/add | 27083 | 11474 | 27740 | 9880 | 1.16× |
| ArrayList.remove.1 | 8016 | 3629 | 7993 | 2642 | 1.37× |
| SimplifiedLinkedList.remove | 54444 | 28903 | 55300 | 18232 | 1.59× |
| Saddleback_search | 31218 | 23510 | 33759 | 15785 | 1.49× |
| coincidence_count/project | 12041 | 4935 | 11907 | 3113 | 1.59× |
| **Total** | | **93847** | | **65319** | **1.44×** |

Node counts shift slightly (parking is not byte-identical — all proofs still close), confirming it is a queue-scheduling change rather than a different search.

Parking targets the wasted re-expansions of assumes-incomplete bases. Across the six problems:

| Config | assumes-incomplete re-expansions | of which empty (no new match) |
|---|--:|--:|
| main | 71.8 M | 71.1 M (99.0%) |
| this PR | 16.4 M | 15.7 M (95.7%) |

That is ~4.4× fewer; the remaining re-expansions are mostly non-indexable bases (unbound-generic `\assumes` tops) that parking deliberately leaves in the queue.

## Ensuring quality
- Provability-safe on the full real RAP suite (681 goals) once the redundant order-fragile `lenOfSeqSubEQ` is dropped.
- Only effectively-indexable bases parked; over-waking is harmless (a spuriously woken base re-expands to nothing and re-parks); only *missing* a wake could diverge, and that cannot happen for an indexable base.
- compile + spotless + nullness clean.
- Active by default (the previous `-Dkey.queue.parkAssumes` gate is removed).

---
📖 Conceptual overview in the developer docs: [Performance Optimizations (3.1)](https://keyproject.github.io/key-docs/devel/PerformanceOptimizations/#strategy-evaluation-parking-assumes-incomplete-bases)

## Additional information and contact(s)

This PR has been done with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
