### PR TITLE
Support co- and contravariant sorts

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/GenericArgument.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/GenericArgument.java
@@ -16,7 +16,7 @@ import org.key_project.util.collection.ImmutableSLList;
 import org.jspecify.annotations.NonNull;
 
 /// An argument for a [ParametricSortInstance] or [ParametricFunctionInstance].
-public record GenericArgument(Sort sort) implements TerminalSyntaxElement {
+public record GenericArgument(@NonNull Sort sort) implements TerminalSyntaxElement {
     @Override
     public @NonNull String toString() {
         return sort.toString();

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ParametricFunctionDecl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ParametricFunctionDecl.java
@@ -41,6 +41,12 @@ public final class ParametricFunctionDecl implements Named, Sorted {
         this.unique = unique;
         this.isRigid = isRigid;
         this.isSkolemConstant = isSkolemConstant;
+        for (var p : parameters) {
+            if (!p.variance().equals(GenericParameter.Variance.INVARIANT)) {
+                throw new IllegalArgumentException(
+                    "Co-/contravariance is not yet supported for parametric functions or predicates");
+            }
+        }
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
@@ -75,9 +75,7 @@ public final class ParametricSortInstance extends AbstractSort {
         ImmutableSet<Sort> baseExt = base.getExtendedSorts();
         if (!baseExt.isEmpty()) {
             for (Sort s : baseExt) {
-                result =
-                    result.add(instantiate(s, getInstMap(base, args),
-                        services));
+                result = result.add(instantiate(s, getInstMap(base, args), services));
             }
         }
 
@@ -139,7 +137,35 @@ public final class ParametricSortInstance extends AbstractSort {
 
     @Override
     public boolean extendsTrans(@NonNull Sort sort) {
-        return sort == this || extendsSorts()
+        if (sort == this)
+            return true;
+
+        if (sort instanceof ParametricSortInstance psi && psi.getBase().equals(base)) {
+            assert psi.getArgs().size() == args.size();
+            var baseParams = psi.getBase().getParameters();
+            var matches = true;
+            for (int i = 0; i < psi.getArgs().size(); i++) {
+                var oa = psi.getArgs().get(i);
+                var ta = args.get(i);
+                var variance = baseParams.get(i).variance();
+                switch (variance) {
+                    case COVARIANT -> {
+                        matches &= ta.sort().extendsTrans(oa.sort());
+                    }
+                    case CONTRAVARIANT -> {
+                        matches &= oa.sort().extendsTrans(ta.sort());
+                    }
+                    case INVARIANT -> {
+                        // Nothing to do
+                    }
+                }
+            }
+            if (matches) {
+                return true;
+            }
+        }
+
+        return extendsSorts()
                 .exists((Sort superSort) -> superSort == sort || superSort.extendsTrans(sort));
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/sort/ParametricSortInstance.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic.sort;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
@@ -11,13 +10,11 @@ import java.util.WeakHashMap;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.GenericArgument;
-import de.uka.ilkd.key.logic.GenericParameter;
 import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.logic.Name;
 import org.key_project.logic.sort.AbstractSort;
 import org.key_project.logic.sort.Sort;
-import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
@@ -67,45 +64,6 @@ public final class ParametricSortInstance extends AbstractSort {
         return new Name(base.name() + "<" + parameters + ">");
     }
 
-    private static ImmutableSet<Sort> computeExt(ParametricSortDecl base,
-            ImmutableList<GenericArgument> args, Services services) {
-        ImmutableSet<Sort> result = DefaultImmutableSet.nil();
-
-        // 1. extensions by base sort
-        ImmutableSet<Sort> baseExt = base.getExtendedSorts();
-        if (!baseExt.isEmpty()) {
-            for (Sort s : baseExt) {
-                result = result.add(instantiate(s, getInstMap(base, args), services));
-            }
-        }
-
-        // 2. extensions by variances
-        ImmutableList<GenericParameter> cov = base.getParameters();
-        int number = 0;
-        for (GenericParameter parameter : base.getParameters()) {
-            switch (parameter.variance()) {
-                case COVARIANT -> {
-                    // take all bases of that arg and add the modified sort as ext class
-                    /*
-                     * for (Sort s : parameter.genericSort().extendsSorts()) {
-                     * ImmutableList<Sort> newArgs = args.replace(number, s);
-                     * result = result.add(ParametricSortInstance.get(base, newArgs));
-                     * }
-                     */
-                    // throw new UnsupportedOperationException(
-                    // "Covariance currently not supported");
-                }
-                case CONTRAVARIANT -> throw new UnsupportedOperationException(
-                    "Contravariance currently not supported");
-
-                case INVARIANT -> {
-                    /* Nothing to be done */}
-            }
-        }
-
-        return result;
-    }
-
     public ParametricSortDecl getBase() {
         return base;
     }
@@ -149,15 +107,9 @@ public final class ParametricSortInstance extends AbstractSort {
                 var ta = args.get(i);
                 var variance = baseParams.get(i).variance();
                 switch (variance) {
-                    case COVARIANT -> {
-                        matches &= ta.sort().extendsTrans(oa.sort());
-                    }
-                    case CONTRAVARIANT -> {
-                        matches &= oa.sort().extendsTrans(ta.sort());
-                    }
-                    case INVARIANT -> {
-                        // Nothing to do
-                    }
+                    case COVARIANT -> matches &= ta.sort().extendsTrans(oa.sort());
+                    case CONTRAVARIANT -> matches &= oa.sort().extendsTrans(ta.sort());
+                    case INVARIANT -> matches &= oa.sort() == ta.sort();
                 }
             }
             if (matches) {
@@ -167,18 +119,6 @@ public final class ParametricSortInstance extends AbstractSort {
 
         return extendsSorts()
                 .exists((Sort superSort) -> superSort == sort || superSort.extendsTrans(sort));
-    }
-
-    /// Compute an instantiation mapping.
-    private static Map<GenericSort, GenericArgument> getInstMap(ParametricSortDecl base,
-            ImmutableList<GenericArgument> args) {
-        var map = new HashMap<GenericSort, GenericArgument>();
-        for (int i = 0; i < base.getParameters().size(); i++) {
-            var param = base.getParameters().get(i);
-            var arg = args.get(i);
-            map.put(param.sort(), arg);
-        }
-        return map;
     }
 
     public static Sort instantiate(GenericSort genericSort, Sort instantiation,

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/sort/TestParametricSorts.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/sort/TestParametricSorts.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.logic.sort;
 
 import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.GenericArgument;
 import de.uka.ilkd.key.logic.GenericParameter;
 import de.uka.ilkd.key.logic.NamespaceSet;
@@ -24,8 +25,7 @@ import org.key_project.util.collection.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 class TestParametricSorts {
     private NamespaceSet nss;
@@ -50,7 +50,7 @@ class TestParametricSorts {
         nb.addSort("boolean").addSort("int")
                 .addSort("Seq").addSort("LocSet").addSort("double")
                 .addSort("float");
-
+        nss.sorts().add(JavaDLTheory.ANY);
     }
 
     private ParametricSortDecl addParametricSort(String name,
@@ -99,5 +99,35 @@ class TestParametricSorts {
         assertEquals("List<[int]>", ((JFunction) term.sub(0).op()).argSorts().get(0).toString());
         assertEquals("int", term.sub(0).op().sort(new Sort[0]).toString());
         assertSame(term.sub(0).sort(), term.sub(1).sort());
+    }
+
+    @Test
+    public void testCovariance() {
+        ParametricSortDecl psd = addParametricSort("List", GenericParameter.Variance.COVARIANT);
+        Sort intSort = nss.sorts().lookup("int");
+        Sort anySort = nss.sorts().lookup("any");
+
+        var intList = ParametricSortInstance.get(psd,
+            ImmutableList.of(new GenericArgument(intSort)), services);
+        var anyList = ParametricSortInstance.get(psd,
+            ImmutableList.of(new GenericArgument(anySort)), services);
+
+        assertTrue(intList.extendsTrans(anyList));
+        assertFalse(anyList.extendsTrans(intList));
+    }
+
+    @Test
+    public void testContravariance() {
+        ParametricSortDecl psd = addParametricSort("List", GenericParameter.Variance.CONTRAVARIANT);
+        Sort intSort = nss.sorts().lookup("int");
+        Sort anySort = nss.sorts().lookup("any");
+
+        var intList = ParametricSortInstance.get(psd,
+            ImmutableList.of(new GenericArgument(intSort)), services);
+        var anyList = ParametricSortInstance.get(psd,
+            ImmutableList.of(new GenericArgument(anySort)), services);
+
+        assertFalse(intList.extendsTrans(anyList));
+        assertTrue(anyList.extendsTrans(intList));
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/sort/TestParametricSorts.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/sort/TestParametricSorts.java
@@ -73,7 +73,7 @@ class TestParametricSorts {
         Sort intSort = nss.sorts().lookup("int");
 
         var someConst = new ParametricFunctionDecl(new Name("someConst"),
-            ImmutableList.of(new GenericParameter(g1, GenericParameter.Variance.COVARIANT)),
+            ImmutableList.of(new GenericParameter(g1, GenericParameter.Variance.INVARIANT)),
             new ImmutableArray<>(), g1, null, false, true, false);
         nss.parametricFunctions().add(someConst);
 
@@ -84,7 +84,7 @@ class TestParametricSorts {
             ParametricSortInstance.get(psd, ImmutableList.of(new GenericArgument(g1)), services);
 
         var head = new ParametricFunctionDecl(new Name("head"),
-            ImmutableList.of(new GenericParameter(g1, GenericParameter.Variance.COVARIANT)),
+            ImmutableList.of(new GenericParameter(g1, GenericParameter.Variance.INVARIANT)),
             new ImmutableArray<>(listOfG1), g1, null, false, true, false);
         nss.parametricFunctions().add(head);
 


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Properly supports parametric sorts with co- and contravariant generic parameters with a custom `extendsTrans` implementation. Also throws an exception on variant parameters for functions, as it is unclear to me how to support that.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->

- I added new test case(s) for new functionality.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
