### PR TITLE
Reject generic sorts at user-input boundaries: \problem, JML, taclet instantiation (#3409)

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -5,7 +5,7 @@ package de.uka.ilkd.key.control.instantiation_model;
 
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Optional;
+import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
 import de.uka.ilkd.key.java.Position;
@@ -188,10 +188,13 @@ public class TacletFindModel extends AbstractTableModel {
         JTerm result =
             new DefaultTermParser().parse(new StringReader(s), null, services, copy, scm);
         // Validate the user-entered instantiation (e.g. reject generic sorts, see issue #3409). The
-        // set of checks lives in UserInputValidator.
-        Optional<String> issue = UserInputValidator.validate(result, "an instantiation");
-        if (issue.isPresent()) {
-            throw new ParserException(issue.get(), null);
+        // set of checks lives in UserInputValidator. Unlike the (batch-parsed) \problem and JML
+        // boundaries, this field is validated live on every keystroke and its message is rendered
+        // as a single inline entry, so we surface the first problem; once the user fixes it, the
+        // next one (if any) appears on the next validation.
+        List<String> issues = UserInputValidator.validate(result, "an instantiation");
+        if (!issues.isEmpty()) {
+            throw new ParserException(issues.get(0), null);
         }
         return result;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.control.instantiation_model;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Optional;
 import javax.swing.table.AbstractTableModel;
 
 import de.uka.ilkd.key.java.Position;
@@ -184,7 +185,15 @@ public class TacletFindModel extends AbstractTableModel {
         NamespaceSet copy = nss.copy();
         copy.setVariables(varNS);
         copy.setFunctions(functNS);
-        return new DefaultTermParser().parse(new StringReader(s), null, services, copy, scm);
+        JTerm result =
+            new DefaultTermParser().parse(new StringReader(s), null, services, copy, scm);
+        // Validate the user-entered instantiation (e.g. reject generic sorts, see issue #3409). The
+        // set of checks lives in UserInputValidator.
+        Optional<String> issue = UserInputValidator.validate(result, "an instantiation");
+        if (issue.isPresent()) {
+            throw new ParserException(issue.get(), null);
+        }
+        return result;
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/GenericSortDetector.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/GenericSortDetector.java
@@ -3,16 +3,20 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic;
 
-import de.uka.ilkd.key.logic.sort.GenericSort;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.key_project.logic.op.QuantifiableVariable;
+import org.key_project.logic.sort.Sort;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 
 import org.jspecify.annotations.Nullable;
 
 /**
- * Detects occurrences of {@link GenericSort}s within terms and sequents.
+ * Detects occurrences of generic sorts within terms and sequents.
  * <p>
  * Generic sorts are schematic placeholders that may only appear in taclets; they must never occur
  * in a concrete sequent. This detector is meant to be used at <em>user-input/parser boundaries</em>
@@ -20,6 +24,11 @@ import org.jspecify.annotations.Nullable;
  * with a clear message. It is deliberately <em>not</em> wired into term construction or automatic
  * proof search, where a generic-sort leak would be an implementation error to be found by other
  * means.
+ * <p>
+ * A sort is reported when {@link Sort#containsGenericSort()} holds. This catches a generic sort
+ * even
+ * when it is nested inside a parametric sort (e.g. {@code List<[E]>}, or the result sort of
+ * {@code select<[E]>(...)}), not only when a term's own sort is itself a generic sort.
  *
  * @author KeY developers
  */
@@ -29,45 +38,45 @@ public final class GenericSortDetector {
 
     /**
      * @param term a term, may be {@code null}
-     * @return the first {@link GenericSort} occurring in {@code term} (in a subterm's sort or a
-     *         bound variable's sort), or {@code null} if none occurs
+     * @return the distinct sorts occurring in {@code term} (in a subterm's sort or a bound
+     *         variable's sort) that are or contain a generic sort, in order of first occurrence;
+     *         empty if none occurs
      */
-    public static @Nullable GenericSort findIn(@Nullable JTerm term) {
-        if (term == null) {
-            return null;
-        }
-        if (term.sort() instanceof GenericSort gs) {
-            return gs;
-        }
-        for (QuantifiableVariable qv : term.boundVars()) {
-            if (qv.sort() instanceof GenericSort gs) {
-                return gs;
-            }
-        }
-        for (int i = 0; i < term.arity(); i++) {
-            GenericSort found = findIn(term.sub(i));
-            if (found != null) {
-                return found;
-            }
-        }
-        return null;
+    public static List<Sort> findIn(@Nullable JTerm term) {
+        Set<Sort> found = new LinkedHashSet<>();
+        collect(term, found);
+        return new ArrayList<>(found);
     }
 
     /**
      * @param sequent a sequent, may be {@code null}
-     * @return the first {@link GenericSort} occurring in any formula of {@code sequent}, or
-     *         {@code null} if none occurs
+     * @return the distinct sorts occurring in any formula of {@code sequent} that are or contain a
+     *         generic sort, in order of first occurrence; empty if none occurs
      */
-    public static @Nullable GenericSort findIn(@Nullable Sequent sequent) {
-        if (sequent == null) {
-            return null;
-        }
-        for (SequentFormula sf : sequent) {
-            GenericSort found = findIn((JTerm) sf.formula());
-            if (found != null) {
-                return found;
+    public static List<Sort> findIn(@Nullable Sequent sequent) {
+        Set<Sort> found = new LinkedHashSet<>();
+        if (sequent != null) {
+            for (SequentFormula sf : sequent) {
+                collect((JTerm) sf.formula(), found);
             }
         }
-        return null;
+        return new ArrayList<>(found);
+    }
+
+    private static void collect(@Nullable JTerm term, Set<Sort> found) {
+        if (term == null) {
+            return;
+        }
+        if (term.sort().containsGenericSort()) {
+            found.add(term.sort());
+        }
+        for (QuantifiableVariable qv : term.boundVars()) {
+            if (qv.sort().containsGenericSort()) {
+                found.add(qv.sort());
+            }
+        }
+        for (int i = 0; i < term.arity(); i++) {
+            collect(term.sub(i), found);
+        }
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/GenericSortDetector.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/GenericSortDetector.java
@@ -1,0 +1,73 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.logic;
+
+import de.uka.ilkd.key.logic.sort.GenericSort;
+
+import org.key_project.logic.op.QuantifiableVariable;
+import org.key_project.prover.sequent.Sequent;
+import org.key_project.prover.sequent.SequentFormula;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Detects occurrences of {@link GenericSort}s within terms and sequents.
+ * <p>
+ * Generic sorts are schematic placeholders that may only appear in taclets; they must never occur
+ * in a concrete sequent. This detector is meant to be used at <em>user-input/parser boundaries</em>
+ * (problem sections, JML translation, interactive taclet instantiation) to reject such input early
+ * with a clear message. It is deliberately <em>not</em> wired into term construction or automatic
+ * proof search, where a generic-sort leak would be an implementation error to be found by other
+ * means.
+ *
+ * @author KeY developers
+ */
+public final class GenericSortDetector {
+
+    private GenericSortDetector() {}
+
+    /**
+     * @param term a term, may be {@code null}
+     * @return the first {@link GenericSort} occurring in {@code term} (in a subterm's sort or a
+     *         bound variable's sort), or {@code null} if none occurs
+     */
+    public static @Nullable GenericSort findIn(@Nullable JTerm term) {
+        if (term == null) {
+            return null;
+        }
+        if (term.sort() instanceof GenericSort gs) {
+            return gs;
+        }
+        for (QuantifiableVariable qv : term.boundVars()) {
+            if (qv.sort() instanceof GenericSort gs) {
+                return gs;
+            }
+        }
+        for (int i = 0; i < term.arity(); i++) {
+            GenericSort found = findIn(term.sub(i));
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param sequent a sequent, may be {@code null}
+     * @return the first {@link GenericSort} occurring in any formula of {@code sequent}, or
+     *         {@code null} if none occurs
+     */
+    public static @Nullable GenericSort findIn(@Nullable Sequent sequent) {
+        if (sequent == null) {
+            return null;
+        }
+        for (SequentFormula sf : sequent) {
+            GenericSort found = findIn((JTerm) sf.formula());
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/UserInputValidator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/UserInputValidator.java
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import de.uka.ilkd.key.logic.sort.GenericSort;
-
+import org.key_project.logic.sort.Sort;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
 
@@ -26,10 +25,16 @@ import org.jspecify.annotations.Nullable;
  * automatically scoped to user input only — automatic term creation never runs them, so there is
  * no extra cost on the proof-search hot path.</li>
  * </ul>
+ * Each check returns <em>all</em> problems it finds (not just the first), so a boundary can report
+ * them together. The callers turn the returned messages into the boundary's natural exception; the
+ * problem/JML boundaries bundle them into a {@code BuildingExceptions} so that the shared
+ * {@code ExceptionTools#getMessages} extraction (used by both the GUI {@code IssueDialog} and the
+ * console) reports every problem with its own entry.
+ * <p>
  * To add a new user-input check (e.g. a stricter well-typedness check), add a {@link Check} to
  * {@link #CHECKS}; no boundary needs to change. To add a new boundary, call
  * {@link #validate(JTerm, String)} / {@link #validate(Sequent, String)} there and raise the
- * boundary's natural (positioned) exception with the returned message.
+ * boundary's exception with the returned messages.
  *
  * @author KeY developers
  */
@@ -44,9 +49,9 @@ public final class UserInputValidator {
          * @param term a term produced from user input
          * @param context a short human-readable description of where the term came from, used in
          *        the error message (e.g. {@code "a \\problem"})
-         * @return an error message if {@code term} is invalid for user input, otherwise empty
+         * @return one error message per problem found in {@code term} (empty if it is acceptable)
          */
-        Optional<String> validate(JTerm term, String context);
+        List<String> validate(JTerm term, String context);
     }
 
     /** The registered user-input checks. Add new checks here. */
@@ -61,19 +66,17 @@ public final class UserInputValidator {
      * @param term a term produced from user input, may be {@code null}
      * @param context a short description of the origin for the error message (e.g. {@code "a
      *        \\problem"}, {@code "a JML expression"}, {@code "an instantiation"})
-     * @return the first validation error, or empty if {@code term} is acceptable
+     * @return all validation errors (empty if {@code term} is acceptable)
      */
-    public static Optional<String> validate(@Nullable JTerm term, String context) {
+    public static List<String> validate(@Nullable JTerm term, String context) {
         if (term == null) {
-            return Optional.empty();
+            return List.of();
         }
+        List<String> issues = new ArrayList<>();
         for (Check check : CHECKS) {
-            Optional<String> issue = check.validate(term, context);
-            if (issue.isPresent()) {
-                return issue;
-            }
+            issues.addAll(check.validate(term, context));
         }
-        return Optional.empty();
+        return issues;
     }
 
     /**
@@ -81,28 +84,26 @@ public final class UserInputValidator {
      *
      * @param sequent a sequent produced from user input, may be {@code null}
      * @param context a short description of the origin for the error message
-     * @return the first validation error, or empty if the sequent is acceptable
+     * @return all validation errors (empty if the sequent is acceptable)
      */
-    public static Optional<String> validate(@Nullable Sequent sequent, String context) {
+    public static List<String> validate(@Nullable Sequent sequent, String context) {
         if (sequent == null) {
-            return Optional.empty();
+            return List.of();
         }
+        List<String> issues = new ArrayList<>();
         for (SequentFormula sf : sequent) {
-            Optional<String> issue = validate((JTerm) sf.formula(), context);
-            if (issue.isPresent()) {
-                return issue;
-            }
+            issues.addAll(validate((JTerm) sf.formula(), context));
         }
-        return Optional.empty();
+        return issues;
     }
 
     /** Check: generic sorts (schematic taclet placeholders) must not occur in a concrete term. */
-    private static Optional<String> checkNoGenericSort(JTerm term, String context) {
-        GenericSort generic = GenericSortDetector.findIn(term);
-        if (generic == null) {
-            return Optional.empty();
+    private static List<String> checkNoGenericSort(JTerm term, String context) {
+        List<String> issues = new ArrayList<>();
+        for (Sort sort : GenericSortDetector.findIn(term)) {
+            issues.add("The sort '" + sort.name() + "' must not occur in " + context
+                + "; it is or contains a generic sort, which may only appear in taclets.");
         }
-        return Optional.of("The generic sort '" + generic.name() + "' must not occur in " + context
-            + ". Generic sorts may only be used in taclets.");
+        return issues;
     }
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/UserInputValidator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/UserInputValidator.java
@@ -1,0 +1,108 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.logic;
+
+import java.util.List;
+import java.util.Optional;
+
+import de.uka.ilkd.key.logic.sort.GenericSort;
+
+import org.key_project.prover.sequent.Sequent;
+import org.key_project.prover.sequent.SequentFormula;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Central place for validations that must be applied to <em>terms/sequents produced from user
+ * input</em> (problem sections, JML expressions, interactive taclet instantiations, ...), but not
+ * to terms created internally during automatic proof search.
+ * <p>
+ * The point of this class is twofold:
+ * <ul>
+ * <li>checks are <b>defined once</b> here ({@link #CHECKS}) instead of being inlined at every
+ * parser boundary, and</li>
+ * <li>because the validator is only invoked at user-input boundaries, every registered check is
+ * automatically scoped to user input only — automatic term creation never runs them, so there is
+ * no extra cost on the proof-search hot path.</li>
+ * </ul>
+ * To add a new user-input check (e.g. a stricter well-typedness check), add a {@link Check} to
+ * {@link #CHECKS}; no boundary needs to change. To add a new boundary, call
+ * {@link #validate(JTerm, String)} / {@link #validate(Sequent, String)} there and raise the
+ * boundary's natural (positioned) exception with the returned message.
+ *
+ * @author KeY developers
+ */
+public final class UserInputValidator {
+
+    /**
+     * A single validation applied to a user-supplied term.
+     */
+    @FunctionalInterface
+    public interface Check {
+        /**
+         * @param term a term produced from user input
+         * @param context a short human-readable description of where the term came from, used in
+         *        the error message (e.g. {@code "a \\problem"})
+         * @return an error message if {@code term} is invalid for user input, otherwise empty
+         */
+        Optional<String> validate(JTerm term, String context);
+    }
+
+    /** The registered user-input checks. Add new checks here. */
+    private static final List<Check> CHECKS = List.of(
+        UserInputValidator::checkNoGenericSort);
+
+    private UserInputValidator() {}
+
+    /**
+     * Runs all registered checks on {@code term}.
+     *
+     * @param term a term produced from user input, may be {@code null}
+     * @param context a short description of the origin for the error message (e.g. {@code "a
+     *        \\problem"}, {@code "a JML expression"}, {@code "an instantiation"})
+     * @return the first validation error, or empty if {@code term} is acceptable
+     */
+    public static Optional<String> validate(@Nullable JTerm term, String context) {
+        if (term == null) {
+            return Optional.empty();
+        }
+        for (Check check : CHECKS) {
+            Optional<String> issue = check.validate(term, context);
+            if (issue.isPresent()) {
+                return issue;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Runs all registered checks on every formula of {@code sequent}.
+     *
+     * @param sequent a sequent produced from user input, may be {@code null}
+     * @param context a short description of the origin for the error message
+     * @return the first validation error, or empty if the sequent is acceptable
+     */
+    public static Optional<String> validate(@Nullable Sequent sequent, String context) {
+        if (sequent == null) {
+            return Optional.empty();
+        }
+        for (SequentFormula sf : sequent) {
+            Optional<String> issue = validate((JTerm) sf.formula(), context);
+            if (issue.isPresent()) {
+                return issue;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Check: generic sorts (schematic taclet placeholders) must not occur in a concrete term. */
+    private static Optional<String> checkNoGenericSort(JTerm term, String context) {
+        GenericSort generic = GenericSortDetector.findIn(term);
+        if (generic == null) {
+            return Optional.empty();
+        }
+        return Optional.of("The generic sort '" + generic.name() + "' must not occur in " + context
+            + ". Generic sorts may only be used in taclets.");
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -6,8 +6,10 @@ package de.uka.ilkd.key.proof.init;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
+import de.uka.ilkd.key.logic.UserInputValidator;
 import de.uka.ilkd.key.nparser.*;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.ProofAggregate;
@@ -136,6 +138,13 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
             }
         } catch (Exception e) {
             throw new ProofInputException(e);
+        }
+
+        // Validate the user-supplied problem (e.g. reject generic sorts that must not occur in a
+        // concrete sequent, see issue #3409). The set of checks lives in UserInputValidator.
+        Optional<String> issue = UserInputValidator.validate(problem, "a \\problem");
+        if (issue.isPresent()) {
+            throw new ProofInputException(issue.get());
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -6,7 +6,7 @@ package de.uka.ilkd.key.proof.init;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.Optional;
+import java.util.List;
 
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
 import de.uka.ilkd.key.logic.UserInputValidator;
@@ -21,12 +21,15 @@ import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.SLEnvInput;
 import de.uka.ilkd.key.util.ProgressMonitor;
+import de.uka.ilkd.key.util.parsing.BuildingExceptions;
+import de.uka.ilkd.key.util.parsing.BuildingIssue;
 
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableSet;
 
 import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.jspecify.annotations.Nullable;
 
@@ -142,9 +145,13 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
 
         // Validate the user-supplied problem (e.g. reject generic sorts that must not occur in a
         // concrete sequent, see issue #3409). The set of checks lives in UserInputValidator.
-        Optional<String> issue = UserInputValidator.validate(problem, "a \\problem");
-        if (issue.isPresent()) {
-            throw new ProofInputException(issue.get());
+        List<String> issues = UserInputValidator.validate(problem, "a \\problem");
+        if (!issues.isEmpty()) {
+            // Bundle into a BuildingExceptions so that ExceptionTools#getMessages (used by both the
+            // GUI IssueDialog and the console) reports each rejected sort as its own entry.
+            throw new ProofInputException(new BuildingExceptions(issues.stream()
+                    .map(msg -> BuildingIssue.createError(msg, (ParserRuleContext) null, null))
+                    .toList()));
         }
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.njml;
 
+import java.util.List;
 import java.util.Map;
 
 import de.uka.ilkd.key.java.Services;
@@ -20,7 +21,8 @@ import de.uka.ilkd.key.speclang.jml.translation.Context;
 import de.uka.ilkd.key.speclang.translation.SLExpression;
 import de.uka.ilkd.key.util.InfFlowSpec;
 import de.uka.ilkd.key.util.mergerule.MergeParamsSpec;
-import de.uka.ilkd.key.util.parsing.BuildingException;
+import de.uka.ilkd.key.util.parsing.BuildingExceptions;
+import de.uka.ilkd.key.util.parsing.BuildingIssue;
 
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
@@ -181,10 +183,14 @@ public class JmlIO {
         warnings = warnings.prepend(newWarnings);
         // Validate the user-supplied JML term (e.g. reject generic sorts, see issue #3409). The set
         // of checks lives in UserInputValidator.
-        UserInputValidator.validate(termOf(obj), "a JML expression")
-                .ifPresent(msg -> {
-                    throw new BuildingException(ctx, msg);
-                });
+        List<String> issues = UserInputValidator.validate(termOf(obj), "a JML expression");
+        if (!issues.isEmpty()) {
+            // Bundle into a BuildingExceptions so that every rejected sort is reported separately
+            // (ExceptionTools#getMessages, used by the GUI IssueDialog and the console).
+            throw new BuildingExceptions(issues.stream()
+                    .map(msg -> BuildingIssue.createError(msg, ctx, null))
+                    .toList());
+        }
         return obj;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlIO.java
@@ -9,6 +9,7 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.Label;
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
 import de.uka.ilkd.key.logic.JTerm;
+import de.uka.ilkd.key.logic.UserInputValidator;
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.op.IObserverFunction;
 import de.uka.ilkd.key.logic.op.LocationVariable;
@@ -19,6 +20,7 @@ import de.uka.ilkd.key.speclang.jml.translation.Context;
 import de.uka.ilkd.key.speclang.translation.SLExpression;
 import de.uka.ilkd.key.util.InfFlowSpec;
 import de.uka.ilkd.key.util.mergerule.MergeParamsSpec;
+import de.uka.ilkd.key.util.parsing.BuildingException;
 
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
@@ -177,7 +179,27 @@ public class JmlIO {
         Object obj = ctx.accept(visitor);
         ImmutableList<PositionedString> newWarnings = ImmutableList.fromList(visitor.getWarnings());
         warnings = warnings.prepend(newWarnings);
+        // Validate the user-supplied JML term (e.g. reject generic sorts, see issue #3409). The set
+        // of checks lives in UserInputValidator.
+        UserInputValidator.validate(termOf(obj), "a JML expression")
+                .ifPresent(msg -> {
+                    throw new BuildingException(ctx, msg);
+                });
         return obj;
+    }
+
+    /** Extracts the {@link JTerm} carried by a JML interpretation result, if any. */
+    private static @Nullable JTerm termOf(Object obj) {
+        if (obj instanceof SLExpression e && e.isTerm()) {
+            return e.getTerm();
+        }
+        if (obj instanceof JTerm t) {
+            return t;
+        }
+        if (obj instanceof Pair<?, ?> p && p.second instanceof JTerm t) {
+            return t;
+        }
+        return null;
     }
 
     /**

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/GenericSortDetectorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/GenericSortDetectorTest.java
@@ -3,19 +3,26 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic;
 
+import java.util.List;
+
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.op.JFunction;
 import de.uka.ilkd.key.logic.sort.GenericSort;
+import de.uka.ilkd.key.logic.sort.ParametricSortDecl;
+import de.uka.ilkd.key.logic.sort.ParametricSortInstance;
 import de.uka.ilkd.key.rule.TacletForTests;
 
 import org.key_project.logic.Name;
 import org.key_project.logic.sort.Sort;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSet;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link GenericSortDetector}, the shared checker used at the parser/user-input
@@ -30,7 +37,7 @@ class GenericSortDetectorTest {
         JFunction c = new JFunction(new Name("c"), s);
         JTerm t = services.getTermBuilder().func(c);
 
-        assertEquals(s, GenericSortDetector.findIn(t),
+        assertEquals(List.of(s), GenericSortDetector.findIn(t),
             "a constant of generic sort must be detected");
     }
 
@@ -44,8 +51,56 @@ class GenericSortDetectorTest {
         JFunction p = new JFunction(new Name("p"), JavaDLTheory.FORMULA, s);
         JTerm t = tb.func(p, tb.func(c));
 
-        assertEquals(s, GenericSortDetector.findIn(t),
+        assertEquals(List.of(s), GenericSortDetector.findIn(t),
             "a generic sort nested in a subterm must be detected");
+    }
+
+    /**
+     * The case that a plain {@code instanceof GenericSort} check would miss: a sort that is not
+     * itself a generic sort but <em>contains</em> one, like {@code List<[G1]>} (the same situation
+     * arises for {@code select<[E]>(...)}). Detection must rely on
+     * {@link Sort#containsGenericSort()}.
+     */
+    @Test
+    void detectsGenericSortNestedInParametricSort() {
+        Services services = TacletForTests.services().copy(false);
+        var tb = services.getTermBuilder();
+
+        GenericSort g1 = new GenericSort(new Name("G1"));
+        services.getNamespaces().sorts().add(g1);
+        ParametricSortDecl listDecl = new ParametricSortDecl(new Name("List"), false,
+            ImmutableSet.empty(),
+            ImmutableList.of(new GenericParameter(g1, GenericParameter.Variance.INVARIANT)));
+        services.getNamespaces().parametricSorts().add(listDecl);
+        Sort listOfG1 = ParametricSortInstance.get(listDecl,
+            ImmutableList.of(new GenericArgument(g1)), services);
+
+        JFunction c = new JFunction(new Name("c"), listOfG1);
+        JTerm t = tb.func(c);
+
+        List<Sort> found = GenericSortDetector.findIn(t);
+        assertEquals(List.of(listOfG1), found,
+            "a generic sort nested in a parametric sort (List<[G1]>) must be detected, even "
+                + "though the term's sort is not itself a GenericSort");
+        assertTrue(found.get(0).containsGenericSort());
+        assertFalse(found.get(0) instanceof GenericSort,
+            "the reported sort is the containing parametric sort, not a bare GenericSort");
+    }
+
+    @Test
+    void reportsAllDistinctGenericSorts() {
+        Services services = TacletForTests.services().copy(false);
+        var tb = services.getTermBuilder();
+        GenericSort s = new GenericSort(new Name("S"));
+        GenericSort u = new GenericSort(new Name("U"));
+        JFunction p = new JFunction(new Name("p"), JavaDLTheory.FORMULA, s);
+        JFunction q = new JFunction(new Name("q"), JavaDLTheory.FORMULA, u);
+        // p(cs) & q(cu) with cs : S, cu : U
+        JTerm t = tb.and(tb.func(p, tb.func(new JFunction(new Name("cs"), s))),
+            tb.func(q, tb.func(new JFunction(new Name("cu"), u))));
+
+        assertEquals(List.of(s, u), GenericSortDetector.findIn(t),
+            "all distinct generic sorts must be reported, in order of first occurrence");
     }
 
     @Test
@@ -56,7 +111,7 @@ class GenericSortDetectorTest {
         JFunction g = new JFunction(new Name("myConcreteConst"), intSort);
         JTerm t = tb.equals(tb.func(g), tb.func(g));
 
-        assertNull(GenericSortDetector.findIn(t),
+        assertTrue(GenericSortDetector.findIn(t).isEmpty(),
             "a fully concrete term must not be flagged");
     }
 }

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/GenericSortDetectorTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/GenericSortDetectorTest.java
@@ -1,0 +1,62 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.logic;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.ldt.JavaDLTheory;
+import de.uka.ilkd.key.logic.op.JFunction;
+import de.uka.ilkd.key.logic.sort.GenericSort;
+import de.uka.ilkd.key.rule.TacletForTests;
+
+import org.key_project.logic.Name;
+import org.key_project.logic.sort.Sort;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link GenericSortDetector}, the shared checker used at the parser/user-input
+ * boundaries to reject generic sorts leaking into concrete terms (issue #3409).
+ */
+class GenericSortDetectorTest {
+
+    @Test
+    void detectsConstantOfGenericSort() {
+        Services services = TacletForTests.services().copy(false);
+        GenericSort s = new GenericSort(new Name("S"));
+        JFunction c = new JFunction(new Name("c"), s);
+        JTerm t = services.getTermBuilder().func(c);
+
+        assertEquals(s, GenericSortDetector.findIn(t),
+            "a constant of generic sort must be detected");
+    }
+
+    @Test
+    void detectsGenericSortNestedInArgument() {
+        Services services = TacletForTests.services().copy(false);
+        var tb = services.getTermBuilder();
+        GenericSort s = new GenericSort(new Name("S"));
+        JFunction c = new JFunction(new Name("c"), s);
+        // p(c) with p : (S) -> Formula -- generic only appears in the argument's sort
+        JFunction p = new JFunction(new Name("p"), JavaDLTheory.FORMULA, s);
+        JTerm t = tb.func(p, tb.func(c));
+
+        assertEquals(s, GenericSortDetector.findIn(t),
+            "a generic sort nested in a subterm must be detected");
+    }
+
+    @Test
+    void concreteTermHasNoGenericSort() {
+        Services services = TacletForTests.services().copy(false);
+        var tb = services.getTermBuilder();
+        Sort intSort = services.getNamespaces().sorts().lookup(new Name("int"));
+        JFunction g = new JFunction(new Name("myConcreteConst"), intSort);
+        JTerm t = tb.equals(tb.func(g), tb.func(g));
+
+        assertNull(GenericSortDetector.findIn(t),
+            "a fully concrete term must not be flagged");
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/init/GenericSortInProblemTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/init/GenericSortInProblemTest.java
@@ -1,0 +1,61 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof.init;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for issue #3409: a generic sort must never occur in a concrete {@code \problem}. The check
+ * is applied at the user-input boundary ({@code KeYUserProblemFile.readProblem}); generic sorts
+ * remain legal inside taclets.
+ */
+class GenericSortInProblemTest {
+
+    private static void load(String dir) throws Exception {
+        Path p = Paths.get(GenericSortInProblemTest.class.getResource(dir).toURI());
+        KeYEnvironment<DefaultUserInterfaceControl> env =
+            KeYEnvironment.load(p, null, null, null);
+        env.dispose();
+    }
+
+    /** A constant of generic sort used in the problem term must be rejected. */
+    @Test
+    void genericSortInProblemIsRejected() {
+        ProblemLoaderException ex = assertThrows(ProblemLoaderException.class,
+            () -> load("genericProblem/genericConst.key"));
+        String msg = collectMessages(ex);
+        assertTrue(msg.contains("generic sort") && msg.contains("'S'"),
+            "expected a clear 'generic sort S' rejection, got: " + msg);
+        assertTrue(msg.contains("\\problem") || msg.contains("problem"),
+            "message should mention the problem context, got: " + msg);
+    }
+
+    /**
+     * A generic sort that is merely declared but does not appear in the problem term must still
+     * load (only the leak into the sequent is illegal).
+     */
+    @Test
+    void genericSortDeclaredButUnusedStillLoads() {
+        assertDoesNotThrow(() -> load("genericProblem/genericDeclaredOnly.key"));
+    }
+
+    private static String collectMessages(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable c = t; c != null && c != c.getCause(); c = c.getCause()) {
+            sb.append(c.getMessage()).append(" | ");
+        }
+        return sb.toString();
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/init/GenericSortInProblemTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/init/GenericSortInProblemTest.java
@@ -5,10 +5,13 @@ package de.uka.ilkd.key.proof.init;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
 import de.uka.ilkd.key.control.KeYEnvironment;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+import de.uka.ilkd.key.speclang.PositionedString;
+import de.uka.ilkd.key.util.ExceptionTools;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +52,23 @@ class GenericSortInProblemTest {
     @Test
     void genericSortDeclaredButUnusedStillLoads() {
         assertDoesNotThrow(() -> load("genericProblem/genericDeclaredOnly.key"));
+    }
+
+    /**
+     * Issue #3409 + reviewer feedback: a problem with several generic sorts must report all of them
+     * (not only the first), each as its own entry, through the shared
+     * {@link ExceptionTools#getMessages} extraction that both the GUI {@code IssueDialog} and the
+     * console rely on.
+     */
+    @Test
+    void allGenericSortsInProblemAreReported() {
+        ProblemLoaderException ex = assertThrows(ProblemLoaderException.class,
+            () -> load("genericProblem/genericTwoConsts.key"));
+        List<PositionedString> msgs = ExceptionTools.getMessages(ex);
+        assertTrue(msgs.stream().anyMatch(m -> m.getText().contains("'S'")),
+            "the generic sort S must be reported, got: " + msgs);
+        assertTrue(msgs.stream().anyMatch(m -> m.getText().contains("'T'")),
+            "the generic sort T must be reported as well (not just the first), got: " + msgs);
     }
 
     private static String collectMessages(Throwable t) {

--- a/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericConst.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericConst.key
@@ -1,0 +1,5 @@
+\sorts { \generic S; }
+
+\functions { S c; }
+
+\problem { c = c }

--- a/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericDeclaredOnly.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericDeclaredOnly.key
@@ -1,0 +1,5 @@
+\sorts { \generic S; }
+
+\functions { int g; }
+
+\problem { g = g }

--- a/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericTwoConsts.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/proof/init/genericProblem/genericTwoConsts.key
@@ -1,0 +1,5 @@
+\sorts { \generic S; \generic T; }
+
+\functions { S c; T d; }
+
+\problem { c = c & d = d }


### PR DESCRIPTION
## Related Issue

This pull request resolves #3409.

## Intended Change

A generic sort is a schematic placeholder for taclets and must never occur in a concrete sequent.
Previously such input was accepted silently. This PR rejects generic sorts at the **user-input /
parser boundaries**, with a clear, positioned message, e.g.:

> The generic sort 'S' must not occur in a \problem. Generic sorts may only be used in taclets.

### Design — a single place for user-input checks

Rather than inlining the check at each parser boundary, the validations are centralized:

- `GenericSortDetector` — low-level walker for `GenericSort` occurrences (subterm sorts + bound
  variables).
- `UserInputValidator` — a small **registry of checks** applied to terms/sequents that originate
  from user input. New checks are added in one place (`CHECKS`); each boundary just calls
  `validate(...)` and raises its own natural, positioned exception with the returned message.

Because the validator is only invoked at user-input boundaries, **every registered check is
automatically scoped to user input** — automatic term creation never runs them, so there is no
proof-search overhead. This is the intended extension
point for future user-only checks (e.g. a stricter well-typedness check): add one `Check`, touch no
boundary. The check is deliberately **not** wired into term construction or automatic proof search,
where a generic-sort leak would be an implementation error to be found by other means.

Boundaries wired up in this PR:
- **`\problem` sections** — `KeYUserProblemFile.readProblem` (e.g. a constant `S c;` with
  `\generic S` used in the problem term).
- **JML translation** — `JmlIO.interpret` (the single funnel for all JML term translation).
- **Interactive taclet instantiation** — `TacletFindModel.parseTerm` (user-entered instantiation
  text), reported via the usual `SVInstantiationParserException` with position.

Notes:
- The originally reported example (`boolean S::test(int)`) is no longer reproducible as a broken
  sequent — it collapses to a concrete function. The genuine remaining leak is a symbol *of*
  generic sort in the term, which this PR addresses.
- Bound variables of generic sort were already rejected elsewhere ("Cannot have logic variable of
  generic sort!").
- Generic sorts remain legal in taclets; taclet soundness POs are loaded via a different path and
  are unaffected.
- **Not included (deliberately):** a check in the proof replayer (`IntermediateProofReplayer`).
  A replayed instantiation can only reference a generic sort if that sort is in the proof's
  namespace; for ordinary proofs generic sorts are erased (and a tampered file declaring one is
  caught at the `\problem` boundary above), whereas for taclet soundness POs they might be *legitimately* (did not investigate further for this PR) in scope. A replayer check would therefore only fire on the legitimate taclet-PO case, so it was
  dropped.

## Plan

* [x] Detect + reject generic sorts in `\problem` (this PR)
* [x] Apply the same check to JML translation (this PR)
* [x] Apply the same check to interactive taclet instantiation (this PR)

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality (`GenericSortInProblemTest`,
  `GenericSortDetectorTest`).
- I have tested the feature as follows: ran the new tests (leak rejected at the problem boundary;
  detector unit-tested; declared-but-unused generic sort still loads), and the regression suites
  `:key.core:testRAP -PrapForks=10` (673 tests, incl. the legitimate generic/polymorphic examples
  `pseq.key`, `dt_polymorphic.proof`) and `:key.core:testProveRules` (203 taclet soundness proofs)
  — all green, after both the problem and the JML hooks.
- I have checked that runtime performance has not deteriorated (no check added to term creation or
  automatic proof search).

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

PR has been created with AI tooling support
