### PR TITLE
LogicPrinter: reduce per-subterm overhead and harden against unbalanced blocks

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
@@ -788,13 +788,19 @@ public class LogicPrinter {
             layouter.startTerm(0);
             layouter.print(notationInfo.getAbbrevMap().getAbbrev(t));
         } else {
-            if (t.hasLabels() && !getVisibleTermLabels(t).isEmpty() && notationInfo
-                    .getNotation(t.op()).getPriority() < NotationInfo.PRIORITY_ATOM) {
+            // printTerm is the central recursive method (called once per subterm), so the
+            // notation and the visible-label set are looked up once here instead of up to three
+            // times. getVisibleTermLabels is only consulted when the term actually has labels,
+            // preserving the previous short-circuit (its SequentViewLogicPrinter override
+            // allocates and filters on every call).
+            final Notation notation = notationInfo.getNotation(t.op());
+            final boolean parens = t.hasLabels() && !getVisibleTermLabels(t).isEmpty()
+                    && notation.getPriority() < NotationInfo.PRIORITY_ATOM;
+            if (parens) {
                 layouter.print("(");
             }
-            notationInfo.getNotation(t.op()).print(t, this);
-            if (t.hasLabels() && !getVisibleTermLabels(t).isEmpty() && notationInfo
-                    .getNotation(t.op()).getPriority() < NotationInfo.PRIORITY_ATOM) {
+            notation.print(t, this);
+            if (parens) {
                 layouter.print(")");
             }
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
@@ -690,7 +690,15 @@ public class LogicPrinter {
             layouter.markEndSub();
             layouter.end();
         } catch (UnbalancedBlocksException e) {
+            reset();
             throw new RuntimeException("Unbalanced blocks in pretty printer", e);
+        } catch (RuntimeException | Error e) {
+            // A failure deep in the recursive term printing (e.g. a NullPointerException) unwinds
+            // past the pending end() calls and leaves the layouter with open blocks. Discard the
+            // dirty layouter so that a subsequently reused printer does not fail with a misleading
+            // UnbalancedBlocksException that masks this root cause.
+            reset();
+            throw e;
         }
     }
 
@@ -731,9 +739,19 @@ public class LogicPrinter {
      * @param seq The Sequent to be pretty-printed
      */
     public void printSequent(Sequent seq) {
-        layouter.beginC(0);
-        printSequentInExistingBlock(seq);
-        layouter.end();
+        try {
+            layouter.beginC(0);
+            printSequentInExistingBlock(seq);
+            layouter.end();
+        } catch (UnbalancedBlocksException e) {
+            reset();
+            throw new RuntimeException("Unbalanced blocks in pretty printer", e);
+        } catch (RuntimeException | Error e) {
+            // See printFilteredSequent: discard the layouter left dirty by a printing failure so a
+            // reused printer cannot later fail with a misleading UnbalancedBlocksException.
+            reset();
+            throw e;
+        }
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/GoalList.java
@@ -230,13 +230,16 @@ public class GoalList extends JList<Goal> implements TabPanel {
                     }); // do not print term labels
             try {
                 sp.printSequent(seq);
-            } catch (Exception ex) {
-                LOGGER.warn("GoalList: Problem printing sequent.", ex);
-            } finally {
+                // Only read the result once printing has completed: result() returns the raw
+                // backend buffer without flushing, so on a failed print it would yield a
+                // truncated/empty sequent. Read it here on the success path instead.
                 res = sp.result().replace('\n', ' ');
                 res = res.substring(0, Math.min(MAX_DISPLAYED_SEQUENT_LENGTH, res.length()));
-                seqToString.put(seq, res);
+            } catch (Exception ex) {
+                LOGGER.warn("GoalList: Problem printing sequent.", ex);
+                res = "<unable to print sequent>";
             }
+            seqToString.put(seq, res);
         }
         return res;
     }


### PR DESCRIPTION
## Intended Change

A focused review of `LogicPrinter` for two aspects — printing performance and
the intermittent "unbalanced blocks" failures — surfaced three issues. Each is
addressed in its own commit.

1. **Performance: redundant lookups in the recursive hot path.**
   `LogicPrinter.printTerm` is invoked once per subterm of a sequent. For a
   labeled term it recomputed the same values up to three times:
   `notationInfo.getNotation(t.op())` (a map lookup with a fallback cascade) and
   `getVisibleTermLabels(t)`. The latter is overridden in
   `SequentViewLogicPrinter` to allocate a `LinkedList`, scan every label for
   visibility and build a fresh `ImmutableArray` on each call, so the repeated
   evaluation produced identical results at real allocation cost. The notation
   and the parenthesization decision are now computed once; the visible labels
   are still only consulted when the term has labels (preserving the previous
   short-circuit). Behaviour is unchanged.

2. **Balanced blocks: reset the layouter on a printing failure.**
   The top-level sequent printing methods caught only
   `UnbalancedBlocksException` and rewrapped it. A primary failure deep in the
   recursive term printing (e.g. a `NullPointerException`) instead unwinds past
   the pending `end()` calls and leaves the `Layouter`'s block stack non-empty.
   Because a `LogicPrinter` (and its layouter) can be reused, the next print
   then fails with a confusing `UnbalancedBlocksException` that masks the real
   cause, the intermittent problem. `printFilteredSequent` and `printSequent`
   now `reset()` the layouter (fresh clone) on any `RuntimeException`/`Error`
   before propagating. The nested helper `printSequentInExistingBlock` is left
   untouched: it runs inside an outer block, so resetting there would break the
   caller's matching `end()`.

3. **Balanced blocks: read the printed sequent only on success in `GoalList`.**
   `GoalList.seqToString` read `sp.result()` in a `finally` block, i.e. also
   when `printSequent` had thrown. `result()` returns the raw backend buffer
   without flushing pending layout tokens, so on a failed print this cached a
   silently truncated/empty sequent. The result extraction is moved onto the
   success path, with an explicit placeholder cached on failure.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: `:key.core` and `:key.ui` compile;
  `spotlessCheck` passes on both modules; the pretty-printer unit tests
  (`LogicPrinterTest`, `PrettyPrinterTest`, `PrettyPrinterRoundtripTest`,
  `FinalPrinterTest`) all pass (42 tests), confirming the `printTerm` refactor
  is behaviour-preserving. The full test suites are left to CI.
- I have checked that runtime performance has not deteriorated (the printTerm
  change removes redundant per-subterm lookups/allocations).

## Additional information and contact(s)

PR created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

