### PR TITLE
Fix gradle task dependencies

### DIFF
--- a/key.ncore/build.gradle
+++ b/key.ncore/build.gradle
@@ -35,6 +35,8 @@ tasks.register('runAntlr4Key', JavaExec) {
     }
 }
 compileJava.dependsOn runAntlr4Key
+sourcesJar.dependsOn runAntlr4Key
+javadocJar.dependsOn runAntlr4Key
 
 sourceSets.main.java.srcDirs(String.valueOf(projectDir) + '/build/generated-src/antlr/main/')
 


### PR DESCRIPTION
Nightly deployer got destroyed by ANTLR refactoring: 

```
A problem was found with the configuration of task ':key.ncore:sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/home/runner/work/key/key/key.ncore/build/generated-src/antlr/main'.
    
    Reason: Task ':key.ncore:sourcesJar' uses this output of task ':key.ncore:runAntlr4Key' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':key.ncore:runAntlr4Key' as an input of ':key.ncore:sourcesJar'.
      2. Declare an explicit dependency on ':key.ncore:runAntlr4Key' from ':key.ncore:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':key.ncore:runAntlr4Key' from ':key.ncore:sourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/9.5.1/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

Waiting for https://github.com/KeYProject/key/actions/runs/27870275890 to be green. 
