### PR TITLE
Fix 'choose contract' in parser

### DIFF
--- a/key.core/src/main/antlr4/JavaKeYParser.g4
+++ b/key.core/src/main/antlr4/JavaKeYParser.g4
@@ -12,6 +12,10 @@ public SyntaxErrorReporter getErrorReporter() { return errorReporter;}
 
 options { tokenVocab=JavaKeYLexer; } // use tokens from STLexer.g4
 
+problem
+   : (PROBLEM LBRACE (t = termorseq) RBRACE | CHOOSECONTRACT (chooseContract = string_value SEMI)? | PROOFOBLIGATION (proofObligation = cvalue)? SEMI?) proofScriptEntry?
+   ;
+
 decls
 :
     ( bootClassPath          // for problems

--- a/key.ncore/src/main/antlr/KeYParser.g4
+++ b/key.ncore/src/main/antlr/KeYParser.g4
@@ -15,7 +15,7 @@ file
    ;
 
 problem
-   : (PROBLEM LBRACE (t = termorseq) RBRACE | CHOOSECONTRACT (chooseContract = string_value SEMI)? | PROOFOBLIGATION (proofObligation = cvalue)? SEMI?) proofScriptEntry?
+   : (PROBLEM LBRACE (t = termorseq) RBRACE | PROOFOBLIGATION (proofObligation = cvalue)? SEMI?) proofScriptEntry?
    ;
 
 /**


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Small follow up to #3822: `\chooseContract` was left in the ncore grammar and an implicit token was declared. This PR moves that definition to `key.core`.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- Other: Grammar

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
