### PR TITLE
Taclet match dialog: collapse big matched terms; add an editor for SV fields

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/ExpandableText.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/ExpandableText.java
@@ -34,8 +34,9 @@ public class ExpandableText extends JPanel {
     public ExpandableText(String text, int limit) {
         this.full = text == null ? "" : text;
         this.limit = limit;
-        // only collapse genuinely long content; short multi-line terms are shown in full (wrapped)
-        this.expandable = full.length() > limit;
+        // collapse genuinely long content, or anything taller than two lines, so a big term does
+        // not dominate the panel; short one/two-line terms are shown in full (wrapped)
+        this.expandable = full.length() > limit || TmText.lineCount(full) > 2;
 
         setOpaque(false);
         setLayout(new BorderLayout(4, 0));

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/MatchInfoPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/MatchInfoPanel.java
@@ -48,6 +48,9 @@ public class MatchInfoPanel extends JPanel {
     /** label-column width so the value columns line up across the Rule/Find/Matched rows */
     private static final int LABEL_WIDTH = 92;
 
+    /** a matched term taller than this many lines is collapsed behind a toggle */
+    private static final int MATCHED_PREVIEW_LINES = 2;
+
     private final KeYMediator mediator;
 
     /**
@@ -202,18 +205,25 @@ public class MatchInfoPanel extends JPanel {
     }
 
     /**
-     * renders the matched term, colouring each sub-term a bound schema variable matched in that
-     * variable's palette colour. Falls back to plain text if the positions cannot be determined.
+     * renders the matched term, colouring each sub-term a bound schema variable matched in its
+     * variable's palette colour. A term taller than {@link #MATCHED_PREVIEW_LINES} lines is instead
+     * shown collapsed behind a toggle via {@link ExpandableText} (the same component the bindings
+     * use), so a big matched term does not dominate the panel; the in-term highlight is kept for
+     * shorter terms, where the whole term is visible at once anyway. Falls back to plain text if
+     * the
+     * positions cannot be determined.
      */
     private JComponent matchedTerm(Term find, Term matched) {
         try {
             List<SvSpan> spans = new ArrayList<>();
             collectSvSpans(find, matched, new ArrayDeque<>(), spans);
             TmPrint.Positioned printed = TmPrint.termWithPositions(mediator, matched);
-            if (printed.positions() == null || spans.isEmpty()) {
+            if (printed.positions() == null || spans.isEmpty()
+                    || TmText.lineCount(printed.text()) > MATCHED_PREVIEW_LINES) {
                 return new ExpandableText(printed.text());
             }
-            return highlighted(printed.text(), printed.positions(), spans);
+            return styledTerm(printed.text(),
+                resolveRanges(printed.text(), printed.positions(), spans));
         } catch (RuntimeException ex) {
             return new ExpandableText(TmPrint.term(mediator, matched));
         }
@@ -240,21 +250,12 @@ public class MatchInfoPanel extends JPanel {
         }
     }
 
-    private JComponent highlighted(String text, InitialPositionTable positions,
+    /**
+     * the sub-term ranges to highlight, resolved to character offsets {@code [start, end, colour]}.
+     */
+    private List<int[]> resolveRanges(String text, InitialPositionTable positions,
             List<SvSpan> spans) {
-        JTextPane pane = new JTextPane();
-        pane.setEditable(false);
-        pane.setOpaque(false);
-        pane.setBorder(null);
-        pane.setText(text);
-
-        StyledDocument doc = pane.getStyledDocument();
-        Font mono = TmStyle.mono(pane);
-        SimpleAttributeSet base = new SimpleAttributeSet();
-        StyleConstants.setFontFamily(base, mono.getFamily());
-        StyleConstants.setFontSize(base, mono.getSize());
-        doc.setCharacterAttributes(0, text.length(), base, true);
-
+        List<int[]> ranges = new ArrayList<>();
         int len = text.length();
         for (SvSpan span : spans) {
             // the initial position table roots the printed term at path [0]; the sub-term path
@@ -269,9 +270,38 @@ public class MatchInfoPanel extends JPanel {
             }
             int start = Math.max(0, Math.min(r.start(), len));
             int end = Math.max(start, Math.min(r.end(), len));
+            if (end > start) {
+                ranges.add(new int[] { start, end, span.color() });
+            }
+        }
+        return ranges;
+    }
+
+    /** a read-only monospaced pane showing {@code text} with the given coloured sub-term ranges. */
+    private JTextPane styledTerm(String text, List<int[]> ranges) {
+        JTextPane pane = new JTextPane();
+        pane.setEditable(false);
+        pane.setOpaque(false);
+        pane.setBorder(null);
+        pane.setText(text);
+
+        StyledDocument doc = pane.getStyledDocument();
+        Font mono = TmStyle.mono(pane);
+        SimpleAttributeSet base = new SimpleAttributeSet();
+        StyleConstants.setFontFamily(base, mono.getFamily());
+        StyleConstants.setFontSize(base, mono.getSize());
+        doc.setCharacterAttributes(0, text.length(), base, true);
+
+        int len = text.length();
+        for (int[] r : ranges) {
+            int start = Math.min(r[0], len);
+            int end = Math.min(r[1], len);
+            if (end <= start) {
+                continue;
+            }
             SimpleAttributeSet a = new SimpleAttributeSet();
-            StyleConstants.setBackground(a, SvPalette.background(span.color()));
-            StyleConstants.setForeground(a, SvPalette.foreground(span.color()));
+            StyleConstants.setBackground(a, SvPalette.background(r[2]));
+            StyleConstants.setForeground(a, SvPalette.foreground(r[2]));
             doc.setCharacterAttributes(start, end - start, a, false);
         }
         // never stretch vertically beyond the content (BoxLayout would otherwise inflate it)

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/SVInstantiationPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/SVInstantiationPanel.java
@@ -26,6 +26,7 @@ import javax.swing.text.JTextComponent;
 import de.uka.ilkd.key.control.instantiation_model.TacletFindModel;
 import de.uka.ilkd.key.control.instantiation_model.TacletInstantiationModel;
 import de.uka.ilkd.key.core.KeYMediator;
+import de.uka.ilkd.key.gui.fonticons.IconFactory;
 import de.uka.ilkd.key.gui.nodeviews.PosInSequentTransferable;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.LocSetLDT;
@@ -313,9 +314,24 @@ public class SVInstantiationPanel extends JPanel {
             toggle = TmStyle.disclosure("the whole instantiation");
             toggle.addActionListener(e -> setExpanded(!expanded));
 
+            // the inline field stays small; an edit icon (the same one the error dialog uses) opens
+            // a larger, resizable editor for comfortably entering long instantiations
+            JButton edit = new JButton(IconFactory.editFile(12));
+            edit.setFocusable(false);
+            edit.setBorderPainted(false);
+            edit.setContentAreaFilled(false);
+            edit.setMargin(new Insets(0, 3, 0, 3));
+            edit.setToolTipText("Edit in a larger, resizable window");
+            edit.addActionListener(e -> openInEditor());
+
+            JPanel controls = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            controls.setOpaque(false);
+            controls.add(toggle);
+            controls.add(edit);
+
             JPanel east = new JPanel(new BorderLayout());
             east.setOpaque(false);
-            east.add(toggle, BorderLayout.NORTH);
+            east.add(controls, BorderLayout.NORTH);
 
             component = new JPanel(new BorderLayout(4, 0));
             component.setOpaque(false);
@@ -347,6 +363,47 @@ public class SVInstantiationPanel extends JPanel {
             scroll.setBorder(on
                     ? BorderFactory.createLineBorder(hl != null ? hl : new Color(0x378ADD), 2)
                     : defaultBorder);
+        }
+
+        /**
+         * opens the field's content in a larger, resizable editor window; on OK the edited text
+         * replaces the field's content (which refreshes the status/preview as usual).
+         */
+        private void openInEditor() {
+            Window owner = SwingUtilities.getWindowAncestor(component);
+            JDialog dlg = new JDialog(owner, "Edit instantiation",
+                Dialog.ModalityType.APPLICATION_MODAL);
+
+            JTextArea ta = new JTextArea(area.getText(), 14, 60);
+            ta.setFont(TmStyle.mono(ta));
+            ta.setLineWrap(true);
+            ta.setWrapStyleWord(true);
+
+            JButton ok = new JButton("OK");
+            JButton cancel = new JButton("Cancel");
+            ok.addActionListener(e -> {
+                area.setText(ta.getText());
+                autoExpandIfMultiline();
+                dlg.dispose();
+            });
+            cancel.addActionListener(e -> dlg.dispose());
+
+            JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
+            buttons.setOpaque(false);
+            buttons.add(cancel);
+            buttons.add(ok);
+
+            JPanel content = new JPanel(new BorderLayout(0, 8));
+            content.setBorder(new EmptyBorder(8, 8, 8, 8));
+            content.add(new JScrollPane(ta), BorderLayout.CENTER);
+            content.add(buttons, BorderLayout.SOUTH);
+            dlg.setContentPane(content);
+            dlg.getRootPane().setDefaultButton(ok);
+            dlg.pack();
+            dlg.setMinimumSize(new Dimension(320, 200));
+            dlg.setLocationRelativeTo(owner);
+            SwingUtilities.invokeLater(ta::requestFocusInWindow);
+            dlg.setVisible(true);
         }
 
         private void updateHeight() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TmText.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TmText.java
@@ -48,6 +48,20 @@ final class TmText {
         return "<html><div style='width:480px'>" + esc + "</div></html>";
     }
 
+    /** the number of lines in {@code s} (newline count + 1; {@code 1} for {@code null}/empty). */
+    static int lineCount(String s) {
+        if (s == null || s.isEmpty()) {
+            return 1;
+        }
+        int lines = 1;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == '\n') {
+                lines++;
+            }
+        }
+        return lines;
+    }
+
     /**
      * the character offset into {@code s} of the given 1-based {@code line} and 1-based
      * {@code column}, clamped to {@code [0, s.length()]}.

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/TmTextTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/TmTextTest.java
@@ -71,4 +71,15 @@ public class TmTextTest {
         assertEquals(6, TmText.offsetOf(s, 2, 4), "end of the second line");
         assertEquals(6, TmText.offsetOf(s, 9, 1), "a line past the end clamps to the length");
     }
+
+    @Test
+    public void lineCount() {
+        assertEquals(1, TmText.lineCount(null));
+        assertEquals(1, TmText.lineCount(""));
+        assertEquals(1, TmText.lineCount("one line"));
+        assertEquals(2, TmText.lineCount("a\nb"));
+        assertEquals(3, TmText.lineCount("a\nb\nc"));
+        assertEquals(3, TmText.lineCount("a\nb\n"), "a trailing newline still bounds a third line");
+    }
+
 }


### PR DESCRIPTION
Follow-ups to the redesigned dialog:

- The "Matched" term could grow very large with no way to collapse it. It is now
  collapsed behind a toggle (the same ExpandableText the bindings use) when it
  spans more than two lines; the in-term colour highlight is kept for shorter
  terms, where the whole term is visible at once anyway. ExpandableText likewise
  now collapses any content taller than two lines, not only over-long content.

- The editable schema-variable fields stay compact, but their expanded area is
  often too small for big instantiations. They gain an edit icon (the same
  edit-file icon the error dialog uses) next to the toggle that opens a larger,
  resizable editor window; on OK the text replaces the field's content.

- TmText.lineCount (with unit tests) backs the line-count decisions.

<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->


## Intended Change

- Fixes that for very ling formulas the matched term section got too large
- Allows more convenient editor pane for entering large SV instantiations (for some even the expanded area was too small)

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://keyproject.github.io/key-docs/user/TacletMatchDialog/).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: tried it out with a large term

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

PR was done with AI tooling.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
