### PR TITLE
Regression tests for resolved parser/JML issues (#1119, #1536); pin #329

### DIFF
--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/NestedUpdateParsingTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/NestedUpdateParsingTest.java
@@ -1,0 +1,44 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.nparser;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guards for issue #1536 (parsing of nested updates).
+ *
+ * <p>
+ * The originally reported cryptic error ("Not a legal lhs: ...") for an update whose left-hand
+ * side is itself an update application is now a clear, actionable message, and the bracketed form
+ * the message suggests parses correctly.
+ */
+class NestedUpdateParsingTest {
+
+    private static void load(String problem) throws Exception {
+        Services services = TacletForTests.services().copy(false);
+        KeyIO io = new KeyIO(services, services.getNamespaces());
+        io.load("\\programVariables { int a,b; }\n\\problem { " + problem + " }")
+                .loadCompleteProblem();
+    }
+
+    @Test
+    void unbracketedNestedUpdateGivesHelpfulError() {
+        Exception ex = assertThrows(Exception.class,
+            () -> load("{{a:=3} b:=a}( a = 1 & b = 3 )"));
+        assertTrue(String.valueOf(ex.getMessage()).contains("bracketed version"),
+            "expected a hint to use the bracketed form, got: " + ex.getMessage());
+    }
+
+    @Test
+    void bracketedNestedUpdateParses() {
+        assertDoesNotThrow(() -> load("{{a:=3} (b:=a)}( a = 1 & b = 3 )"));
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/init/ParameterNameResolutionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/init/ParameterNameResolutionTest.java
@@ -1,0 +1,52 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof.init;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.KeYEnvironment;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Resolution of method-parameter names that look special to KeY.
+ */
+class ParameterNameResolutionTest {
+
+    private static void load(String dir) throws Exception {
+        Path p = Paths.get(
+            ParameterNameResolutionTest.class.getResource(dir).toURI());
+        KeYEnvironment<DefaultUserInterfaceControl> env =
+            KeYEnvironment.load(p, null, null, null);
+        env.dispose();
+    }
+
+    /**
+     * Regression guard for issue #1119: a method parameter named {@code result} (which can also be
+     * referred to via {@code \result}) used to fail with "Name already in namespace: result". This
+     * now loads fine; the test guards against a reintroduction.
+     */
+    @Test
+    void parameterNamedResultResolves() {
+        assertDoesNotThrow(() -> load("issue1119"));
+    }
+
+    /**
+     * Issue #329: a JML reference to a parameter whose name ends in {@code _<digits>} (e.g.
+     * {@code para_0}) fails with "Cannot resolve 'para_0'". Root cause: {@code VariableNamer}
+     * treats the {@code _<digits>} suffix as a uniquification index (see
+     * {@code VariableNamer.parseName}/{@code getBasenameAndIndex}), so the literal identifier is
+     * never matched. Fixing this touches the variable-naming subsystem, hence disabled until then.
+     */
+    @Disabled("#329: identifier ending in _<digits> mis-parsed as an index by VariableNamer")
+    @Test
+    void parameterEndingInUnderscoreDigitResolves() {
+        assertDoesNotThrow(() -> load("issue329"));
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/proof/init/issue1119/Result.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/proof/init/issue1119/Result.java
@@ -1,0 +1,8 @@
+public class Result {
+    /*@ public normal_behaviour
+      @ ensures \result == result;
+      @*/
+    public int test(int result) {
+        return result;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/proof/init/issue329/Para.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/proof/init/issue329/Para.java
@@ -1,0 +1,9 @@
+public class Para {
+    /*@ public normal_behaviour
+      @ requires para_0 >= 0;
+      @ ensures \result == para_0;
+      @*/
+    public int test(int para_0) {
+        return para_0;
+    }
+}


### PR DESCRIPTION
## Related Issue

Adds regression tests for #1119 and #1536 (both already fixed) and pins #329 (still open).

## Intended Change

While triaging the open parser/JML bugs, three issues turned out to be in different states.
This PR records that with tests; no production code changes.

* **#1119** — a method parameter named `result` (also referable via `\result`) used to fail with
  "Name already in namespace: result". It loads fine now → green regression guard
  (`ParameterNameResolutionTest.parameterNamedResultResolves`).
* **#1536** — a nested update whose left-hand side is an update application
  (`{{a:=3} b:=a}(…)`) used to fail with a cryptic "Not a legal lhs". It now produces an
  actionable error pointing to the bracketed form `{{a:=3} (b:=a)}(…)`, which parses → two green
  guards (`NestedUpdateParsingTest`).
* **#329** — a JML reference to a parameter whose name ends in `_<digits>` (e.g. `para_0`) still
  fails with "Cannot resolve 'para_0'". Root cause: `VariableNamer` treats a trailing `_<digits>`
  as a uniquification index (`parseName`/`getBasenameAndIndex`), so the literal identifier is never
  matched. Fixing this touches the variable-naming subsystem, so it is pinned with a `@Disabled`
  test ready to enable once addressed.

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code (test code only)

## Ensuring quality

- I added new test case(s) for new functionality.
- I have tested the feature as follows: ran
  `./gradlew :key.core:test --tests "de.uka.ilkd.key.proof.init.ParameterNameResolutionTest" --tests "de.uka.ilkd.key.nparser.NestedUpdateParsingTest"`
  — the #1119/#1536 guards pass, the #329 test is skipped (disabled).

## Additional information and contact(s)

If maintainers agree #1119 and #1536 are resolved, they can be closed (these tests guard against
regressions). #329 remains open; the disabled test documents the desired behaviour.

This PR has been done with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
