### PR TITLE
Fix most-recent file not set after loading recent-files list (#3711)

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/RecentFileMenu.java
@@ -185,9 +185,13 @@ public class RecentFileMenu {
             var file = ParsingFacade.parseConfigurationFile(filename);
             List<Configuration> recent = file.asConfigurationList();
             this.recentFiles.clear();
+            this.mostRecentFile = null;
             for (var c : recent) {
                 final var e = new RecentFileEntry(c);
-                if (mostRecentFile != null) {
+                // The list is stored most-recent-first, so the first entry is the most recent.
+                // (Previously this condition was inverted and overwrote mostRecentFile with every
+                // entry, leaving it null after startup -- issue #3711.)
+                if (mostRecentFile == null) {
                     mostRecentFile = e;
                 }
                 recentFiles.add(e);

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/RecentFileMenuTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/RecentFileMenuTest.java
@@ -1,0 +1,54 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui;
+
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import de.uka.ilkd.key.settings.Configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for issue #3711: after loading the recent-files list from disk, the "most
+ * recent" file (used by the Reload action) must be the first entry of the stored list. Previously
+ * {@code RecentFileMenu.loadFrom} left {@code mostRecentFile} null after startup because of an
+ * inverted condition, so Reload picked the wrong (or no) file.
+ */
+class RecentFileMenuTest {
+
+    @Test
+    void mostRecentIsFirstEntryAfterLoad(@TempDir Path tmp) throws Exception {
+        Path fileA = tmp.resolve("A.key");
+        Path fileB = tmp.resolve("B.key");
+
+        Path store = tmp.resolve("recent.props");
+        writeRecentFileStore(store, fileA, fileB);
+
+        // mainWindow is only stored as a field and not used on the loadFrom/getMostRecent path.
+        RecentFileMenu menu = new RecentFileMenu(null);
+        menu.loadFrom(store);
+
+        assertEquals(fileA.toString(), menu.getMostRecent(),
+            "Reload should target the first (most recent) stored entry");
+    }
+
+    /** Writes a recent-files configuration in the same format {@code RecentFileMenu.store} uses. */
+    private static void writeRecentFileStore(Path store, Path... paths) throws Exception {
+        List<Configuration> entries = java.util.Arrays.stream(paths).map(p -> {
+            Configuration c = new Configuration();
+            c.set("path", p.toString());
+            c.set("singleJava", false);
+            return c;
+        }).toList();
+        try (BufferedWriter w = Files.newBufferedWriter(store)) {
+            new Configuration.ConfigurationWriter(w).printValue(entries);
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

This pull request resolves #3711.

## Intended Change

`RecentFileMenu.loadFrom` updated `mostRecentFile` only when it was *already* non-null,
and then reassigned it on every loop iteration. As a result, after startup
`mostRecentFile` was left `null`, so `File -> Reload` (which uses `getMostRecent()`) had
no — or the wrong — target.

The fix resets `mostRecentFile` and sets it to the first entry of the stored list, which
is kept most-recent-first.

Note: the in-session "move an already-listed file to the front" behaviour described in
#3711 was already fixed by an earlier refactor of `addRecentFileNoSave`; this PR addresses
the remaining startup case.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: added `RecentFileMenuTest.mostRecentIsFirstEntryAfterLoad`,
  a headless test that writes a recent-files store (via the same `Configuration.ConfigurationWriter`
  the app uses), loads it, and asserts `getMostRecent()` is the first entry. Verified it fails
  without the fix (`expected A.key but was null`) and passes with it. Ran
  `./gradlew :key.ui:test --tests "de.uka.ilkd.key.gui.RecentFileMenuTest"`.
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

PR created with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
