### PR TITLE
Make cross-platform path/URI/charset handling in load/save more robust

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
@@ -228,6 +228,22 @@ public class KeYFile implements EnvInput {
     }
 
 
+    /**
+     * Normalizes a path string read from a KeY/proof file so that it can be parsed by
+     * {@link Paths#get(String, String...)} on the current platform. KeY now always writes path
+     * separators as forward slashes, but proofs saved by older versions on Windows may contain
+     * backslashes. On POSIX a backslash is a valid file-name character, so such a path would not be
+     * split into segments and could not be resolved. Converting backslashes to forward slashes is
+     * safe on all platforms (Windows accepts '/' as a separator) and keeps these legacy proofs
+     * loadable.
+     *
+     * @param path the raw path string as stored in the file
+     * @return the path string with backslashes replaced by forward slashes
+     */
+    private static String normalizeStoredPath(String path) {
+        return path.replace('\\', '/');
+    }
+
     @Override
     public Path readBootClassPath() {
         ProblemInformation pi = getProblemInformation();
@@ -235,6 +251,7 @@ public class KeYFile implements EnvInput {
         if (bootClassPath == null) {
             return null;
         }
+        bootClassPath = normalizeStoredPath(bootClassPath);
         Path bootClassPathFile = Paths.get(bootClassPath);
         if (!bootClassPathFile.isAbsolute()) {
             // convert to absolute by resolving against the parent path of the parsed file
@@ -263,6 +280,7 @@ public class KeYFile implements EnvInput {
             if (cp == null) {
                 fileList.add(null);
             } else {
+                cp = normalizeStoredPath(cp);
                 var f = Paths.get(cp);
                 if (!f.isAbsolute()) {
                     f = parentDirectory.resolve(cp);
@@ -278,6 +296,7 @@ public class KeYFile implements EnvInput {
         ProblemInformation pi = getProblemInformation();
         String javaPath = pi.getJavaSource();
         if (javaPath != null) {
+            javaPath = normalizeStoredPath(javaPath);
             Path absFile = Paths.get(javaPath);
             if (!absFile.isAbsolute()) {
                 // convert to absolute by resolving against the parent path of the parsed file

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/UrlRuleSource.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/UrlRuleSource.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof.io;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -29,9 +28,21 @@ public class UrlRuleSource extends RuleSource {
     UrlRuleSource(final URL url) {
         this.url = url;
         if ("file".equals(url.getProtocol())) {
-            numberOfBytes = new File(url.getFile()).length();
+            numberOfBytes = fileSizeOrCountStream();
         } else {
             numberOfBytes = countBytesByReadingStream();
+        }
+    }
+
+    private long fileSizeOrCountStream() {
+        try {
+            // Resolve the file via the URI (like file()) rather than url.getFile(): the latter is
+            // not percent-decoded and keeps the leading '/' of "file:/C:/..." on Windows, so for
+            // paths containing spaces (%20) or on Windows it would point at a non-existent file and
+            // report a length of 0.
+            return Files.size(Paths.get(url.toURI()));
+        } catch (URISyntaxException | IOException e) {
+            return countBytesByReadingStream();
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/settings/ProofIndependentSettings.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.settings;
 
 import java.beans.PropertyChangeListener;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -149,8 +150,8 @@ public class ProofIndependentSettings {
             filename.getParentFile().mkdirs();
         }
 
-        try (var out =
-            new BufferedWriter(new FileWriter(filename.toString().replace(".props", ".json")))) {
+        try (var out = new BufferedWriter(new FileWriter(
+            filename.toString().replace(".props", ".json"), StandardCharsets.UTF_8))) {
             config.save(out, "Proof-Independent-Settings-File. Generated " + new Date());
         } catch (IOException e) {
             LOGGER.error("Could not store settings to {}", filename, e);

--- a/key.util/src/main/java/org/key_project/util/Filenames.java
+++ b/key.util/src/main/java/org/key_project/util/Filenames.java
@@ -42,14 +42,27 @@ public class Filenames {
     /// Computes the relative path of `toFilename` in relation to `origFilename`.
     /// If `origFilename` is already a relative path, it is returned instead. This implementation
     /// relies on [Path].
+    ///
+    /// Path separators in the result are always forward slashes so that the result is portable
+    /// across operating systems. If the two paths reside on different roots (e.g. different drive
+    /// letters on Windows) no relative path exists; in that case the absolute `origFilename` is
+    /// returned, mirroring [org.key_project.util.java.IOUtil#safePathRelativeTo].
     public static String makeFilenameRelative(String origFilename, String toFilename) {
         var file = Paths.get(origFilename);
         if (!file.isAbsolute()) {
-            return file.toString();
+            return toSlashes(file);
         }
 
         var base = Paths.get(toFilename).toAbsolutePath();
-        return base.relativize(file).toString();
+        if (!java.util.Objects.equals(file.getRoot(), base.getRoot())) {
+            // Path.relativize would throw IllegalArgumentException for different roots.
+            return toSlashes(file);
+        }
+        return toSlashes(base.relativize(file));
+    }
+
+    private static String toSlashes(Path path) {
+        return path.toString().replace('\\', '/');
     }
 
 

--- a/key.util/src/main/java/org/key_project/util/java/IOUtil.java
+++ b/key.util/src/main/java/org/key_project/util/java/IOUtil.java
@@ -718,9 +718,12 @@ public final class IOUtil {
                 String protocol = url.getProtocol();
                 String userInfo = url.getUserInfo();
                 String host = url.getHost();
-                // A '+' in file names is not supported, since it is converted
-                // into a space ('%20') according to the URI standard.
-                String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
+                // URLDecoder decodes the application/x-www-form-urlencoded form, in which a
+                // literal '+' denotes a space. A URL path, however, never uses '+' for a space
+                // (it is percent-encoded as %20), so a '+' here is part of the file name and must
+                // be preserved. Protect it before decoding the remaining percent-escapes.
+                String path =
+                    URLDecoder.decode(url.getPath().replace("+", "%2B"), StandardCharsets.UTF_8);
                 String query = url.getQuery();
                 String ref = url.getRef();
                 return new URI(!StringUtil.isEmpty(protocol) ? protocol : null,


### PR DESCRIPTION
## Intended Change

While auditing KeY for cross-platform (Linux/macOS/Windows) robustness of
loading and saving, several latent path/URI/charset issues surfaced. This PR
fixes them. Each issue is a separate commit.

1. **`IOUtil.toURI` corrupted `+` in file paths (all platforms).**
   The central `URL → File` converter decoded the URL path with
   `URLDecoder`, whose `application/x-www-form-urlencoded` semantics turn a
   literal `+` into a space. URL paths never encode a space as `+` (they use
   `%20`), so any file or directory whose name contains `+` (e.g. `C++Model/`,
   `a+b.key`) was silently mangled. The `+` is now protected before decoding.

2. **Loader did not normalize backslashes — legacy Windows proofs failed on POSIX.**
   `KeYFile.readBootClassPath`/`readClassPath`/`readJavaPath` parsed the stored
   path strings directly with `Paths.get`. Newer proofs are written with forward
   slashes, but proofs saved by older KeY versions on Windows contain
   backslashes; on POSIX a backslash is a valid file-name character, so the path
   was not split into segments and could not be resolved. The three readers now
   normalize separators, matching what `IncludeFinder.addInclude` already does
   for `\include`.

3. **`UrlRuleSource` reported the wrong file size on Windows / for spaced paths.**
   The constructor used `new File(url.getFile()).length()`; `url.getFile()` is
   not percent-decoded and keeps the leading `/` of `file:/C:/…` on Windows, so
   for paths with spaces (`%20`) or on Windows it pointed at a non-existent file
   and returned `0`. It now resolves via `Paths.get(url.toURI())`, matching the
   class's own `file()` method, with a stream-counting fallback.

4. **`Filenames.makeFilenameRelative` was not cross-platform safe.**
   `Path.relativize` throws `IllegalArgumentException` when the two paths have
   different roots (e.g. different drive letters on Windows), and the result was
   returned with native separators. It now guards the differing-root case and
   normalizes output to forward slashes, mirroring `IOUtil.safePathRelativeTo`.

5. **Proof-independent settings JSON was written with the platform-default charset.**
   The settings file is read as UTF-8 (`CharStreams.fromPath`) but was written
   with a plain `FileWriter`. On a JDK whose default charset is not UTF-8 (older
   JDKs on Windows), non-ASCII content (umlauts in bookmarked paths, user names)
   was written in one encoding and parsed back in another. The writer is now
   explicitly UTF-8.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: The full test suites are left to CI as I do not have access to a local windows machine

<!-- No new tests were added: these are corrections to existing path/charset
     handling. The affected code is exercised by existing load/save tests. -->

## Additional information and contact(s)

This PR has been done with AI tooling.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
