### PR TITLE
Fix intermittent key.core.testgen failures from SMT symbol-map race

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,11 @@ jobs:
 
       - name: Setup SMT solvers
         uses: keyproject/setup-smt@v0
-        # with:
-        #  z3Version: 4.13.0
+        with:
+          # Pin Z3 so CI is reproducible: an unpinned solver makes the SMT-dependent tests
+          # (e.g. key.core.testgen) a moving target that fails intermittently when the action's
+          # default version changes.
+          z3Version: 4.13.0
 
       - name: z3 version
         run: z3 --version
@@ -93,6 +96,8 @@ jobs:
 
       - name: Setup SMT solvers
         uses: keyproject/setup-smt@v0
+        with:
+          z3Version: 4.13.0
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/key.core.testgen/src/test/java/de/uka/ilkd/key/testcase/smt/ce/TestCommons.java
+++ b/key.core.testgen/src/test/java/de/uka/ilkd/key/testcase/smt/ce/TestCommons.java
@@ -24,6 +24,8 @@ import de.uka.ilkd.key.smt.SolverLauncher;
 import de.uka.ilkd.key.smt.solvertypes.SolverType;
 import de.uka.ilkd.key.util.HelperClassForTests;
 
+import org.junit.jupiter.api.Assumptions;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -62,9 +64,12 @@ public abstract class TestCommons {
 
     protected boolean correctResult(String filepath, boolean isValid)
             throws ProblemLoaderException {
-        if (toolNotInstalled()) {
-            return true;
-        }
+        // Skip (rather than silently pass) when the solver is not available: a green result from a
+        // test that never actually ran the solver is misleading. Genuine solver/translation errors
+        // are deliberately NOT swallowed here, so real regressions still fail.
+        Assumptions.assumeFalse(toolNotInstalled(),
+            () -> "SMT solver " + getSolverType().getName()
+                + " is not installed/usable; skipping test.");
         SMTSolverResult result = checkFile(filepath);
         // System.gc();
         // unknown is always allowed. But wrong answers are not allowed

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/VersionChecker.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/VersionChecker.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.smt;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +18,12 @@ import org.jspecify.annotations.Nullable;
 public class VersionChecker {
     public static final VersionChecker INSTANCE = new VersionChecker();
 
-    private static final long MAX_DELAY = 1000;
+    /**
+     * Upper bound for how long we wait for the solver to print its version and exit. Generous on
+     * purpose: this runs once per solver, and a too-small bound made version detection flaky on
+     * loaded CI machines (cold process start &gt; 1s).
+     */
+    private static final long MAX_DELAY = 10_000;
 
     /**
      *
@@ -30,22 +36,29 @@ public class VersionChecker {
         Process p = null;
         try {
             p = pb.start();
-            p.waitFor(MAX_DELAY, TimeUnit.MILLISECONDS);
+            // Wait for the process to actually finish before reading. Previously the code gated on
+            // BufferedReader.ready(), which returns false whenever the output has not been buffered
+            // yet (a race under load) and then reported "no version". Honor the timeout instead and
+            // read only after the process has terminated, so the output is already available.
+            if (!p.waitFor(MAX_DELAY, TimeUnit.MILLISECONDS)) {
+                p.destroyForcibly();
+                return null;
+            }
             try (BufferedReader r = new BufferedReader(
                 new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
-                // Avoid potential blocking by the buffer's readLine()
-                if (!r.ready()) {
-                    return null;
-                }
-                String line = r.readLine();
-                // TODO weigl for Java 11 use "p.destroyForcibly();"
-                return line;
+                // The process has exited, so this read does not block.
+                return r.readLine();
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (IOException e) {
+            // Solver not found / not executable: treat as "version unknown" rather than crashing
+            // the caller.
+            return null;
         } finally {
             if (p != null && p.isAlive()) {
-                p.destroy();
+                p.destroyForcibly();
             }
         }
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/lang/SMTTermBinOp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/lang/SMTTermBinOp.java
@@ -20,8 +20,12 @@ import org.slf4j.LoggerFactory;
 public class SMTTermBinOp extends SMTTerm {
     private static final Logger LOGGER = LoggerFactory.getLogger(SMTTermBinOp.class);
 
-    private static Map<Op, String> bvSymbols;
-    private static Map<Op, String> intSymbols;
+    /*
+     * Built once, fully, and published as immutable maps (see SMTTermMultOp): never lazily
+     * initialized, to avoid a half-built map being observed during concurrent SMT translation.
+     */
+    private static final Map<Op, String> bvSymbols = createBvSymbols();
+    private static final Map<Op, String> intSymbols = createIntSymbols();
 
     public enum OpProperty {
         NONE, LEFTASSOC, RIGHTASSOC, FULLASSOC, CHAINABLE, PAIRWISE
@@ -45,9 +49,6 @@ public class SMTTermBinOp extends SMTTerm {
         this.right = right;
         this.left.upp = this;
         this.right.upp = this;
-        if (bvSymbols == null || intSymbols == null) {
-            initMaps();
-        }
 
         throw new RuntimeException("BinaryOps are no longer supported.");
     }
@@ -64,9 +65,9 @@ public class SMTTermBinOp extends SMTTerm {
         };
     }
 
-    private static void initMaps() {
+    private static Map<Op, String> createBvSymbols() {
         // bitvec
-        bvSymbols = new HashMap<>();
+        HashMap<Op, String> bvSymbols = new HashMap<>();
         bvSymbols.put(Op.IFF, "iff");
         bvSymbols.put(Op.IMPLIES, "=>");
         bvSymbols.put(Op.EQUALS, "=");
@@ -98,9 +99,12 @@ public class SMTTermBinOp extends SMTTerm {
         bvSymbols.put(Op.BVSLE, "bvsle");
         bvSymbols.put(Op.BVSGT, "bvsgt");
         bvSymbols.put(Op.BVSGE, "bvsge");
+        return Map.copyOf(bvSymbols);
+    }
 
+    private static Map<Op, String> createIntSymbols() {
         // int
-        intSymbols = new HashMap<>();
+        HashMap<Op, String> intSymbols = new HashMap<>();
         intSymbols.put(Op.IFF, "iff");
         intSymbols.put(Op.IMPLIES, "=>");
         intSymbols.put(Op.EQUALS, "=");
@@ -114,6 +118,7 @@ public class SMTTermBinOp extends SMTTerm {
         intSymbols.put(Op.REM, "rem");
         intSymbols.put(Op.PLUS, "+");
         intSymbols.put(Op.MINUS, "-");
+        return Map.copyOf(intSymbols);
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/lang/SMTTermMultOp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/lang/SMTTermMultOp.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.smt.lang;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -19,8 +20,14 @@ import java.util.List;
 // A more suitable name for this class will be TermMultOp
 public class SMTTermMultOp extends SMTTerm {
 
-    private static HashMap<Op, String> bvSymbols;
-    private static HashMap<Op, String> intSymbols;
+    /*
+     * These tables are built once, fully, and published as immutable maps. They must not be lazily
+     * initialized: a publish-then-populate scheme (assigning an empty map to the field and only
+     * then filling it) can let another thread observe a half-built map and fail with a spurious
+     * "Unknown operator" during concurrent SMT translation.
+     */
+    private static final Map<Op, String> bvSymbols = createBvSymbols();
+    private static final Map<Op, String> intSymbols = createIntSymbols();
 
     public enum OpProperty {
         NONE, LEFTASSOC, RIGHTASSOC, FULLASSOC, CHAINABLE, PAIRWISE
@@ -76,9 +83,9 @@ public class SMTTermMultOp extends SMTTerm {
         };
     }
 
-    private static void initMaps() {
+    private static Map<Op, String> createBvSymbols() {
         // bitvec
-        bvSymbols = new HashMap<>();
+        HashMap<Op, String> bvSymbols = new HashMap<>();
         bvSymbols.put(Op.IFF, "iff");
         bvSymbols.put(Op.IMPLIES, "=>");
         bvSymbols.put(Op.EQUALS, "=");
@@ -111,8 +118,12 @@ public class SMTTermMultOp extends SMTTerm {
         bvSymbols.put(Op.BVSGT, "bvsgt");
         bvSymbols.put(Op.BVSGE, "bvsge");
         bvSymbols.put(Op.BVSDIV, "bvsdiv");
+        return Map.copyOf(bvSymbols);
+    }
+
+    private static Map<Op, String> createIntSymbols() {
         // int
-        intSymbols = new HashMap<>();
+        HashMap<Op, String> intSymbols = new HashMap<>();
         intSymbols.put(Op.IFF, "iff");
         intSymbols.put(Op.IMPLIES, "=>");
         intSymbols.put(Op.EQUALS, "=");
@@ -126,6 +137,7 @@ public class SMTTermMultOp extends SMTTerm {
         intSymbols.put(Op.REM, "rem");
         intSymbols.put(Op.PLUS, "+");
         intSymbols.put(Op.MINUS, "-");
+        return Map.copyOf(intSymbols);
     }
 
 
@@ -138,9 +150,6 @@ public class SMTTermMultOp extends SMTTerm {
         this.subs = subs;
         for (SMTTerm sub : this.subs) {
             sub.upp = this;
-        }
-        if (bvSymbols == null || intSymbols == null) {
-            initMaps();
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/smt/solvertypes/SolverTypeImplementation.java
@@ -10,6 +10,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.smt.*;
@@ -483,9 +484,66 @@ public final class SolverTypeImplementation implements SolverType {
             isSupportedVersion = false;
             return false;
         }
-        isSupportedVersion = installedVersion.compareTo(getMinimumSupportedVersion()) >= 0;
+        isSupportedVersion = isAtLeast(installedVersion, getMinimumSupportedVersion());
         return isSupportedVersion;
     }
+
+    /**
+     * Decides whether {@code installed} denotes a version that is at least {@code minimum}.
+     * <p>
+     * Both strings may carry surrounding text (e.g. {@code "Z3 version 4.13.0 - 64 bit"}); the
+     * first dotted numeric token of each is extracted and compared component by component
+     * numerically. This avoids the pitfalls of the previous purely lexicographic comparison, under
+     * which e.g. {@code "4.13.0"} sorted before {@code "4.4.1"}. If no numeric version can be
+     * extracted from either side, we fall back to the lexicographic comparison so behaviour does
+     * not silently change for solvers with non-numeric version strings.
+     *
+     * @param installed the raw version string reported by the solver
+     * @param minimum the configured minimum supported version (may be empty for "no constraint")
+     * @return true iff {@code installed} is greater than or equal to {@code minimum}
+     */
+    static boolean isAtLeast(String installed, String minimum) {
+        if (minimum == null || minimum.isBlank()) {
+            return true;
+        }
+        int[] iv = extractVersion(installed);
+        int[] mv = extractVersion(minimum);
+        if (iv == null || mv == null) {
+            // Cannot parse a numeric version from one of the sides: keep the old behaviour.
+            return installed.compareTo(minimum) >= 0;
+        }
+        for (int i = 0; i < Math.max(iv.length, mv.length); i++) {
+            int a = i < iv.length ? iv[i] : 0;
+            int b = i < mv.length ? mv[i] : 0;
+            if (a != b) {
+                return a > b;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Extracts the first dotted numeric token (e.g. {@code 4.13.0}) from the given string and
+     * returns its components, or {@code null} if the string contains no such token.
+     */
+    private static int @Nullable [] extractVersion(String s) {
+        var matcher = VERSION_PATTERN.matcher(s);
+        if (!matcher.find()) {
+            return null;
+        }
+        String[] parts = matcher.group(1).split("\\.");
+        int[] result = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            try {
+                result[i] = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return result;
+    }
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)*)");
 
     @Override
     public boolean supportHasBeenChecked() {


### PR DESCRIPTION
## Intended Change

`key.core.testgen` has been failing intermittently in CI for the last few weeks
(e.g. run 28220166551). All ~13 failures (`TestCE.*` with `SolverException`,
`TestcaseGenerationE2ETest.arrayUtil`) trace to a single root cause:
`RuntimeException: Unknown operator: EQUALS … intSym.size=18 bvSym.size=34`
raised during SMT term translation.

Root cause: the static SMT symbol tables in `SMTTermMultOp` (mirrored in
`SMTTermBinOp`) were lazily initialised by publishing an empty map to the
static field and only then populating it
(`bvSymbols = new HashMap<>(); bvSymbols.put(...)`), with non-`volatile`,
unsynchronised fields. With concurrent SMT solver threads, one thread can
observe a half-built map and miss `EQUALS` (which both maps actually contain),
producing the spurious error — a timing-dependent, intermittent failure.

This PR fixes the race and hardens the surrounding solver infrastructure:

- **`SMTTermMultOp` / `SMTTermBinOp`**: build the symbol tables eagerly and
  publish them as immutable maps (`Map.copyOf`) in `private static final`
  fields, removing the lazy-init window entirely.
- **`VersionChecker`**: the version probe gated on `BufferedReader.ready()`,
  which returns `false` whenever the solver's output is not yet buffered (a
  race under load) and then reported "no version". It now waits for the process
  to terminate before reading, raises the timeout to 10s, and returns `null` on
  error instead of throwing.
- **`SolverTypeImplementation`**: version support is now compared numerically
  rather than lexicographically (the old comparison sorted e.g. `4.13.0` before
  the configured minimum `Z3 version 4.4.1`).
- **`TestCommons`**: when the solver is not installed/usable, the test now skips
  via a JUnit assumption instead of silently returning a passing result. Genuine
  solver/translation errors are deliberately still surfaced as failures.
- **`tests.yml`**: pin `setup-smt` to `z3Version: 4.13.0` so CI is reproducible.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code
- There are changes to the deployment/CI infrastructure (gradle, github, ...)

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: ran `:key.core.testgen:test` for `TestCE`
  and `TestcaseGenerationE2ETest` locally with Z3 4.15.4 — all pass (previously
  13 failed); `key.core` compiles and `spotlessApply` reports no changes.
- I have checked that runtime performance has not deteriorated: the symbol maps
  are now built once eagerly rather than lazily, so there is no per-call cost.

## Additional information and contact(s)

PR created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

