### PR TITLE
Make proof-tree painting cheap on large proofs 

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1238,38 +1238,52 @@ public class ProofTreeView extends JPanel implements TabPanel {
             if (node.isClosed()) {
                 // all goals below this node are closed
                 style.icon = IconFactory.provedFolderIcon(iconHeight);
-            } else {
-                // Find leaf goal for node and check whether this is a linked goal.
+            } else if (hasLinkedGoalBelow(node.getNode())) {
+                // Some open goal below this branch is linked -> linked-folder icon.
+                // (DS: marks a "folder" as linked if it has at least one linked child.)
+                style.icon = IconFactory.linkedFolderIcon(iconHeight);
+            }
+        }
 
-                // DS: This marks all "folder" nodes as linked that have
-                // at least one linked child. Check whether this is
-                // an acceptable behavior.
-                class FindGoalVisitor implements ProofVisitor {
-                    private boolean isLinked = false;
-
-                    public boolean isLinked() {
-                        return this.isLinked;
-                    }
-
-                    @Override
-                    public void visit(Proof proof, Node visitedNode) {
-                        Goal g;
-                        if ((g = proof.getOpenGoal(visitedNode)) != null && g.isLinked()) {
-                            this.isLinked = true;
-                        }
-                    }
-                }
-                FindGoalVisitor v = new FindGoalVisitor();
-                proof.breadthFirstSearch(node.getNode(), v);
-                if (v.isLinked()) {
-                    style.icon = IconFactory.linkedFolderIcon(iconHeight);
+        /**
+         * Whether some open goal below {@code branchRoot} is linked (controls the linked-folder
+         * icon).
+         *
+         * <p>
+         * Stock KeY answered this with a breadth-first search over the branch's <em>entire
+         * subtree</em>, calling the linear-scan {@link Proof#getOpenGoal(Node)} on every visited
+         * node -- i.e. O(subtree x openGoals) per branch, re-run on every repaint. On large proofs
+         * that turned tree painting into billions of operations and made the GUI sluggish. Instead
+         * we iterate the proof's open goals (far fewer than a big subtree) and only walk ancestors
+         * for the linked ones; the {@code isLinked()} pre-check short-circuits entirely in the
+         * common case where no goal is linked.
+         */
+        private boolean hasLinkedGoalBelow(Node branchRoot) {
+            for (final Goal g : proof.openGoals()) {
+                if (g.isLinked() && isSelfOrAncestor(branchRoot, g.node())) {
+                    return true;
                 }
             }
+            return false;
+        }
+
+        /**
+         * Whether {@code ancestor} equals {@code descendant} or is one of its transitive parents.
+         */
+        private static boolean isSelfOrAncestor(Node ancestor, Node descendant) {
+            for (Node n = descendant; n != null; n = n.parent()) {
+                if (n == ancestor) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private void renderLeaf(Style style, GUIAbstractTreeNode node) {
             Node leaf = node.getNode();
-            Goal goal = proof.getOpenGoal(leaf);
+            // getOpenGoal is a linear scan of all open goals; a closed leaf has none, so skip it
+            // there (equivalent result) instead of scanning on every closed leaf we paint.
+            Goal goal = leaf.isClosed() ? null : proof.getOpenGoal(leaf);
             String toolTipText;
 
             if (goal == null || leaf.isClosed()) {


### PR DESCRIPTION
## Intended Change

`ProofTreeView.ProofRenderer.renderBranch` decides the rare "linked-folder" icon by running a
breadth-first search over the branch's **entire subtree on every repaint**, calling the
linear-scan `Proof.getOpenGoal` on each visited node.  That is O(subtree × open goals) per open branch,
per paint no matter **whether** the merge rule is used or not. On large proofs (tens of thousands of nodes, many open goals) this turns tree painting
into billions of operations and freezes the EDT. A thread dump on a ~300k-node proof showed the
EDT RUNNABLE with 70+s of CPU in `renderBranch`.

The fix iterates the proof's **open goals** instead of the whole subtree (far fewer of them),
short-circuited by the cheap `isLinked()` test and walking ancestors only for linked goals. A
branch is still marked linked iff it contains a linked open goal — same result, a tiny fraction of
the cost. `renderLeaf` additionally skips the `getOpenGoal` scan for closed leaves (a closed leaf
has no open goal). Behaviour is unchanged; only the cost of computing the icon changes, and large
proof trees now paint smoothly.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: the change is behaviour-preserving (the linked-folder icon
  still appears for branches that contain a linked goal); on a >300k-node proof the tree now paints
  smoothly instead of freezing the GUI.
- I have checked that runtime performance has not deteriorated (it is a performance improvement).

## Additional information and contact(s)

Found via a thread dump while working on the multi-core prover branch (#3842), which makes such
large proofs easy to reach, but the fix is stock-KeY and independent of it — factored out here as a
standalone change.

PR created with AI tooling

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
