### PR TITLE
Implement \real literals (#3570); fix LogicPrinter.quickPrintSemisequent (#243)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/TypeConverter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/TypeConverter.java
@@ -96,6 +96,10 @@ public final class TypeConverter {
         return (DoubleLDT) getLDT(DoubleLDT.NAME);
     }
 
+    public RealLDT getRealLDT() {
+        return (RealLDT) getLDT(RealLDT.NAME);
+    }
+
     public BooleanLDT getBooleanLDT() {
         return (BooleanLDT) getLDT(BooleanLDT.NAME);
     }
@@ -975,5 +979,4 @@ public final class TypeConverter {
         }
         return null;
     }
-
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/expression/literal/RealLiteral.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/expression/literal/RealLiteral.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.java.ast.expression.literal;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
@@ -15,58 +16,91 @@ import org.key_project.logic.Name;
 import org.key_project.util.ExtList;
 
 /**
- * JML \real literal.
+ * JML {@code \real} literal.
+ * <p>
+ * A real is an unbounded mathematical value, so it is stored exactly as an arbitrary-precision pair
+ * {@code (unscaledValue, scale)} with value {@code unscaledValue * 10^(-scale)} (the same scheme as
+ * {@link BigDecimal}, but with an unbounded {@link BigInteger} scale rather than an {@code int}).
+ * The pair is kept in canonical form (trailing zeros stripped), so equal values have equal fields.
+ * {@link BigDecimal} is used only to parse bounded source strings, never to hold the value.
  *
  * @author bruns
  */
-
 public non-sealed class RealLiteral extends Literal {
 
-    /**
-     * Textual representation of the value.
-     */
-
-    protected final String value;
+    private final BigInteger unscaledValue;
+    private final BigInteger scale;
 
     /**
-     * Double literal.
+     * Real literal with value {@code unscaledValue * 10^(-scale)}.
      */
+    public RealLiteral(BigInteger unscaledValue, BigInteger scale) {
+        final BigInteger[] canonical = canonicalize(unscaledValue, scale);
+        this.unscaledValue = canonical[0];
+        this.scale = canonical[1];
+    }
 
     public RealLiteral() {
-        this.value = "0.0";
+        this(BigInteger.ZERO, BigInteger.ZERO);
     }
 
     public RealLiteral(int value) {
-        this(value + ".0");
+        this(BigInteger.valueOf(value), BigInteger.ZERO);
     }
 
     public RealLiteral(double value) {
-        this.value = String.valueOf(value);
-    }
-
-    public RealLiteral(BigDecimal value) {
-        this.value = String.valueOf(value);
+        this(BigDecimal.valueOf(value));
     }
 
     public RealLiteral(ExtList children, String value) {
         super(children);
-        this.value = value;
+        final BigDecimal parsed = new BigDecimal(value);
+        final BigInteger[] canonical =
+            canonicalize(parsed.unscaledValue(), BigInteger.valueOf(parsed.scale()));
+        this.unscaledValue = canonical[0];
+        this.scale = canonical[1];
     }
 
     public RealLiteral(ExtList children) {
         super(children);
-        value = "0.0";
+        this.unscaledValue = BigInteger.ZERO;
+        this.scale = BigInteger.ZERO;
     }
 
     /**
-     * Double literal.
+     * Real literal parsed from its decimal textual representation (e.g. {@code "1.25"},
+     * {@code "-0.5"}, {@code "1.5e3"}).
      *
-     * @param value
-     *        a string.
+     * @param value a decimal string.
      */
-
     public RealLiteral(String value) {
-        this.value = value;
+        this(new BigDecimal(value));
+    }
+
+    /**
+     * Bridge constructor: extracts the exact {@code (unscaledValue, scale)} of a parsed decimal.
+     * Private because the value is never <em>stored</em> as a {@link BigDecimal}.
+     */
+    private RealLiteral(BigDecimal parsed) {
+        this(parsed.unscaledValue(), BigInteger.valueOf(parsed.scale()));
+    }
+
+    /**
+     * Strip trailing decimal zeros so that equal real values have identical {@code (unscaled,
+     * scale)} pairs (e.g. {@code 1.0} and {@code 1.00} both become {@code (1, 0)}, {@code 100}
+     * becomes {@code (1, -2)}). Zero is canonicalized to {@code (0, 0)}.
+     */
+    private static BigInteger[] canonicalize(BigInteger unscaled, BigInteger scale) {
+        if (unscaled.signum() == 0) {
+            return new BigInteger[] { BigInteger.ZERO, BigInteger.ZERO };
+        }
+        BigInteger u = unscaled;
+        BigInteger s = scale;
+        while (u.remainder(BigInteger.TEN).signum() == 0) {
+            u = u.divide(BigInteger.TEN);
+            s = s.subtract(BigInteger.ONE);
+        }
+        return new BigInteger[] { u, s };
     }
 
     @Override
@@ -77,22 +111,49 @@ public non-sealed class RealLiteral extends Literal {
         if (o == null || o.getClass() != this.getClass()) {
             return false;
         }
-        return ((RealLiteral) o).getValue().equals(getValue());
+        final RealLiteral other = (RealLiteral) o;
+        return unscaledValue.equals(other.unscaledValue) && scale.equals(other.scale);
     }
 
     @Override
     public int computeHashCode() {
-        return 17 * super.computeHashCode() + getValue().hashCode();
+        return 31 * (17 * super.computeHashCode() + unscaledValue.hashCode()) + scale.hashCode();
     }
 
     /**
-     * Get value.
-     *
-     * @return the string.
+     * @return the unscaled value {@code v} such that the represented number is
+     *         {@code v * 10^(-scale)}
      */
+    public BigInteger getUnscaledValue() {
+        return unscaledValue;
+    }
 
+    /**
+     * @return the (possibly negative) power-of-ten scale {@code s} such that the represented number
+     *         is {@code unscaledValue * 10^(-s)}
+     */
+    public BigInteger getScale() {
+        return scale;
+    }
+
+    /**
+     * @return the canonical decimal textual representation of the value (e.g. {@code "1.25"},
+     *         {@code "-0.5"}, {@code "100"}).
+     */
     public String getValue() {
-        return value;
+        final String digits = unscaledValue.abs().toString();
+        final String sign = unscaledValue.signum() < 0 ? "-" : "";
+        final int s = scale.intValueExact();
+        if (s <= 0) {
+            // integer value: append (-s) trailing zeros
+            return sign + digits + "0".repeat(-s);
+        }
+        if (digits.length() <= s) {
+            // pure fraction: 0.00..0digits
+            return sign + "0." + "0".repeat(s - digits.length()) + digits;
+        }
+        final int point = digits.length() - s;
+        return sign + digits.substring(0, point) + "." + digits.substring(point);
     }
 
     /**
@@ -103,7 +164,7 @@ public non-sealed class RealLiteral extends Literal {
      *        the Visitor
      */
     public void visit(Visitor v) {
-        // v.performActionOnDoubleLiteral(this);
+        v.performActionOnRealLiteral(this);
     }
 
     public KeYJavaType getKeYJavaType(Services javaServ) {

--- a/key.core/src/main/java/de/uka/ilkd/key/java/visitor/JavaASTVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/visitor/JavaASTVisitor.java
@@ -477,6 +477,11 @@ public abstract class JavaASTVisitor extends JavaASTWalker implements Visitor {
     }
 
     @Override
+    public void performActionOnRealLiteral(RealLiteral x) {
+        doDefaultAction(x);
+    }
+
+    @Override
     public void performActionOnLabeledStatement(LabeledStatement x) {
         doDefaultAction(x);
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/java/visitor/Visitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/visitor/Visitor.java
@@ -54,6 +54,8 @@ public interface Visitor {
 
     void performActionOnIntLiteral(IntLiteral x);
 
+    void performActionOnRealLiteral(RealLiteral realLiteral);
+
     void performActionOnBooleanLiteral(BooleanLiteral x);
 
     void performActionOnEmptySetLiteral(EmptySetLiteral x);
@@ -415,4 +417,5 @@ public interface Visitor {
     void performActionOnJmlAssert(JmlAssert jmlAssert);
 
     void performActionOnSubtype(Subtype subtype);
+
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/ldt/RealLDT.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/ldt/RealLDT.java
@@ -3,15 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.ldt;
 
+import java.math.BigInteger;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.abstraction.PrimitiveType;
 import de.uka.ilkd.key.java.ast.abstraction.Type;
 import de.uka.ilkd.key.java.ast.expression.Expression;
 import de.uka.ilkd.key.java.ast.expression.literal.Literal;
+import de.uka.ilkd.key.java.ast.expression.literal.RealLiteral;
 import de.uka.ilkd.key.java.ast.reference.ExecutionContext;
 import de.uka.ilkd.key.logic.JTerm;
 import de.uka.ilkd.key.logic.TermServices;
 import de.uka.ilkd.key.logic.op.JFunction;
+import de.uka.ilkd.key.util.Debug;
 
 import org.key_project.logic.Name;
 import org.key_project.logic.op.Function;
@@ -27,10 +31,23 @@ import org.key_project.util.ExtList;
 public final class RealLDT extends LDT {
 
     public static final Name NAME = new Name("real");
+    /**
+     * Name of the function wrapping a real literal as {@code __R(unscaledValue, scale)}. The
+     * {@code __} prefix marks it as a reserved built-in symbol, kept out of the way of identifiers
+     * a user might declare in a problem file (see also {@code Z}/{@code C}/{@code FP}/{@code DFP},
+     * which should eventually adopt the same reserved-prefix convention).
+     */
+    public static final Name REAL_NUMBERS_NAME = new Name("__R");
 
+    public final Function realNumbers;
 
     public RealLDT(TermServices services) {
         super(NAME, services);
+        realNumbers = addFunction(services, REAL_NUMBERS_NAME.toString());
+    }
+
+    public Function getRealNumberSymbol() {
+        return realNumbers;
     }
 
 
@@ -58,26 +75,21 @@ public final class RealLDT extends LDT {
 
     @Override
     public JTerm translateLiteral(Literal lit, Services services) {
-        // return skolem term
-        final Function sk =
-            new JFunction(new Name(String.valueOf(NAME) + lit), targetSort());
-        return services.getTermBuilder().func(sk);
+        Debug.assertTrue(lit instanceof RealLiteral,
+            "Literal '" + lit + "' is not a real valued literal.");
+
+        final RealLiteral real = (RealLiteral) lit;
+        return services.getTermBuilder().rTerm(real.getUnscaledValue(), real.getScale());
     }
 
-    // @Override
-    // public Function getFunctionFor(String op, Services services) {
-    // switch (op) {
-    // case "gt": return getGreaterThan();
-    // case "geq": return getGreaterOrEquals();
-    // case "lt": return getLessThan();
-    // case "leq": return getLessOrEquals();
-    // case "div": return getDivIEEE();
-    // case "mul": return getMulIEEE();
-    // case "add": return getAddIEEE();
-    // case "sub": return getSubIEEE();
-    // }
-    // return null;
-    // }
+    private boolean isNumberLiteral(org.key_project.logic.op.Operator f) {
+        String n = f.name().toString();
+        if (n.length() == 1) {
+            char c = n.charAt(0);
+            return '0' <= c && c <= '9';
+        }
+        return false;
+    }
 
     @Override
     public Function getFunctionFor(de.uka.ilkd.key.java.ast.expression.Operator op,
@@ -88,15 +100,40 @@ public final class RealLDT extends LDT {
     }
 
 
+
     @Override
     public boolean hasLiteralFunction(Function f) {
-        return false;
+        return containsFunction(f) && (f.arity() == 0 || isNumberLiteral(f));
     }
 
 
     @Override
     public Expression translateTerm(JTerm t, ExtList children, Services services) {
+        if (t.op() instanceof JFunction func && func == realNumbers) {
+            // \R(unscaledValue, scale) encodes the value unscaledValue * 10^(-scale). Both operands
+            // are unbounded signed numerals, so the value is never squeezed through an int.
+            final IntegerLDT intLDT = services.getTypeConverter().getIntegerLDT();
+            final BigInteger unscaled = numeralValue(t.sub(0), intLDT);
+            final BigInteger scale = numeralValue(t.sub(1), intLDT);
+            return new RealLiteral(unscaled, scale);
+        }
         return null;
+    }
+
+    /**
+     * Decode a term of sort {@code numbers} into its integer value. Unlike
+     * {@link IntegerLDT#toNumberString} this also handles the negative-sign wrapper
+     * ({@code neglit}) that {@code numbers} terms carry for negative values.
+     *
+     * @param numeral a term of sort {@code numbers}
+     * @param intLDT the integer LDT owning the numeral symbols
+     * @return the value the numeral represents
+     */
+    private static BigInteger numeralValue(JTerm numeral, IntegerLDT intLDT) {
+        if (numeral.op() == intLDT.getNegativeNumberSign()) {
+            return numeralValue(numeral.sub(0), intLDT).negate();
+        }
+        return new BigInteger(intLDT.toNumberString(numeral));
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic;
 
+import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1283,6 +1284,17 @@ public class TermBuilder {
     public JTerm cTerm(String numberString) {
         return func(services.getTypeConverter().getIntegerLDT().getCharSymbol(),
             numberTerm(numberString));
+    }
+
+    /**
+     * Create a term representing a real value as {@code \R(unscaledValue, scale)}, i.e.
+     * {@code unscaledValue * 10^(-scale)}. Both operands are unbounded {@code numbers}, so this is
+     * exact for any real literal: it preserves the sign, all fractional digits (including leading
+     * zeros) and the scale, without ever squeezing the value through a bounded {@code int}.
+     */
+    public JTerm rTerm(BigInteger unscaledValue, BigInteger scale) {
+        return func(services.getTypeConverter().getRealLDT().getRealNumberSymbol(),
+            numberTerm(unscaledValue.toString()), numberTerm(scale.toString()));
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import de.uka.ilkd.key.java.*;
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
+import de.uka.ilkd.key.java.ast.expression.literal.RealLiteral;
 import de.uka.ilkd.key.java.ast.expression.literal.StringLiteral;
 import de.uka.ilkd.key.ldt.*;
 import de.uka.ilkd.key.logic.*;
@@ -274,7 +275,8 @@ public class ExpressionBuilder extends DefaultBuilder {
         JTerm result = accept(ctx.sub);
         assert result != null;
         if (ctx.MINUS() != null) {
-            Function Z = functions().lookup("Z");
+            Function Z = functions().lookup(IntegerLDT.NUMBERS_NAME);
+            final Function realNumbers = functions().lookup(RealLDT.REAL_NUMBERS_NAME);
             if (result.op() == Z) {
                 // weigl: rewrite neg(Z(1(#)) to Z(neglit(1(#))
                 // This mimics the old JavaKeYParser behaviour. Unknown if necessary.
@@ -282,6 +284,12 @@ public class ExpressionBuilder extends DefaultBuilder {
                 final JTerm num = result.sub(0);
                 return capsulateTf(ctx,
                     () -> getTermFactory().createTerm(Z, getTermFactory().createTerm(neglit, num)));
+            } else if (realNumbers != null && result.op() == realNumbers) {
+                final Function neglit = functions().lookup("neglit");
+                final JTerm unscaled = result.sub(0);
+                final JTerm scale = result.sub(1);
+                return capsulateTf(ctx, () -> getTermFactory().createTerm(realNumbers,
+                    getTermFactory().createTerm(neglit, unscaled), scale));
             } else if (result.sort() != JavaDLTheory.FORMULA) {
                 Sort sort = result.sort();
                 if (sort == null) {
@@ -1704,13 +1712,16 @@ public class ExpressionBuilder extends DefaultBuilder {
 
     @Override
     public Object visitRealLiteral(RealLiteralContext ctx) {
-        String txt = ctx.getText(); // full text of node incl. unary minus.
-        char lastChar = txt.charAt(txt.length() - 1);
-        if (lastChar == 'R' || lastChar == 'r') {
-            semanticError(ctx,
-                "The given float literal does not have a suffix. This is essential to determine its exact meaning. You probably want to add 'r' as a suffix.");
+        // full text incl. an optional leading '-' and the optional 'r'/'R' suffix
+        String txt = ctx.getText();
+        final char last = txt.charAt(txt.length() - 1);
+        if (last == 'r' || last == 'R') {
+            txt = txt.substring(0, txt.length() - 1);
         }
-        throw new Error("not yet implemented");
+        // RealLiteral parses the decimal exactly into (unscaledValue, scale); rTerm wraps it as
+        // __R(unscaledValue, scale) -- the same encoding RealLDT.translateLiteral produces.
+        final RealLiteral real = new RealLiteral(txt);
+        return getServices().getTermBuilder().rTerm(real.getUnscaledValue(), real.getScale());
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
@@ -186,7 +186,11 @@ public class LogicPrinter {
     public static String quickPrintSemisequent(Semisequent s, Services services) {
         var p = quickPrinter(services, NotationInfo.DEFAULT_PRETTY_SYNTAX,
             NotationInfo.DEFAULT_UNICODE_ENABLED, NotationInfo.DEFAULT_HIDE_PACKAGE_PREFIX);
+        // Wrap in an explicit block so the layouter flushes its last pending break; without this
+        // the trailing formula of the semisequent is dropped (issue #243). Mirrors quickPrintTerm.
+        p.layouter().beginC();
         p.printSemisequent(s);
+        p.layouter().end();
         return p.result();
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/Notation.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/Notation.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.pp;
 
+import java.math.BigInteger;
 import java.util.Iterator;
 
 import de.uka.ilkd.key.java.ast.ProgramElement;
@@ -10,6 +11,7 @@ import de.uka.ilkd.key.ldt.DoubleLDT;
 import de.uka.ilkd.key.ldt.FloatLDT;
 import de.uka.ilkd.key.ldt.IntegerLDT;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
+import de.uka.ilkd.key.ldt.RealLDT;
 import de.uka.ilkd.key.logic.JTerm;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.util.Debug;
@@ -661,6 +663,46 @@ public abstract class Notation {
             final String number = printNumberTerm(t);
             if (number != null) {
                 sp.printConstant(number);
+            } else {
+                sp.printFunctionTerm(t);
+            }
+        }
+    }
+
+
+    /**
+     * The standard concrete syntax for a real literal {@code __R(unscaledValue, scale)}: prints the
+     * value as a decimal with an {@code r} suffix (e.g. {@code 1.25r}), the inverse of what the
+     * term parser accepts.
+     */
+    static final class RealLiteral extends Notation {
+        public RealLiteral() {
+            super(120);
+        }
+
+        public static String printRealTerm(JTerm realTerm) {
+            if (!realTerm.op().name().equals(RealLDT.REAL_NUMBERS_NAME) || realTerm.arity() != 2) {
+                return null;
+            }
+            final String unscaled = NumLiteral.printNumberTerm(realTerm.sub(0));
+            final String scale = NumLiteral.printNumberTerm(realTerm.sub(1));
+            if (unscaled == null || scale == null) {
+                return null;
+            }
+            try {
+                // reuse the literal's own canonical rendering (FQN: the enclosing notation class
+                // shares its simple name with the AST literal)
+                return new de.uka.ilkd.key.java.ast.expression.literal.RealLiteral(
+                    new BigInteger(unscaled), new BigInteger(scale)).getValue() + "r";
+            } catch (NumberFormatException | ArithmeticException e) {
+                return null;
+            }
+        }
+
+        public void print(JTerm t, LogicPrinter sp) {
+            final String real = printRealTerm(t);
+            if (real != null) {
+                sp.printConstant(real);
             } else {
                 sp.printFunctionTerm(t);
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/NotationInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/NotationInfo.java
@@ -297,6 +297,9 @@ public final class NotationInfo {
             PRIORITY_ARITH_STRONG, PRIORITY_BELOW_ARITH_STRONG));
         tbl.put(doubleLDT.getNeg(), new Notation.Prefix("-", PRIORITY_BOTTOM, PRIORITY_ATOM));
 
+        final RealLDT realLDT = services.getTypeConverter().getRealLDT();
+        tbl.put(realLDT.getRealNumberSymbol(), new Notation.RealLiteral());
+
 
         // heap operators
         final HeapLDT heapLDT = services.getTypeConverter().getHeapLDT();

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/PrettyPrinter.java
@@ -458,6 +458,11 @@ public class PrettyPrinter implements Visitor {
     }
 
     @Override
+    public void performActionOnRealLiteral(RealLiteral x) {
+        layouter.print(x.getValue());
+    }
+
+    @Override
     public void performActionOnPackageSpecification(PackageSpecification x) {
         layouter.nl();
         layouter.keyWord("package");

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/integer/integerHeader.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/integer/integerHeader.key
@@ -5,12 +5,6 @@
 \sorts {
     numbers;
     int;
-
-    // these sort are not axiomatised yet; to come in CHARTER
-    // they are here included to allow us to load Java program that
-    // contain some methods or fields of type float or double
-
-    real; // TODO @Real
 }
 
 \functions {

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/ldt.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/ldt.key
@@ -20,6 +20,7 @@
     "./integer/javaIntegerHeader.key",
     javaHeader,
     "./float/floatHeader.key",
+    "./reals/realHeader.key",
     heap,
     "./locset/locSets.key",
     "./permission/permission.key",

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/reals/realHeader.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/reals/realHeader.key
@@ -1,0 +1,16 @@
+ /* This file is part of KeY - https://key-project.org
+  * KeY is licensed under the GNU General Public License Version 2
+  * SPDX-License-Identifier: GPL-2.0-only */
+
+ \sorts {
+    // not axiomatised yet (to come in CHARTER); included here so that we can load
+    // programs/specifications that mention the real type, and represent \real literals.
+    real;
+}
+
+\functions {
+   // Reserved built-in (the '__' prefix keeps it out of the user namespace).
+   // First argument is the unscaled value, the second one the scale:
+   // value = unscaledValue * 10^(-scale).
+   real __R(numbers, numbers);
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/ldt/RealLDTTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/ldt/RealLDTTest.java
@@ -1,0 +1,80 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.ldt;
+
+import java.math.BigInteger;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.java.ast.expression.literal.RealLiteral;
+import de.uka.ilkd.key.logic.JTerm;
+import de.uka.ilkd.key.logic.TermBuilder;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.key_project.util.ExtList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Round-trip tests for the {@code \R(unscaledValue, scale)} real-literal encoding (issue #3570):
+ * {@link TermBuilder#rTerm(BigInteger, BigInteger)} must build a term that
+ * {@link RealLDT#translateTerm(JTerm, ExtList, Services)} decodes back to the same value.
+ */
+public class RealLDTTest {
+
+    private static RealLiteral roundTrip(Services services, RealLiteral in) {
+        final JTerm term = services.getTermBuilder().rTerm(in.getUnscaledValue(), in.getScale());
+        return (RealLiteral) services.getTypeConverter().getRealLDT()
+                .translateTerm(term, new ExtList(), services);
+    }
+
+    @Test
+    void rTermRoundTripsAllValues() {
+        final Services services = TacletForTests.services();
+
+        // covers: integer, simple fraction, negative <1, leading-zero fraction (scale matters),
+        // trailing-zero integer (negative scale after canonicalization), negative >1, zero
+        final String[] values = {
+            "0", "1.25", "-0.5", "1.025", "0.001", "100", "-1.5", "3.14159", "-12.0", "42"
+        };
+
+        for (String s : values) {
+            final RealLiteral in = new RealLiteral(s);
+            final RealLiteral out = roundTrip(services, in);
+            assertEquals(in, out, () -> "real literal '" + s + "' did not round-trip");
+            assertEquals(in.getValue(), out.getValue(),
+                () -> "printed form of '" + s + "' changed on round-trip");
+        }
+    }
+
+    @Test
+    void canonicalPrintedForms() {
+        assertEquals("1.25", new RealLiteral("1.25").getValue());
+        assertEquals("-0.5", new RealLiteral("-0.5").getValue());
+        assertEquals("0.001", new RealLiteral("0.001").getValue());
+        assertEquals("100", new RealLiteral("100").getValue());
+        assertEquals("-12", new RealLiteral("-12.0").getValue()); // trailing zero stripped
+        assertEquals("0", new RealLiteral("0.0").getValue());
+    }
+
+    /**
+     * The whole point of the {@code (unscaledValue, scale)} encoding over {@code numbers}: it is
+     * not
+     * bounded by {@code int}. A scale beyond {@link Integer#MAX_VALUE} must still round-trip
+     * through
+     * the term representation (equality compares the unbounded fields, not the printed form).
+     */
+    @Test
+    void encodingIsUnboundedInScale() {
+        final Services services = TacletForTests.services();
+        final BigInteger hugeScale = BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.TEN);
+        final RealLiteral in = new RealLiteral(BigInteger.valueOf(7), hugeScale);
+
+        final RealLiteral out = roundTrip(services, in);
+
+        assertEquals(in, out, "huge-scale real did not round-trip");
+        assertEquals(hugeScale, out.getScale(), "scale was truncated");
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3570Test.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3570Test.java
@@ -1,0 +1,61 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.nparser;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.ldt.RealLDT;
+import de.uka.ilkd.key.logic.JTerm;
+import de.uka.ilkd.key.pp.LogicPrinter;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests around issue #3570: real number literals such as {@code 1.0r} can be parsed into a term of
+ * sort {@code real} (encoded as {@code __R(unscaledValue, scale)}) and printed back to their
+ * decimal form.
+ */
+class Issue3570Test {
+
+    private static KeyIO io() {
+        Services services = TacletForTests.services().copy(false);
+        return new KeyIO(services, services.getNamespaces());
+    }
+
+    @Test
+    void realLiteralParsesToRealSort() {
+        JTerm t = io().parseExpression("1.25r");
+        assertEquals("real", t.sort().name().toString(), "real literal should have sort real");
+        assertEquals(RealLDT.REAL_NUMBERS_NAME, t.op().name(),
+            "real literal should be wrapped in the __R symbol");
+    }
+
+    /**
+     * Parser and pretty-printer are inverse: a literal prints back to its canonical decimal form
+     * (with the {@code r} suffix), and re-parsing that form yields the very same term.
+     */
+    @Test
+    void realLiteralRoundTripsThroughParserAndPrinter() {
+        // input -> canonical printed form (trailing zeros stripped)
+        String[][] cases = {
+            { "1.25r", "1.25r" },
+            { "-0.5r", "-0.5r" },
+            { "0.001r", "0.001r" },
+            { "100r", "100r" },
+            { "-12.0r", "-12r" },
+            { "0.0r", "0r" },
+            { "3.14159r", "3.14159r" },
+        };
+        KeyIO io = io();
+        for (String[] c : cases) {
+            JTerm t = io.parseExpression(c[0]);
+            assertEquals(c[1], LogicPrinter.quickPrintTerm(t, io.getServices()).trim(),
+                "printed form of " + c[0]);
+            assertEquals(t, io.parseExpression(c[1]),
+                "re-parsing the printed form of " + c[0] + " must yield the same term");
+        }
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/pp/Issue243Test.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/pp/Issue243Test.java
@@ -1,0 +1,43 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.pp;
+
+import java.io.IOException;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.nparser.KeyIO;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.key_project.prover.sequent.Sequent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for issue #243: {@code LogicPrinter.printSemisequent} /
+ * {@code quickPrintSemisequent} drops the last formula of the semisequent, while the same
+ * formulas printed as part of a full sequent are rendered completely.
+ */
+class Issue243Test {
+
+    @Test
+    void quickPrintSemisequentDoesNotDropLastFormula() throws IOException {
+        Services services = TacletForTests.services().copy(false);
+        KeyIO io = new KeyIO(services, services.getNamespaces());
+
+        Sequent seq = io.load("""
+                \\problem { ==> true, false }
+                """).loadCompleteProblem().getProblem();
+
+        String semi = LogicPrinter.quickPrintSemisequent(seq.succedent(), services);
+        String full = LogicPrinter.quickPrintSequent(seq, services);
+
+        // The full sequent renders both formulas; the semisequent must render the same content.
+        // Before the fix, the trailing formula is missing from the semisequent rendering.
+        assertTrue(semi.contains("true") && semi.contains("false"),
+            "quickPrintSemisequent dropped a formula. semisequent=<" + semi
+                + ">, full sequent=<" + full + ">");
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/runallproofs/ProofCollections.java
@@ -120,6 +120,9 @@ public class ProofCollections {
         oldBook.provable("standard_key/BookExamples/02FirstOrderLogic/Ex2.58.key");
         oldBook.provable("standard_key/BookExamples/03DynamicLogic/Sect3.3.1.key");;
 
+        // Real literals
+        var reals = c.group("reals");
+        reals.provable("standard_key/reals/realLiterals.key");
 
         // Comprehension Tests
         var comprehensions = c.group("comprehensions");

--- a/key.ui/examples/standard_key/reals/realLiterals.key
+++ b/key.ui/examples/standard_key/reals/realLiterals.key
@@ -1,0 +1,34 @@
+/**
+@provable automatic
+@author KeY (real-literal support, issue #3570)
+
+Demonstrates the abstract \real type:
+  - real literals (1.25r, -0.5r, 100r) as first-class terms of sort `real`,
+  - reasoning with real-sorted symbols and quantifiers,
+  - a real-valued assignment, modelled by the update {r := c}.
+
+The real LDT is currently a stub without arithmetic axioms, so only
+equality/structural reasoning is available (no +, *, < on reals yet).
+Java program blocks do not yet support the `real` type either, so the
+"assignment" below is shown with an update rather than a \<{ ... }\> modality.
+*/
+
+\functions {
+  real c;
+}
+
+\programVariables {
+  real r;
+}
+
+\problem {
+       // real literals are first-class terms of sort `real`
+       ( 1.25r = 1.25r & -0.5r = -0.5r & 100r = 100r )
+
+       // reasoning with real-sorted symbols and quantifiers
+     & (\forall real x; x = x)
+
+       // a real-valued assignment: the update {r := c} stores the value of c
+       // into the real program variable r, after which r holds that value
+     & (c = 1.25r -> {r := c}(r = 1.25r))
+}

--- a/key.ui/examples/standard_key/reals/realLiterals.txt
+++ b/key.ui/examples/standard_key/reals/realLiterals.txt
@@ -1,0 +1,13 @@
+example.name = Real literals
+example.path = Data Types
+example.file = realLiterals.key
+
+Real numbers (the \real type)
+
+Shows the abstract \real type in action: real literals in the logic
+(1.25r, -0.5r, 100r), reasoning with real-sorted symbols and quantifiers,
+and a real-valued assignment modelled by an update {r := c}.
+
+The real LDT is still a stub without arithmetic axioms, so only
+equality/structural reasoning is demonstrated (there is no +, *, < on
+reals yet), and Java program blocks do not yet support the real type.


### PR DESCRIPTION
## Related Issue

This pull request resolves #243 and #3570.

## Intended Change

### #243 — `LogicPrinter.quickPrintSemisequent` dropped the last formula

The method printed the semisequent without an enclosing layouter block, so the
pretty-printer never flushed its final pending break and the trailing formula was lost
(e.g. `true,` instead of `true, false`). The same formulas printed via a full sequent
rendered correctly because `printSequent` wraps its output in `beginC/end`. Fixed by
wrapping the semisequent in an explicit block, mirroring `quickPrintTerm`.

### #3570 — real literals are now supported

`\real` literals such as `1.0r` used to be rejected by the term parser. This PR
implements them end to end.

* **Exact, unbounded representation.** A real is a mathematical value, so `RealLiteral`
  now stores it as an arbitrary-precision pair `(unscaledValue, scale)` with value
  `unscaledValue * 10^(-scale)` — the `BigDecimal` scheme, but with an unbounded
  `BigInteger` scale rather than an `int`, and kept in canonical form (trailing zeros
  stripped) so equal values have equal fields. `BigDecimal` is used only to parse bounded
  source strings, never to hold the value.
* **Term encoding.** The literal is encoded as `__R(unscaledValue, scale)` over `numbers`
  (`realHeader.key` now declares `real __R(numbers, numbers);` and the `real` sort, moved
  out of `integerHeader.key`). `TermBuilder.rTerm` / `RealLDT.translateLiteral` /
  `translateTerm` build and decode it; because both operands are unbounded `numbers`, the
  value never passes through an `int` (a scale beyond `Integer.MAX_VALUE` round-trips).
* **Parsing.** `ExpressionBuilder.visitRealLiteral` builds the term; a negative literal
  folds the sign into the literal (the real LDT has no `neg`), mirroring the existing
  integer-literal handling and using a bootstrap-safe namespace lookup.
* **Pretty-printing.** A new `Notation.RealLiteral` prints `__R(u, s)` back as its
  canonical decimal with an `r` suffix (`1.25r`, `-0.5r`, `100r`), the inverse of the
  parser; registered next to `Z`/`FP`/`DFP`.
* **Example + regression test.** `standard_key/reals/realLiterals.key` showcases real
  literals, real-sorted quantification and a real-valued assignment (via an update); it is
  wired into `runAllProofs` (it proves *and* reloads, so the printer→parser round-trip is
  checked on every CI run).

#### Decisions worth highlighting

* **Reserved `__` name.** The wrapper is named `__R` rather than a bare identifier so it
  does not steal a name a user might declare in a problem file. This is the first user of a
  reserved-prefix convention; migrating the other built-in literal symbols
  (`Z`/`C`/`FP`/`DFP`) out of the user namespace is left as separate follow-up work.
* **Scope.** The `RealLDT` is intentionally still a stub: there are **no arithmetic axioms**
  yet (no `+`, `*`, `<` on reals), so only equality/structural reasoning is available. The
  `real` type is also not yet usable inside Java program blocks (`\<{ ... }\>`), only in the
  logic and in JML; the example therefore models an assignment with an update. Axiomatising
  real arithmetic is a separate, larger piece of work.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s):
  - `Issue243Test` — red before, green after the semisequent fix.
  - `RealLDTTest` — the `(unscaledValue, scale)` encoding round-trips (incl. negatives,
    leading-zero fractions, trailing-zero integers, and a scale beyond `Integer.MAX_VALUE`).
  - `Issue3570Test` — a real literal parses to sort `real`, and parser and pretty-printer
    are inverse (incl. negatives and trailing-zero canonicalization).
- I have tested the feature as follows: the unit tests above, plus the full regression
  suites `:key.core:testRAP -PrapForks=10` (674 — including the new `reals` proof, which is
  proved and reloaded) and `:key.core:testProveRules` (203) — all green.
- I have checked that runtime performance has not deteriorated (the added parser/printer
  branches only fire for real literals; the extra namespace lookup mirrors the existing
  integer-literal handling on the same code path).

## Additional information and contact(s)

PR prepared with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
