### PR TITLE
Fixes for minor regressions on main

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/settings/AbstractPropertiesSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/AbstractPropertiesSettings.java
@@ -127,22 +127,24 @@ public abstract class AbstractPropertiesSettings extends AbstractSettings {
     }
 
     protected PropertyEntry<Double> createDoubleProperty(String key, double defValue) {
-        PropertyEntry<Double> pe =
-            new DefaultPropertyEntry<>(key, defValue, parseDouble, (it) -> (double) it);
+        PropertyEntry<Double> pe = new DefaultPropertyEntry<>(key, defValue, parseDouble,
+            (it) -> ((Number) it).doubleValue());
         propertyEntries.add(pe);
         return pe;
     }
 
     protected PropertyEntry<Integer> createIntegerProperty(String key, int defValue) {
+        // A stored numeric value may deserialize as Integer or Long depending on its magnitude and
+        // the settings format, so accept any Number rather than assuming a particular boxed type.
         PropertyEntry<Integer> pe = new DefaultPropertyEntry<>(key, defValue, parseInt,
-            (it) -> Math.toIntExact((Long) it));
+            (it) -> Math.toIntExact(((Number) it).longValue()));
         propertyEntries.add(pe);
         return pe;
     }
 
     protected PropertyEntry<Float> createFloatProperty(String key, float defValue) {
-        PropertyEntry<Float> pe =
-            new DefaultPropertyEntry<>(key, defValue, parseFloat, (it) -> (float) (double) it);
+        PropertyEntry<Float> pe = new DefaultPropertyEntry<>(key, defValue, parseFloat,
+            (it) -> ((Number) it).floatValue());
         propertyEntries.add(pe);
         return pe;
     }

--- a/key.core/src/test/java/de/uka/ilkd/key/settings/AbstractPropertiesSettingsTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/settings/AbstractPropertiesSettingsTest.java
@@ -1,0 +1,45 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.settings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for {@link AbstractPropertiesSettings} numeric properties: a stored value may
+ * deserialize as {@link Integer} or {@link Long} depending on its magnitude and the settings
+ * format,
+ * and reading it back must not depend on which boxed type it happens to be (it used to crash KeY on
+ * startup with a {@code ClassCastException}).
+ */
+public class AbstractPropertiesSettingsTest {
+
+    private static final class TestSettings extends AbstractPropertiesSettings {
+        final PropertyEntry<Integer> intProp;
+
+        TestSettings() {
+            super("TestCat");
+            intProp = createIntegerProperty("myInt", 7);
+        }
+    }
+
+    @Test
+    public void readsIntegerPropertyStoredAsInteger() {
+        Configuration cfg = new Configuration();
+        cfg.getOrCreateSection("TestCat").set("myInt", 42); // stored as Integer
+        TestSettings settings = new TestSettings();
+        settings.readSettings(cfg);
+        assertEquals(42, settings.intProp.get());
+    }
+
+    @Test
+    public void readsIntegerPropertyStoredAsLong() {
+        Configuration cfg = new Configuration();
+        cfg.getOrCreateSection("TestCat").set("myInt", Long.valueOf(42)); // stored as Long
+        TestSettings settings = new TestSettings();
+        settings.readSettings(cfg);
+        assertEquals(42, settings.intProp.get());
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
@@ -263,7 +263,11 @@ public class RecentFileMenu {
         public Configuration asConfiguration() {
             Configuration config = new Configuration();
             config.set(KEY_PATH, path);
-            config.set(KEY_PROFILE, (Object) profile);
+            // Only store a real profile name; writing a null serializes to the string "null", which
+            // then fails to resolve on reload.
+            if (profile != null) {
+                config.set(KEY_PROFILE, profile);
+            }
             config.set(KEY_LOAD_SINGLE_JAVA, singleJava);
             config.set(KEY_OPTIONS, additionalOption);
             return config;
@@ -305,15 +309,18 @@ public class RecentFileMenu {
                 }
             } else {
                 String profileName = fileEntry.profile;
-                var selectedProfile =
-                    ServiceLoader.load(DefaultProfileResolver.class)
-                            .stream()
-                            .filter(it -> it.get().getProfileName().equals(profileName))
-                            .findFirst()
-                            .map(it -> it.get().getDefaultProfile());
+                // A missing profile -- null, or the literal string "null" that older recent-file
+                // entries stored for it -- means "use the default profile", not an error.
+                boolean hasProfile = profileName != null && !profileName.equals("null");
+                var selectedProfile = hasProfile
+                        ? ServiceLoader.load(DefaultProfileResolver.class)
+                                .stream()
+                                .filter(it -> it.get().getProfileName().equals(profileName))
+                                .findFirst()
+                                .map(it -> it.get().getDefaultProfile())
+                        : Optional.<Profile>empty();
 
-
-                if (profileName != null && selectedProfile.isEmpty()) {
+                if (hasProfile && selectedProfile.isEmpty()) {
                     JOptionPane.showMessageDialog(mainWindow,
                         "Could not find previous selected profile %s.".formatted(profileName));
                     return;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/WindowUserInterfaceControl.java
@@ -210,6 +210,10 @@ public class WindowUserInterfaceControl extends AbstractMediatorUserInterfaceCon
             if (!isAtLeastOneMacroRunning()) {
                 mainWindow.hideStatusProgress();
                 assert info instanceof ProofMacroFinishedInfo;
+                // Show the macro's aggregate result (total rules applied / goals closed). Without
+                // this the status line keeps whatever the macro's last internal strategy run left
+                // there -- a tiny partial count rather than the whole macro's work.
+                mainWindow.displayResults(info.toString());
                 final Proof proof = (Proof) info.getProof();
                 if (proof != null && !proof.closed()
                         && mainWindow.getMediator().getSelectedProof() == proof) {


### PR DESCRIPTION
<!-- PR title: Fixes for minor regressions on main -->

## Intended Change

Three small, independent fixes for minor regressions on `main`. 

- **Robustly read numeric settings stored as Integer or Long.** Fixes: 
#3833
- **Don't crash reloading a recent file with no stored profile.** A recent-file
  entry whose profile name was never set had the null value as the string
  `"null"`; reloading it then tried to resolve a profile named `"null"`, failed. 
  A missing profile name is now treated as "use the default profile" on
  load, and the `"null"` placeholder is no longer written on save.
- **Show a proof macro's aggregate statistics in the status line.** After a
  compound macro finished, the status line kept the partial count from the macro's
  last internal strategy pass instead of the macro's own aggregate. The
  `ProofMacroFinishedInfo` aggregate is now displayed when a macro completes.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- Added a regression test for the settings converter
  (`AbstractPropertiesSettingsTest`).
- Compiles and passes spotless; the touched modules' unit tests pass.
- Each fix is an independent commit, easy to review or revert in isolation.

## Additional information and contact(s)

These fixes were separated out of the multithreading work
([#3842](https://github.com/KeYProject/key/pull/3842)) as standalone,
cherry-pickable commits so they can land on `main` independently.

This PR has been done with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
