### PR TITLE
Fix pruning of cached branches

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
@@ -7,6 +7,7 @@ import java.util.*;
 import javax.swing.*;
 
 import de.uka.ilkd.key.proof.init.InitConfig;
+import de.uka.ilkd.key.proof.reference.ClosedBy;
 import de.uka.ilkd.key.rule.NoPosTacletApp;
 import de.uka.ilkd.key.rule.merge.MergePartner;
 import de.uka.ilkd.key.rule.merge.MergeRuleBuiltInRuleApp;
@@ -35,6 +36,16 @@ class ProofPruner {
      * @return the subtrees whose common root was the given {@code cuttingPoint}
      */
     public ImmutableList<Node> prune(final Node cuttingPoint) {
+        // special case: prune cached goal = only need to re-open the final node
+        ClosedBy cby = cuttingPoint.lookup(ClosedBy.class);
+        Goal goal = proof.getClosedGoal(cuttingPoint);
+        if (cby != null && goal != null) {
+            cuttingPoint.deregister(cby, ClosedBy.class);
+            proof.reOpenGoal(goal);
+            refreshGoal(goal, cuttingPoint);
+            return ImmutableList.of(cuttingPoint);
+        }
+
         // there is only one leaf containing an open goal that is interesting for pruning the
         // subtree of <code>node</code>, namely the first leave that is found by a breadth
         // first search.

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/ProofPruner.java
@@ -38,8 +38,13 @@ class ProofPruner {
     public ImmutableList<Node> prune(final Node cuttingPoint) {
         // special case: prune cached goal = only need to re-open the final node
         ClosedBy cby = cuttingPoint.lookup(ClosedBy.class);
-        Goal goal = proof.getClosedGoal(cuttingPoint);
-        if (cby != null && goal != null) {
+        if (cby != null) {
+            Goal goal = proof.getClosedGoal(cuttingPoint);
+            if (goal == null) {
+                throw new IllegalStateException("Something went wrong: Node " + cuttingPoint.name()
+                    + " has ClosedBy registered, but no corresponding goal!");
+            }
+
             cuttingPoint.deregister(cby, ClosedBy.class);
             proof.reOpenGoal(goal);
             refreshGoal(goal, cuttingPoint);

--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/CachingExtension.java
@@ -146,7 +146,7 @@ public class CachingExtension
         if (!CachingSettingsProvider.getCachingSettings().getEnabled()) {
             return;
         }
-        // new global off switch
+        // new global off switch (toolbar)
         if (!getProofCachingEnabled()) {
             return;
         }

--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/ReferenceSearchDialog.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/ReferenceSearchDialog.java
@@ -61,7 +61,6 @@ public class ReferenceSearchDialog extends JDialog {
         super(MainWindow.getInstance());
         table = new ReferenceSearchTable(proof, MainWindow.getInstance().getMediator());
         table.getTableHeader().setReorderingAllowed(false);
-        this.setLocationByPlatform(true);
         this.setTitle("Proof Caching");
         this.listener = listener;
 
@@ -100,6 +99,7 @@ public class ReferenceSearchDialog extends JDialog {
         }
 
         this.pack();
+        setLocationRelativeTo(MainWindow.getInstance());
     }
 
     private JButton getApplyButton() {

--- a/keyext.caching/src/test/java/de/uka/ilkd/key/proof/reference/TestReferenceSearcher.java
+++ b/keyext.caching/src/test/java/de/uka/ilkd/key/proof/reference/TestReferenceSearcher.java
@@ -76,8 +76,8 @@ class TestReferenceSearcher {
             }
 
             // test that copying works
-            foundReference.register(close, ClosedBy.class);
             p.pruneProof(foundReference);
+            foundReference.register(close, ClosedBy.class);
             p.closeGoal(p.getOpenGoal(foundReference));
             assertTrue(p.closed());
             Proof proof = foundReference.proof();
@@ -95,8 +95,8 @@ class TestReferenceSearcher {
             assertEquals(n55.serialNr(), n55Close.node().serialNr());
             assertSame(p2, n55Close.proof());
             int previousTotal = p.countNodes();
-            n55.register(n55Close, ClosedBy.class);
             p.pruneProof(n55);
+            n55.register(n55Close, ClosedBy.class);
             p.closeGoal(p.getOpenGoal(n55));
             assertTrue(p.closed());
             n55.proof().copyCachedGoals(p2, null, null);


### PR DESCRIPTION
## Related Issue

This pull request resolves #3846.

## Intended Change

Two bugfixes

1. Fix proof caching info window to be centered (tested on Linux). Is now centered with the same method as other KeY windows.
2. Fix pruning of cached branches.

The second part is done almost exactly like in #3440. I tested both the minimal prune (prune directly at the cached node), and a larger (multi-branch) prune.
I added a `refreshGoal` call, in case it helps.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: manually

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
