### PR TITLE
Fix "Rule of same name exists already" error after pruning (rare but occuring cases after mass pruning with try-closeable-goals)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
@@ -67,8 +67,16 @@ class ProofPruner {
 
             if (initConfig != null && visitedNode.parent() != null) {
                 proof.mgt().ruleUnApplied(visitedNode.parent().getAppliedRuleApp());
-                for (final NoPosTacletApp app : visitedNode.parent()
-                        .getLocalIntroducedRules()) {
+            }
+            // Deregister taclets that were locally introduced (e.g. via \addrules) in the pruned
+            // subtree. These are stored on the node at which they were introduced, so we must
+            // iterate the node itself rather than its parent: otherwise taclets introduced at a
+            // leaf of a branch other than firstLeaf are never deregistered (the parent-based loop
+            // only ever reaches the introduced rules of nodes that have a child in the subtree).
+            // The cutting point itself survives the pruning, so its locally introduced rules are
+            // kept.
+            if (initConfig != null && visitedNode != cuttingPoint) {
+                for (final NoPosTacletApp app : visitedNode.getLocalIntroducedRules()) {
                     initConfig.getJustifInfo().removeJustificationFor(app.taclet());
                 }
             }

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestGoal.java
@@ -10,6 +10,7 @@ import de.uka.ilkd.key.proof.calculus.JavaDLSequentKit;
 import de.uka.ilkd.key.proof.init.AbstractProfile;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.rule.TacletForTests;
+import de.uka.ilkd.key.rule.inst.SVInstantiations;
 
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
@@ -82,6 +83,51 @@ public class TestGoal {
             "Taclet Index of set back goal contains rule \"imp-left\" that were not "
                 + "there before");
 
+    }
+
+    /**
+     * Regression test for the pruning bug where taclets introduced (e.g. via {@code \addrules}) at
+     * the leaf of a branch other than the one the pruning descends first ("firstLeaf") kept their
+     * justification registered in the {@link InitConfig}. On the next automatic run a fresh taclet
+     * with the same name would then be registered, causing
+     * "A rule named ... has already been registered."
+     * <p>
+     * The locally introduced taclets are stored on the node at which they were introduced, so the
+     * deregistration during pruning must iterate the node itself, not its parent.
+     */
+    @Test
+    public void testSetBackRemovesJustificationOfResidualBranch() {
+        Sequent seq = JavaDLSequentKit.createSuccSequent(
+            ImmutableSLList.singleton(new SequentFormula(TacletForTests.parseTerm("A"))));
+        final InitConfig initConfig =
+            new InitConfig(new Services(AbstractProfile.getDefaultProfile()));
+        proof = new Proof("", seq, null, initConfig.createTacletIndex(),
+            initConfig.createBuiltInRuleIndex(), initConfig);
+
+        Goal g = proof.openGoals().head();
+        ImmutableList<Goal> lg = g.split(2);
+        // split() reuses 'this' (g) for the first child node and clones for the rest, prepending
+        // the clones to the result list. Hence lg.head() is attached to the second child (a
+        // residual leaf during pruning) and lg.tail().head() is g, attached to the first child
+        // (firstLeaf).
+        final Goal residualGoal = lg.head();
+        final Goal firstGoal = lg.tail().head();
+        proof.add(residualGoal);
+
+        final var onFirst = TacletForTests.lookupTaclet("imp_right").taclet();
+        final var onResidual = TacletForTests.lookupTaclet("or_left").taclet();
+        firstGoal.addTaclet(onFirst, SVInstantiations.EMPTY_SVINSTANTIATIONS, true);
+        residualGoal.addTaclet(onResidual, SVInstantiations.EMPTY_SVINSTANTIATIONS, true);
+
+        assertNotNull(initConfig.getJustifInfo().getJustification(onFirst));
+        assertNotNull(initConfig.getJustifInfo().getJustification(onResidual));
+
+        proof.pruneProof(proof.root());
+
+        assertNull(initConfig.getJustifInfo().getJustification(onFirst),
+            "justification of taclet introduced on the firstLeaf branch must be removed on prune");
+        assertNull(initConfig.getJustifInfo().getJustification(onResidual),
+            "justification of taclet introduced on a residual branch leaf must be removed on prune");
     }
 
     @Test


### PR DESCRIPTION
After using the Full-Auto-Macro where some proof goals remained open,  I got an error "Rule of same name exists already ", when starting the proof search again. 

The problem is a slight oversight in the proof pruner which misses to unregistered locally introduced rules at leaves. This fixes this rare but happening error. It also fixes a separate error that if at the cutting point a new taclet was registered, then this got lost.
 
## Intended Change

Fix spurious double registration bug for taclets in \addrules
<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality. The added test fails on main and suceeds on this PR
 
## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
