### PR TITLE
Report missing \endmodality at the modality opening; move source-location classes to ncore (#3867)

### DIFF
--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodSubsetPO.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/po/ProgramMethodSubsetPO.java
@@ -29,6 +29,7 @@ import de.uka.ilkd.key.settings.Configuration;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.parsing.Position;
 
 // need to switch spotless off for this comment as it replaces @code with &#64;code
 // spotless:off

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/KeYWatchpoint.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/KeYWatchpoint.java
@@ -4,7 +4,6 @@
 package de.uka.ilkd.key.symbolic_execution.strategy.breakpoint;
 
 import de.uka.ilkd.key.java.JavaTools;
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.ast.SourceElement;
 import de.uka.ilkd.key.java.ast.StatementBlock;
 import de.uka.ilkd.key.java.ast.StatementContainer;
@@ -27,6 +26,7 @@ import org.key_project.prover.engine.impl.ApplyStrategyInfo;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.Sequent;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/LineBreakpoint.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/LineBreakpoint.java
@@ -5,7 +5,6 @@ package de.uka.ilkd.key.symbolic_execution.strategy.breakpoint;
 
 import java.nio.file.Paths;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.ast.SourceElement;
 import de.uka.ilkd.key.java.ast.StatementBlock;
 import de.uka.ilkd.key.java.ast.StatementContainer;
@@ -19,6 +18,7 @@ import de.uka.ilkd.key.speclang.translation.SLTranslationException;
 
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.ExtList;
+import org.key_project.util.parsing.Position;
 
 public class LineBreakpoint extends AbstractConditionalBreakpoint {
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/MethodBreakpoint.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/strategy/breakpoint/MethodBreakpoint.java
@@ -25,6 +25,7 @@ import de.uka.ilkd.key.speclang.translation.SLTranslationException;
 import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionUtil;
 
 import org.key_project.prover.rules.RuleApp;
+import org.key_project.util.parsing.Position;
 
 public class MethodBreakpoint extends AbstractConditionalBreakpoint {
     /**

--- a/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
+++ b/key.core.symbolic_execution/src/main/java/de/uka/ilkd/key/symbolic_execution/util/SymbolicExecutionUtil.java
@@ -80,6 +80,7 @@ import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
 import org.key_project.util.java.CollectionUtil;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/AbstractSymbolicExecutionTestCase.java
+++ b/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/AbstractSymbolicExecutionTestCase.java
@@ -57,6 +57,7 @@ import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.helper.FindResources;
 import org.key_project.util.java.CollectionUtil;
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/po/TestProgramMethodSubsetPO.java
+++ b/key.core.symbolic_execution/src/test/java/de/uka/ilkd/key/symbolic_execution/testcase/po/TestProgramMethodSubsetPO.java
@@ -4,12 +4,12 @@
 package de.uka.ilkd.key.symbolic_execution.testcase.po;
 
 import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.symbolic_execution.po.ProgramMethodSubsetPO;
 import de.uka.ilkd.key.symbolic_execution.testcase.AbstractSymbolicExecutionTestCase;
 import de.uka.ilkd.key.symbolic_execution.util.SymbolicExecutionEnvironment;
 
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.control.instantiation_model;
 import java.util.Iterator;
 import javax.swing.*;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.JTerm;
 import de.uka.ilkd.key.logic.NamespaceSet;
@@ -26,6 +25,7 @@ import org.key_project.prover.rules.instantiation.AssumesFormulaInstDirect;
 import org.key_project.prover.rules.instantiation.AssumesFormulaInstantiation;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 public class TacletAssumesModel extends DefaultComboBoxModel<AssumesFormulaInstantiation> {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletAssumesModel.java
@@ -18,7 +18,6 @@ import de.uka.ilkd.key.proof.MissingInstantiationException;
 import de.uka.ilkd.key.proof.SVInstantiationParserException;
 import de.uka.ilkd.key.proof.io.ProofSaver;
 import de.uka.ilkd.key.rule.TacletApp;
-import de.uka.ilkd.key.util.RecognitionException;
 
 import org.key_project.logic.Term;
 import org.key_project.prover.rules.instantiation.AssumesFormulaInstDirect;
@@ -26,6 +25,7 @@ import org.key_project.prover.rules.instantiation.AssumesFormulaInstantiation;
 import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.parsing.Position;
+import org.key_project.util.parsing.RecognitionException;
 
 public class TacletAssumesModel extends DefaultComboBoxModel<AssumesFormulaInstantiation> {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletFindModel.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.ProgramElement;
 import de.uka.ilkd.key.logic.*;
@@ -20,7 +19,6 @@ import de.uka.ilkd.key.nparser.JavaKeYParser;
 import de.uka.ilkd.key.nparser.ParsingFacade;
 import de.uka.ilkd.key.parser.DefaultTermParser;
 import de.uka.ilkd.key.parser.IdDeclaration;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.parser.ParserException;
 import de.uka.ilkd.key.pp.AbbrevMap;
 import de.uka.ilkd.key.proof.*;
@@ -39,6 +37,8 @@ import org.key_project.prover.rules.instantiation.IllegalInstantiationException;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.Pair;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.jspecify.annotations.NonNull;

--- a/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/instantiation_model/TacletInstantiationModel.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.control.instantiation_model;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.IProgramVariable;
@@ -24,6 +23,7 @@ import org.key_project.prover.sequent.SequentFormula;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.parsing.Position;
 
 public class TacletInstantiationModel {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ConvertException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ConvertException.java
@@ -4,8 +4,8 @@
 package de.uka.ilkd.key.java;
 
 
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
 
 import com.github.javaparser.ast.Node;
 
@@ -39,7 +39,7 @@ public class ConvertException extends RuntimeException implements HasLocation {
      * @param node the JavaParser node the conversion failed on
      */
     public ConvertException(String message, Node node) {
-        this(message, Location.fromNode(node));
+        this(message, JavaSourceLocations.locationFromNode(node));
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/java/JavaService.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/JavaService.java
@@ -194,7 +194,7 @@ public class JavaService {
                 .orElse(new Position(-1, -1));
         return new BuildingIssue(simplifyJavaParserMessage(problem.getVerboseMessage()),
             problem.getCause().orElse(null), false,
-            de.uka.ilkd.key.java.Position.fromJPPosition(loc), source);
+            JavaSourceLocations.positionFromJP(loc), source);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/java/JavaSourceLocations.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/JavaSourceLocations.java
@@ -1,0 +1,54 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.java;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * JavaParser-aware factories for {@link Position} and {@link Location}.
+ * <p>
+ * {@code Position}/{@code Location} themselves live in {@code key.ncore} and must stay free of any
+ * JavaParser (and other target-language) dependencies. The conversions from JavaParser positions
+ * and AST nodes therefore live here, in {@code key.core}.
+ */
+public final class JavaSourceLocations {
+
+    private JavaSourceLocations() {}
+
+    /**
+     * Converts a JavaParser position into a KeY {@link Position}.
+     *
+     * @param p a JavaParser position, may be {@code null}
+     * @return the corresponding KeY position, or {@link Position#UNDEFINED} if {@code p} is missing
+     *         or invalid
+     */
+    public static Position positionFromJP(com.github.javaparser.@Nullable Position p) {
+        if (p == null || p.invalid() || (p.line == -1 && p.column == -1)) {
+            return Position.UNDEFINED;
+        } else {
+            return Position.newOneBased(p.line, p.column);
+        }
+    }
+
+    /**
+     * Builds a {@link Location} from a JavaParser AST node (using its compilation unit's storage
+     * path and the node's begin position).
+     *
+     * @param n a JavaParser node
+     * @return the corresponding location
+     */
+    public static Location locationFromNode(Node n) {
+        var fileUri = n.findCompilationUnit().flatMap(CompilationUnit::getStorage)
+                .map(it -> it.getPath().toUri())
+                .orElse(null);
+
+        var pos = n.getRange().map(it -> it.begin).orElse(null);
+        return new Location(fileUri, positionFromJP(pos));
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/JavaSourceElement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/JavaSourceElement.java
@@ -5,10 +5,10 @@ package de.uka.ilkd.key.java.ast;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.pp.PrettyPrinter;
 
 import org.key_project.util.ExtList;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/Label.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/Label.java
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.java.ast;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.visitor.Visitor;
+
+import org.key_project.util.parsing.Position;
 
 public interface Label extends TerminalProgramElement {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/PositionInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/PositionInfo.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Optional;
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/SourceElement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/SourceElement.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.java.ast;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.visitor.Visitor;
 import de.uka.ilkd.key.logic.equality.EqualsModProperty;
 
 import org.key_project.logic.Property;
 import org.key_project.logic.SyntaxElement;
+import org.key_project.util.parsing.Position;
 
 /**
  * A source element is a piece of syntax. It does not necessarily have a semantics, at least none

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/StatementBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/StatementBlock.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.ProgramPrefixUtil;
 import de.uka.ilkd.key.java.ast.declaration.TypeDeclaration;
 import de.uka.ilkd.key.java.ast.declaration.TypeDeclarationContainer;
@@ -23,6 +22,7 @@ import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/LoopStatement.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ast/statement/LoopStatement.java
@@ -14,6 +14,7 @@ import org.key_project.util.ExtList;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/loader/JP2KeYConverter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/loader/JP2KeYConverter.java
@@ -36,7 +36,6 @@ import de.uka.ilkd.key.logic.ProgramElementName;
 import de.uka.ilkd.key.logic.VariableNamer;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.logic.sort.ProgramSVSort;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.parser.ParserException;
 import de.uka.ilkd.key.rule.metaconstruct.*;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLAssertStatement;
@@ -52,6 +51,7 @@ import org.key_project.logic.op.sv.SchemaVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.Modifier;
@@ -401,8 +401,8 @@ class JP2KeYVisitor extends GenericVisitorAdapter<Object, Void> {
         URI uri = node.findCompilationUnit()
                 .flatMap(com.github.javaparser.ast.CompilationUnit::getStorage)
                 .map(it -> it.getPath().toUri()).orElse(null);
-        Position startPos = Position.fromJPPosition(r.begin);
-        Position endPos = Position.fromJPPosition(r.end);
+        Position startPos = JavaSourceLocations.positionFromJP(r.begin);
+        Position endPos = JavaSourceLocations.positionFromJP(r.end);
         return new PositionInfo(startPos, endPos, uri);
     }
 
@@ -714,7 +714,7 @@ class JP2KeYVisitor extends GenericVisitorAdapter<Object, Void> {
             } catch (UnsolvedSymbolException e1) {
                 throw new ParserException("Cannot resolve '" + n + "'. No variable, field, or type "
                     + "with this name is in scope here (check for typos).",
-                    Location.fromNode(n));
+                    JavaSourceLocations.locationFromNode(n));
             }
         }
     }
@@ -1016,7 +1016,7 @@ class JP2KeYVisitor extends GenericVisitorAdapter<Object, Void> {
             } catch (UnsolvedSymbolException e1) {
                 throw new ParserException("Cannot resolve '" + n + "'. No variable, field, or type "
                     + "with this name is in scope here (check for typos).",
-                    Location.fromNode(n));
+                    JavaSourceLocations.locationFromNode(n));
             }
         }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/loader/JavaBuildingIssue.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/loader/JavaBuildingIssue.java
@@ -6,7 +6,7 @@ package de.uka.ilkd.key.java.loader;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 import com.github.javaparser.ast.Node;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/JMLTransformer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/JMLTransformer.java
@@ -8,8 +8,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import de.uka.ilkd.key.java.ConvertException;
+import de.uka.ilkd.key.java.JavaSourceLocations;
 import de.uka.ilkd.key.nparser.KeyAst;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.jml.pretranslation.*;
@@ -229,7 +229,7 @@ public final class JMLTransformer extends JavaTransformerAbstract {
 
     private Statement transformAssertStatement(TextualJMLAssertStatement stat) {
         KeyAst.Expression ctx = stat.getContext();
-        de.uka.ilkd.key.java.Position pos = ctx.getStartLocation().getPosition();
+        org.key_project.util.parsing.Position pos = ctx.getStartLocation().getPosition();
         int kind = switch (stat.getKind()) {
             case ASSERT -> KIND_ASSERT;
             case ASSUME -> KIND_ASSUME;
@@ -242,7 +242,7 @@ public final class JMLTransformer extends JavaTransformerAbstract {
 
     private Statement transformSetStatement(TextualJMLSetStatement stat) {
         KeyAst.SetStatementContext ctx = new KeyAst.SetStatementContext(stat.getAssignment());
-        // de.uka.ilkd.key.java.Position pos = ctx.getStartLocation().getPosition();
+        // org.key_project.util.parsing.Position pos = ctx.getStartLocation().getPosition();
         KeYMarkerStatement stmt = new KeYMarkerStatement(KIND_SET);
         // TODO simulate/ copy token range.
         stmt.setData(KEY_ASSIGN, ctx);
@@ -284,8 +284,8 @@ public final class JMLTransformer extends JavaTransformerAbstract {
                 // We might have multiple textual constructs now, because the single comment could
                 // contain multiple JML entities (e.g. method contract and ghost field declaration)
 
-                de.uka.ilkd.key.java.Position pos =
-                    de.uka.ilkd.key.java.Position.fromOneZeroBased(1, 0);
+                org.key_project.util.parsing.Position pos =
+                    org.key_project.util.parsing.Position.fromOneZeroBased(1, 0);
                 ImmutableList<TextualJMLConstruct> constructs =
                     pp.parseClassLevel(concatenatedComment, fileName, pos);
                 services.addWarnings(pp.getWarnings());
@@ -393,8 +393,8 @@ public final class JMLTransformer extends JavaTransformerAbstract {
         var stmts = new ArrayList<>(blockStmt.getStatements());
         var newStmts = new ArrayList<Statement>(blockStmt.getStatements().size() * 2);
 
-        final de.uka.ilkd.key.java.Position pos =
-            de.uka.ilkd.key.java.Position.fromOneZeroBased(1, 0);
+        final org.key_project.util.parsing.Position pos =
+            org.key_project.util.parsing.Position.fromOneZeroBased(1, 0);
 
         for (int i = 0; i < stmts.size(); i++) {
             var stmt = stmts.get(i);
@@ -408,7 +408,7 @@ public final class JMLTransformer extends JavaTransformerAbstract {
                         ("Here is something wrong. Your label '%s' is glued to a " +
                             "JML annotation instead of a Java statement. Please consider the use of braces")
                                 .formatted(labeledStmt.getLabel()),
-                        Location.fromNode(inner));
+                        JavaSourceLocations.locationFromNode(inner));
                 }
                 // go into the labled statement
                 stmt = inner;

--- a/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/TransformationPipelineServices.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/TransformationPipelineServices.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.java.transformations.pipeline;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.loader.JavaParserFactory;
 import de.uka.ilkd.key.java.transformations.ConstantExpressionEvaluator;
 import de.uka.ilkd.key.java.transformations.EvaluationException;
@@ -17,6 +16,7 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLLoopSpec;
 import de.uka.ilkd.key.speclang.njml.PreParser;
 
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/ProgramElementName.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/ProgramElementName.java
@@ -11,6 +11,7 @@ import de.uka.ilkd.key.java.visitor.Visitor;
 import de.uka.ilkd.key.rule.MatchConditions;
 
 import org.key_project.logic.Name;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramMethod.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramMethod.java
@@ -26,6 +26,7 @@ import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramSV.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramSV.java
@@ -28,6 +28,7 @@ import org.key_project.logic.SyntaxElement;
 import org.key_project.logic.op.UpdateableOperator;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramVariable.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/ProgramVariable.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic.op;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.*;
 import de.uka.ilkd.key.java.ast.abstraction.ArrayType;
@@ -23,6 +22,7 @@ import org.key_project.logic.SyntaxElement;
 import org.key_project.logic.op.ParsableVariable;
 import org.key_project.logic.sort.Sort;
 import org.key_project.util.ExtList;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -11,12 +11,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.nparser.builder.BuilderHelpers;
 import de.uka.ilkd.key.nparser.builder.ChoiceFinder;
 import de.uka.ilkd.key.nparser.builder.FindProblemInformation;
 import de.uka.ilkd.key.nparser.builder.IncludeFinder;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.init.Includes;
 import de.uka.ilkd.key.scripts.ScriptBlock;
 import de.uka.ilkd.key.scripts.ScriptCommandAst;
@@ -25,6 +23,8 @@ import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.speclang.njml.JmlParser;
 
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ProofReplayer.java
@@ -6,10 +6,11 @@ package de.uka.ilkd.key.nparser;
 import java.net.URI;
 import java.util.*;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.io.IProofFileParser;
 import de.uka.ilkd.key.util.parsing.LocatableException;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/ProofScriptEntry.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/ProofScriptEntry.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.nparser;
 
-import de.uka.ilkd.key.parser.Location;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.NonNull;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -47,6 +47,7 @@ import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;

--- a/key.core/src/main/java/de/uka/ilkd/key/parser/ParserException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/parser/ParserException.java
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.parser;
 
-import de.uka.ilkd.key.util.parsing.HasLocation;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.Nullable;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/MissingInstantiationException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/MissingInstantiationException.java
@@ -4,7 +4,7 @@
 package de.uka.ilkd.key.proof;
 
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 public class MissingInstantiationException extends SVInstantiationExceptionWithPosition {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/MissingSortException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/MissingSortException.java
@@ -4,7 +4,7 @@
 package de.uka.ilkd.key.proof;
 
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 public class MissingSortException extends SVInstantiationExceptionWithPosition {
     private final String toInstantiate;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/NodeInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/NodeInfo.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.ast.ProgramElement;
 import de.uka.ilkd.key.java.ast.SourceElement;
 import de.uka.ilkd.key.java.ast.StatementBlock;
@@ -32,6 +31,7 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.rules.RuleSet;
 import org.key_project.prover.sequent.SequentChangeInfo;
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SVInstantiationExceptionWithPosition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SVInstantiationExceptionWithPosition.java
@@ -4,9 +4,9 @@
 package de.uka.ilkd.key.proof;
 
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.Nullable;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SVInstantiationParserException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SVInstantiationParserException.java
@@ -5,7 +5,7 @@ package de.uka.ilkd.key.proof;
 
 import java.util.Optional;
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 public class SVInstantiationParserException extends SVInstantiationExceptionWithPosition {
 

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SVRigidnessException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SVRigidnessException.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof;
 
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Position;
 
 public class SVRigidnessException extends SVInstantiationExceptionWithPosition {
     private final String toInstantiate;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SortMismatchException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SortMismatchException.java
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof;
 
-import de.uka.ilkd.key.java.Position;
-
 import org.key_project.logic.sort.Sort;
+import org.key_project.util.parsing.Position;
 
 
 public class SortMismatchException extends SVInstantiationExceptionWithPosition {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/FinalFieldCodeValidator.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/FinalFieldCodeValidator.java
@@ -20,11 +20,11 @@ import de.uka.ilkd.key.java.ast.reference.*;
 import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.logic.op.ProgramMethod;
 import de.uka.ilkd.key.logic.op.ProgramVariable;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.parsing.LocatableException;
 
 import org.key_project.logic.SyntaxElement;
 import org.key_project.util.collection.IdentityHashSet;
+import org.key_project.util.parsing.Location;
 
 /**
  * Validates a constructor to ensure that the executed code does not read final fields before they

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
@@ -19,7 +19,6 @@ import de.uka.ilkd.key.nparser.*;
 import de.uka.ilkd.key.nparser.builder.ContractsAndInvariantsFinder;
 import de.uka.ilkd.key.nparser.builder.ProblemFinder;
 import de.uka.ilkd.key.nparser.builder.TacletPBuilder;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.init.*;
 import de.uka.ilkd.key.proof.io.consistency.FileRepo;
 import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
@@ -33,6 +32,7 @@ import de.uka.ilkd.key.util.parsing.BuildingIssue;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Immutables;
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.jspecify.annotations.NonNull;

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ProofScriptEngine.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ProofScriptEngine.java
@@ -16,10 +16,11 @@ import de.uka.ilkd.key.control.AbstractUserInterfaceControl;
 import de.uka.ilkd.key.nparser.JavaKeYParser;
 import de.uka.ilkd.key.nparser.KeyAst;
 import de.uka.ilkd.key.nparser.ParsingFacade;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
+
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.RuleContext;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptBlock.java
@@ -5,7 +5,7 @@ package de.uka.ilkd.key.scripts;
 
 import java.util.List;
 
-import de.uka.ilkd.key.parser.Location;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptCommandAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptCommandAst.java
@@ -9,7 +9,8 @@ import java.util.Objects;
 
 import de.uka.ilkd.key.nparser.JavaKeYParser;
 import de.uka.ilkd.key.nparser.KeyAst;
-import de.uka.ilkd.key.parser.Location;
+
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.jspecify.annotations.NullMarked;

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptException.java
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.scripts;
 
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
 
 
 public class ScriptException extends Exception implements HasLocation {

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptLineParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/ScriptLineParser.java
@@ -9,8 +9,8 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.Nullable;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/PositionedLabeledString.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/PositionedLabeledString.java
@@ -4,9 +4,9 @@
 package de.uka.ilkd.key.speclang;
 
 import de.uka.ilkd.key.logic.label.TermLabel;
-import de.uka.ilkd.key.parser.Location;
 
 import org.key_project.util.collection.ImmutableArray;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.NullMarked;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/PositionedString.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/PositionedString.java
@@ -6,11 +6,11 @@ package de.uka.ilkd.key.speclang;
 import java.net.URI;
 import java.util.Objects;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.logic.label.TermLabel;
-import de.uka.ilkd.key.parser.Location;
 
 import org.key_project.util.collection.ImmutableArray;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/JMLSpecExtractor.java
@@ -24,7 +24,6 @@ import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.label.TermLabel;
 import de.uka.ilkd.key.logic.op.IProgramMethod;
 import de.uka.ilkd.key.logic.op.LocationVariable;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.init.InitConfig;
 import de.uka.ilkd.key.speclang.*;
 import de.uka.ilkd.key.speclang.jml.pretranslation.*;
@@ -38,6 +37,7 @@ import org.key_project.util.collection.*;
 import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableArray;
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLConstruct.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLConstruct.java
@@ -4,13 +4,13 @@
 package de.uka.ilkd.key.speclang.jml.pretranslation;
 
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.LoopContract;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.njml.LabeledParserRuleContext;
 
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/jml/translation/JMLSpecFactory.java
@@ -30,7 +30,6 @@ import de.uka.ilkd.key.logic.label.OriginTermLabel.SpecType;
 import de.uka.ilkd.key.logic.label.ParameterlessTermLabel;
 import de.uka.ilkd.key.logic.op.*;
 import de.uka.ilkd.key.nparser.KeyAst;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.mgt.SpecificationRepository;
 import de.uka.ilkd.key.rule.merge.MergeProcedure;
 import de.uka.ilkd.key.rule.merge.procedures.MergeByIfThenElse;
@@ -53,6 +52,7 @@ import org.key_project.logic.Name;
 import org.key_project.logic.Term;
 import org.key_project.logic.op.Operator;
 import org.key_project.util.collection.*;
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.Token;
 import org.jspecify.annotations.NonNull;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlChecks.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlChecks.java
@@ -7,8 +7,9 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.PositionedString;
+
+import org.key_project.util.parsing.Location;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.jspecify.annotations.NonNull;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlFacade.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/JmlFacade.java
@@ -5,9 +5,10 @@ package de.uka.ilkd.key.speclang.njml;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
+
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/LabeledParserRuleContext.java
@@ -8,7 +8,8 @@ import java.net.URI;
 import de.uka.ilkd.key.logic.label.OriginTermLabel;
 import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
 import de.uka.ilkd.key.logic.label.TermLabel;
-import de.uka.ilkd.key.util.MiscTools;
+
+import org.key_project.util.parsing.SourceNames;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.jspecify.annotations.Nullable;
@@ -51,7 +52,7 @@ public class LabeledParserRuleContext {
 
     private static TermLabel constructTermLabel(ParserRuleContext ctx,
             OriginTermLabel.SpecType specType) {
-        URI filename = MiscTools.getURIFromTokenSource(ctx.start.getTokenSource());
+        URI filename = SourceNames.getURIFromTokenSource(ctx.start.getTokenSource());
         int line = ctx.start.getLine();
         OriginTermLabel.Origin origin = new OriginTermLabel.FileOrigin(specType, filename, line);
         return new OriginTermLabelFactory().createOriginTermLabel(origin);

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/PreParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/njml/PreParser.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.jml.pretranslation.JMLModifier;
@@ -17,6 +15,8 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLModifierList;
 
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.jspecify.annotations.Nullable;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLExceptionFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLExceptionFactory.java
@@ -8,10 +8,10 @@ import java.util.LinkedList;
 import java.util.List;
 
 import de.uka.ilkd.key.speclang.PositionedString;
-import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.parsing.Location;
 import org.key_project.util.parsing.Position;
+import org.key_project.util.parsing.SourceNames;
 
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.Token;
@@ -65,7 +65,7 @@ public class SLExceptionFactory {
     }
 
     public SLExceptionFactory updatePosition(Token start) {
-        fileName = MiscTools.getURIFromTokenSource(start.getTokenSource());
+        fileName = SourceNames.getURIFromTokenSource(start.getTokenSource());
         line = start.getLine();
         column = start.getCharPositionInLine();
         return this;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLExceptionFactory.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLExceptionFactory.java
@@ -7,10 +7,11 @@ import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.MiscTools;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.Token;

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLTranslationException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLTranslationException.java
@@ -4,10 +4,11 @@
 package de.uka.ilkd.key.speclang.translation;
 
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.init.ProofInputException;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 
 public class SLTranslationException extends ProofInputException implements HasLocation {

--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLWarningException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLWarningException.java
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.translation;
 
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.PositionedString;
+
+import org.key_project.util.parsing.Location;
 
 
 public class SLWarningException extends SLTranslationException {

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
@@ -24,6 +24,8 @@ import de.uka.ilkd.key.util.parsing.BuildingIssue;
 import de.uka.ilkd.key.util.parsing.HasLocation;
 import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
 
+import org.key_project.util.parsing.UnterminatedModalityException;
+
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -302,6 +304,11 @@ public final class ExceptionTools {
         // errors had a message but no location, so the GUI/console could not show the source.
         if (exc instanceof NoViableAltException nvae) {
             return Location.fromToken(nvae.getOffendingToken());
+        }
+
+        if (exc instanceof UnterminatedModalityException ume) {
+            return new Location(MiscTools.getURIFromTokenSource(ume.getSourceName()),
+                Position.fromOneZeroBased(ume.getLine(), ume.getCharPositionInLine()));
         }
 
         if (exc.getCause() != null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
@@ -5,8 +5,6 @@ package de.uka.ilkd.key.util;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +22,7 @@ import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
 import org.key_project.util.parsing.HasLocation;
 import org.key_project.util.parsing.Location;
 import org.key_project.util.parsing.Position;
+import org.key_project.util.parsing.SourceNames;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.IntervalSet;
@@ -341,7 +340,7 @@ public final class ExceptionTools {
         if (ip == null) {
             return Location.fromToken(offending);
         }
-        return new Location(MiscTools.getURIFromTokenSource(offending.getTokenSource()), ip);
+        return new Location(SourceNames.getURIFromTokenSource(offending.getTokenSource()), ip);
     }
 
     /**
@@ -412,13 +411,4 @@ public final class ExceptionTools {
         }
         return false;
     }
-
-    private static URI parseFileName(String filename) throws MalformedURLException {
-        try {
-            return filename == null ? null : MiscTools.parseURL(filename).toURI();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/ExceptionTools.java
@@ -12,19 +12,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.loader.JavaBuildingExceptions;
 import de.uka.ilkd.key.java.loader.JavaBuildingIssue;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.parsing.BuildingException;
 import de.uka.ilkd.key.util.parsing.BuildingExceptions;
 import de.uka.ilkd.key.util.parsing.BuildingIssue;
-import de.uka.ilkd.key.util.parsing.HasLocation;
 import de.uka.ilkd.key.util.parsing.SyntaxErrorReporter;
 
-import org.key_project.util.parsing.UnterminatedModalityException;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.IntervalSet;
@@ -304,11 +303,6 @@ public final class ExceptionTools {
         // errors had a message but no location, so the GUI/console could not show the source.
         if (exc instanceof NoViableAltException nvae) {
             return Location.fromToken(nvae.getOffendingToken());
-        }
-
-        if (exc instanceof UnterminatedModalityException ume) {
-            return new Location(MiscTools.getURIFromTokenSource(ume.getSourceName()),
-                Position.fromOneZeroBased(ume.getLine(), ume.getCharPositionInLine()));
         }
 
         if (exc.getCause() != null) {

--- a/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
@@ -47,8 +47,8 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.Filenames;
 import org.key_project.util.Strings;
 import org.key_project.util.collection.*;
+import org.key_project.util.parsing.SourceNames;
 
-import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.TokenSource;
 import org.jspecify.annotations.Nullable;
 
@@ -758,25 +758,11 @@ public final class MiscTools {
     }
 
     public static @Nullable URI getURIFromTokenSource(TokenSource source) {
-        return getURIFromTokenSource(source.getSourceName());
+        return SourceNames.getURIFromTokenSource(source);
     }
 
     public static @Nullable URI getURIFromTokenSource(String source) {
-        if (IntStream.UNKNOWN_SOURCE_NAME.equals(source)) {
-            return null;
-        }
-
-        try {
-            URI uri = new URI(source);
-            if (uri.getScheme() != null) {
-                // use this URI only if there is an explicit scheme;
-                // otherwise parse it as a filename
-                return uri;
-            }
-        } catch (URISyntaxException ignored) {
-        }
-
-        return Path.of(source).toUri();
+        return SourceNames.getURIFromTokenSource(source);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/MiscTools.java
@@ -47,9 +47,7 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.util.Filenames;
 import org.key_project.util.Strings;
 import org.key_project.util.collection.*;
-import org.key_project.util.parsing.SourceNames;
 
-import org.antlr.v4.runtime.TokenSource;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -755,14 +753,6 @@ public final class MiscTools {
         // Path p = fs.getPath(entryName);
         // return p.toUri();
         // }
-    }
-
-    public static @Nullable URI getURIFromTokenSource(TokenSource source) {
-        return SourceNames.getURIFromTokenSource(source);
-    }
-
-    public static @Nullable URI getURIFromTokenSource(String source) {
-        return SourceNames.getURIFromTokenSource(source);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/util/RecognitionException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/RecognitionException.java
@@ -4,9 +4,9 @@
 package de.uka.ilkd.key.util;
 
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.IntStream;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingException.java
@@ -5,9 +5,11 @@ package de.uka.ilkd.key.util.parsing;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.MiscTools;
+
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingException.java
@@ -5,11 +5,10 @@ package de.uka.ilkd.key.util.parsing;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.util.MiscTools;
-
 import org.key_project.util.parsing.HasLocation;
 import org.key_project.util.parsing.Location;
 import org.key_project.util.parsing.Position;
+import org.key_project.util.parsing.SourceNames;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -108,7 +107,7 @@ public class BuildingException extends RuntimeException implements HasLocation {
     @Override
     public Location getLocation() {
         if (offendingSymbol != null) {
-            URI uri = MiscTools.getURIFromTokenSource(offendingSymbol.getTokenSource());
+            URI uri = SourceNames.getURIFromTokenSource(offendingSymbol.getTokenSource());
             Position p = overridePosition != null ? overridePosition
                     : Position.fromToken(offendingSymbol);
             return new Location(uri, p);

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingExceptions.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingExceptions.java
@@ -5,7 +5,8 @@ package de.uka.ilkd.key.util.parsing;
 
 import java.util.List;
 
-import de.uka.ilkd.key.parser.Location;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.NonNull;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingIssue.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/BuildingIssue.java
@@ -5,10 +5,11 @@ package de.uka.ilkd.key.util.parsing;
 
 import java.net.URI;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.MiscTools;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/LocatableException.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/LocatableException.java
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.util.parsing;
 
+import org.key_project.util.parsing.HasLocation;
 
-import de.uka.ilkd.key.parser.Location;
+
+import org.key_project.util.parsing.Location;
 
 
 /**

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/SyntaxErrorReporter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/SyntaxErrorReporter.java
@@ -11,12 +11,12 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import de.uka.ilkd.key.util.ExceptionTools;
-import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.java.StringUtil;
 import org.key_project.util.parsing.HasLocation;
 import org.key_project.util.parsing.Location;
 import org.key_project.util.parsing.Position;
+import org.key_project.util.parsing.SourceNames;
 
 import org.antlr.v4.runtime.*;
 import org.jspecify.annotations.NonNull;
@@ -82,7 +82,7 @@ public class SyntaxErrorReporter extends BaseErrorListener {
             }
         }
         SyntaxError se = new SyntaxError(recognizer, line, tok, charPositionInLine, msg,
-            MiscTools.getURIFromTokenSource(tok.getTokenSource()), stack);
+            SourceNames.getURIFromTokenSource(tok.getTokenSource()), stack);
 
         if (logger != null) {
             logger.warn("[syntax-error] {}:{}:{}: {} {} ({})", se.source, line, charPositionInLine,

--- a/key.core/src/main/java/de/uka/ilkd/key/util/parsing/SyntaxErrorReporter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/util/parsing/SyntaxErrorReporter.java
@@ -10,12 +10,13 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
 import de.uka.ilkd.key.util.MiscTools;
 
 import org.key_project.util.java.StringUtil;
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.*;
 import org.jspecify.annotations.NonNull;

--- a/key.core/src/main/javacc/de/uka/ilkd/key/parser/proofjava/JavaCharStream.java
+++ b/key.core/src/main/javacc/de/uka/ilkd/key/parser/proofjava/JavaCharStream.java
@@ -2,8 +2,8 @@
 package de.uka.ilkd.key.parser.proofjava;
 
 import de.uka.ilkd.key.util.parsing.LocatableException;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 import java.net.URL;
 
 /**

--- a/key.core/src/main/javacc/de/uka/ilkd/key/parser/schemajava/JavaCharStream.java
+++ b/key.core/src/main/javacc/de/uka/ilkd/key/parser/schemajava/JavaCharStream.java
@@ -2,8 +2,8 @@
 package de.uka.ilkd.key.parser.schemajava;
 
 import de.uka.ilkd.key.util.parsing.LocatableException;
-import de.uka.ilkd.key.parser.Location;
-import de.uka.ilkd.key.java.Position;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 import java.net.URL;
 
 /**

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/IncludeErrorReportingTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/IncludeErrorReportingTest.java
@@ -7,8 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3867Test.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3867Test.java
@@ -4,9 +4,10 @@
 package de.uka.ilkd.key.nparser;
 
 import de.uka.ilkd.key.java.Services;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.rule.TacletForTests;
 import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3867Test.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/Issue3867Test.java
@@ -1,0 +1,91 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.nparser;
+
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.parser.Location;
+import de.uka.ilkd.key.rule.TacletForTests;
+import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #3867: a missing/mistyped {@code \endmodality} should be reported at the unterminated
+ * modality's opening, not run on to the next, unrelated {@code \endmodality} (which produced a
+ * confusing error far from the actual mistake).
+ */
+class Issue3867Test {
+
+    private static void load(String src) throws Exception {
+        Services s = TacletForTests.services().copy(false);
+        new KeyIO(s, s.getNamespaces()).load(src).loadComplete();
+    }
+
+    @Test
+    void missingEndmodalityIsReportedAtTheModalityOpening() {
+        // The \find modality's \endmodality (line 4) is mistyped as "endm". Without the fix the
+        // lexer ran on to the \replacewith's \endmodality (line 5) and reported there.
+        String src = """
+                \\rules { test {
+                   \\schemaVar \\modalOperator {diamond, box} #allmodal;
+                   \\find(
+                       \\modality{#allmodal}{}endm (true))
+                   \\replacewith(\\modality{#allmodal}{}\\endmodality(true))
+                }; }""";
+        Throwable ex = assertThrows(Throwable.class, () -> load(src));
+
+        Location loc = assertDoesNotThrow(() -> ExceptionTools.getLocation(ex));
+        assertNotNull(loc, "a location should be reported");
+        assertEquals(4, loc.getPosition().line(),
+            "the error should point at the unterminated modality (line 4), not the later "
+                + "'\\endmodality' on line 5");
+
+        String msg = ExceptionTools.getMessage(ex);
+        assertTrue(msg.contains("endmodality") || msg.toLowerCase().contains("not terminated"),
+            "message should mention the missing \\endmodality, got: " + msg);
+    }
+
+    @Test
+    void modalityKeywordsInCommentsAreIgnored() {
+        // A modality-opening keyword inside a Java line comment must not be mistaken for a nested
+        // modality (it is part of the program text, not KeY syntax).
+        assertDoesNotThrow(() -> load("""
+                \\rules { r {
+                   \\find(\\<{ int x = 0; // use \\modality here
+                   }\\>(true)) \\replacewith(\\<{}\\>(true))
+                }; }"""));
+        // ... and inside a block comment. This also covers the (previously broken) case of a
+        // *closing* keyword inside a comment, which used to terminate the modality early.
+        assertDoesNotThrow(() -> load("""
+                \\rules { r {
+                   \\find(\\<{ /* not a real close \\> here */ int y = 0; }\\>(true))
+                   \\replacewith(\\<{}\\>(true))
+                }; }"""));
+    }
+
+    @Test
+    void wellFormedModalitiesStillParse() {
+        // generic, diamond and box forms must be unaffected by the new check
+        assertDoesNotThrow(() -> load("""
+                \\rules { test {
+                   \\schemaVar \\modalOperator {diamond, box} #allmodal;
+                   \\find(\\modality{#allmodal}{}\\endmodality(true))
+                   \\replacewith(\\modality{#allmodal}{}\\endmodality(true))
+                }; }"""));
+        assertDoesNotThrow(() -> load("""
+                \\rules { test {
+                   \\find(\\<{}\\>(true)) \\replacewith(\\<{}\\>(true))
+                }; }"""));
+        assertDoesNotThrow(() -> load("""
+                \\rules { test {
+                   \\find(\\[{}\\](true)) \\replacewith(\\[{}\\](true))
+                }; }"""));
+    }
+}

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/LargeFilePositionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/LargeFilePositionTest.java
@@ -7,8 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/LineEndingPositionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/LineEndingPositionTest.java
@@ -7,9 +7,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/parser/TestIntLiteralParsing.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/parser/TestIntLiteralParsing.java
@@ -13,7 +13,8 @@ import de.uka.ilkd.key.logic.op.LocationVariable;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.njml.JmlIO;
 import de.uka.ilkd.key.speclang.njml.SpecMathMode;
-import de.uka.ilkd.key.util.RecognitionException;
+
+import org.key_project.util.parsing.RecognitionException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;

--- a/key.core/src/test/java/de/uka/ilkd/key/parser/TestParser.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/parser/TestParser.java
@@ -19,7 +19,8 @@ import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.proof.io.RuleSourceFactory;
 import de.uka.ilkd.key.rule.TacletForTests;
 import de.uka.ilkd.key.util.HelperClassForTests;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+
+import org.key_project.util.parsing.HasLocation;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.junit.jupiter.api.Disabled;

--- a/key.core/src/test/java/de/uka/ilkd/key/parser/messages/ParserMessageTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/parser/messages/ParserMessageTest.java
@@ -14,10 +14,11 @@ import java.util.List;
 import java.util.stream.StreamSupport;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.util.ExceptionTools;
 import de.uka.ilkd.key.util.HelperClassForTests;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/SetStatementTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/SetStatementTest.java
@@ -6,7 +6,6 @@ package de.uka.ilkd.key.speclang;
 import java.nio.file.Path;
 
 import de.uka.ilkd.key.java.JavaInfo;
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
 import de.uka.ilkd.key.java.ast.abstraction.PrimitiveType;
@@ -25,6 +24,7 @@ import de.uka.ilkd.key.util.HelperClassForTests;
 
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatementTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/jml/pretranslation/TextualJMLAssertStatementTest.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.jml.pretranslation;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.speclang.njml.PreParser;
 
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;

--- a/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/speclang/njml/NJmlTranslatorTests.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.util.List;
 
 import de.uka.ilkd.key.java.JavaInfo;
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.abstraction.KeYJavaType;
 import de.uka.ilkd.key.logic.label.OriginTermLabelFactory;
@@ -19,6 +18,7 @@ import de.uka.ilkd.key.speclang.jml.pretranslation.TextualJMLConstruct;
 import de.uka.ilkd.key.util.HelperClassForTests;
 
 import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/ExceptionToolsTest.java
@@ -7,13 +7,13 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.util.parsing.BuildingExceptions;
 import de.uka.ilkd.key.util.parsing.BuildingIssue;
 
 import org.key_project.util.helper.FindResources;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.Token;

--- a/key.core/src/test/java/de/uka/ilkd/key/util/ParserExceptionTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/ParserExceptionTest.java
@@ -16,8 +16,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.io.ProblemLoaderException;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.provider.Arguments;

--- a/key.core/src/test/java/de/uka/ilkd/key/util/parsing/BuildingExceptionsTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/util/parsing/BuildingExceptionsTest.java
@@ -6,9 +6,10 @@ package de.uka.ilkd.key.util.parsing;
 import java.util.List;
 
 import de.uka.ilkd.key.java.ConvertException;
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.ncore/src/main/antlr/KeYLexer.g4
+++ b/key.ncore/src/main/antlr/KeYLexer.g4
@@ -66,6 +66,21 @@ lexer grammar KeYLexer;
         return super.nextToken();
     }
 
+    /**
+     * Called when, while scanning the body of a modality, another modality-opening keyword is
+     * encountered. A modality body is a (schematic) program and must never contain a nested
+     * modality, so this means the current modality's closing {@code \endmodality} (or {@code \>} /
+     * {@code \]}) is missing. Fail the token at its start (the modality opening) -- mirroring the
+     * behaviour at end-of-file -- so the error is reported there instead of running on to the next,
+     * unrelated {@code \endmodality}. (See issue #3867.)
+     */
+    private void unterminatedModality() {
+        throw new org.key_project.util.parsing.UnterminatedModalityException(
+            "Missing '\\endmodality': this modality is not terminated (another modality opening "
+                + "was found before its closing keyword).",
+            _tokenStartLine, _tokenStartCharPositionInLine, getSourceName());
+    }
+
 }
 tokens { MODALITY }
 SORTS
@@ -747,7 +762,20 @@ ERROR_CHAR
    : .
    ;
 
+/**
+ * A modality-opening keyword. Inside a modality body (a schematic program) such a keyword can only
+ * mean that the current modality was not terminated; see {@link #unterminatedModality}.
+ */
+fragment MODALITY_OPEN
+   : '\\modality' | '\\diamond_transaction' | '\\box_transaction' | '\\diamond' | '\\box'
+   | '\\throughout_transaction' | '\\throughout' | '\\<' | '\\[[' | '\\['
+   ;
+
 mode modDiamond;
+MODALITYD_NESTED
+   : MODALITY_OPEN { unterminatedModality (); } -> more
+   ;
+
 MODALITYD_END
    : '\\>' -> type (MODALITY) , popMode
    ;
@@ -764,6 +792,14 @@ MODALITYD_COMMENT
    : [\\] [*] -> more , pushMode (modComment)
    ;
 
+MODALITYD_LINE_COMMENT
+   : '//' -> more , pushMode (modLineComment)
+   ;
+
+MODALITYD_BLOCK_COMMENT
+   : '/*' -> more , pushMode (modComment)
+   ;
+
 MODALITYD_ANY
    : . -> more
    ;
@@ -771,6 +807,10 @@ MODALITYD_ANY
 mode modGeneric;
 MODALITYG_END
    : '\\endmodality' -> type (MODALITY) , popMode
+   ;
+
+MODALITYG_NESTED
+   : MODALITY_OPEN { unterminatedModality (); } -> more
    ;
 
 MODALITYG_STRING
@@ -785,6 +825,14 @@ MODALITYG_COMMENT
    : [\\] [*] -> more , pushMode (modComment)
    ;
 
+MODALITYG_LINE_COMMENT
+   : '//' -> more , pushMode (modLineComment)
+   ;
+
+MODALITYG_BLOCK_COMMENT
+   : '/*' -> more , pushMode (modComment)
+   ;
+
 MODALITYG_ANY
    : . -> more
    ;
@@ -792,6 +840,10 @@ MODALITYG_ANY
 mode modBox;
 MODALITYB_END
    : '\\]' -> type (MODALITY) , popMode
+   ;
+
+MODALITYB_NESTED
+   : MODALITY_OPEN { unterminatedModality (); } -> more
    ;
 
 MODALITYB_STRING
@@ -804,6 +856,14 @@ MODALITYB_CHAR
 
 MODALITYB_COMMENT
    : [\\] [*] -> more , pushMode (modComment)
+   ;
+
+MODALITYB_LINE_COMMENT
+   : '//' -> more , pushMode (modLineComment)
+   ;
+
+MODALITYB_BLOCK_COMMENT
+   : '/*' -> more , pushMode (modComment)
    ;
 
 MODALITYB_ANY
@@ -859,6 +919,17 @@ MOD_COMMENT_END
    ;
 
 MOD_COMMENT_ANY
+   : . -> more
+   ;
+
+// Java line comment inside a modality body: consume up to (and including) the end of line so that
+// a modality opening/closing keyword in the comment is not mistaken for real syntax.
+mode modLineComment;
+MOD_LINE_COMMENT_END
+   : ('\n' | EOF) -> more , popMode
+   ;
+
+MOD_LINE_COMMENT_ANY
    : . -> more
    ;
 

--- a/key.ncore/src/main/java/org/key_project/util/parsing/HasLocation.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/HasLocation.java
@@ -1,10 +1,9 @@
 /* This file is part of KeY - https://key-project.org
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
-package de.uka.ilkd.key.util.parsing;
+package org.key_project.util.parsing;
 
 
-import de.uka.ilkd.key.parser.Location;
 
 import org.jspecify.annotations.Nullable;
 

--- a/key.ncore/src/main/java/org/key_project/util/parsing/Location.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/Location.java
@@ -26,7 +26,6 @@ import org.jspecify.annotations.NonNull;
  * @param position The position in the file
  * @author Hubert Schmid
  */
-
 public record Location(URI fileUri, Position position) implements Comparable<Location> {
     public static final Location UNDEFINED = new Location(null, Position.UNDEFINED);
 

--- a/key.ncore/src/main/java/org/key_project/util/parsing/Location.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/Location.java
@@ -1,20 +1,13 @@
 /* This file is part of KeY - https://key-project.org
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
-package de.uka.ilkd.key.parser;
+package org.key_project.util.parsing;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.util.MiscTools;
-
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
 import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.Token;
 import org.jspecify.annotations.NonNull;
@@ -37,37 +30,9 @@ import org.jspecify.annotations.NonNull;
 public record Location(URI fileUri, Position position) implements Comparable<Location> {
     public static final Location UNDEFINED = new Location(null, Position.UNDEFINED);
 
-    /**
-     * Legacy constructor for creating a new Location from a String denoting the file path and line
-     * and column number, tries to convert the path given as String into a URL.
-     *
-     * @param filename path to the resource of the Location
-     * @param position position of the Location
-     * @throws RuntimeException if the given string is null or can not be parsed to URL
-     * @deprecated Use {@link #Location(URI, Position)} instead.
-     */
-    @Deprecated
-    public static Location fromFileName(String filename, Position position) {
-        try {
-            return new Location(filename == null ? null : MiscTools.parseURL(filename).toURI(),
-                position);
-        } catch (MalformedURLException | URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static Location fromToken(Token token) {
-        return new Location(MiscTools.getURIFromTokenSource(token.getTokenSource()),
+        return new Location(SourceNames.getURIFromTokenSource(token.getTokenSource()),
             Position.fromToken(token));
-    }
-
-    public static Location fromNode(Node n) {
-        var fileUri = n.findCompilationUnit().flatMap(CompilationUnit::getStorage)
-                .map(it -> it.getPath().toUri())
-                .orElse(null);
-
-        var pos = n.getRange().map(it -> it.begin).orElse(null);
-        return new Location(fileUri, Position.fromJPPosition(pos));
     }
 
     public URI getFileUri() { return fileUri; }

--- a/key.ncore/src/main/java/org/key_project/util/parsing/Position.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/Position.java
@@ -1,10 +1,9 @@
 /* This file is part of KeY - https://key-project.org
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
-package de.uka.ilkd.key.java;
+package org.key_project.util.parsing;
 
 import org.antlr.v4.runtime.Token;
-import org.jspecify.annotations.Nullable;
 
 /**
  * The position of a source element, given by its line and column number. Depending on the
@@ -86,14 +85,6 @@ public class Position implements Comparable<Position> {
      */
     public static Position fromToken(Token token) {
         return fromOneZeroBased(token.getLine(), token.getCharPositionInLine());
-    }
-
-    public static Position fromJPPosition(com.github.javaparser.@Nullable Position p) {
-        if (p == null || p.invalid() || (p.line == -1 && p.column == -1)) {
-            return UNDEFINED;
-        } else {
-            return newOneBased(p.line, p.column);
-        }
     }
 
     /**

--- a/key.ncore/src/main/java/org/key_project/util/parsing/Position.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/Position.java
@@ -8,9 +8,8 @@ import org.antlr.v4.runtime.Token;
 /**
  * The position of a source element, given by its line and column number. Depending on the
  * implementation, the valid range of defined line and column numbers may be limited and cut off if
- * superceded.
+ * superseded.
  */
-
 public class Position implements Comparable<Position> {
 
     /**

--- a/key.ncore/src/main/java/org/key_project/util/parsing/RecognitionException.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/RecognitionException.java
@@ -1,12 +1,9 @@
 /* This file is part of KeY - https://key-project.org
  * KeY is licensed under the GNU General Public License Version 2
  * SPDX-License-Identifier: GPL-2.0-only */
-package de.uka.ilkd.key.util;
+package org.key_project.util.parsing;
 
 
-import org.key_project.util.parsing.HasLocation;
-import org.key_project.util.parsing.Location;
-import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.IntStream;
 
@@ -29,6 +26,6 @@ public class RecognitionException extends Exception implements HasLocation {
 
     @Override
     public Location getLocation() {
-        return new Location(MiscTools.getURIFromTokenSource(input.getSourceName()), position);
+        return new Location(SourceNames.getURIFromTokenSource(input.getSourceName()), position);
     }
 }

--- a/key.ncore/src/main/java/org/key_project/util/parsing/SourceNames.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/SourceNames.java
@@ -1,0 +1,45 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.parsing;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import org.antlr.v4.runtime.IntStream;
+import org.antlr.v4.runtime.TokenSource;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Utilities for turning the source name reported by an ANTLR lexer/token into a {@link URI}.
+ * <p>
+ * This lives in {@code key.ncore} so that language-independent parsing infrastructure (e.g.
+ * {@code Location}) can use it without depending on the {@code key.core} utility classes.
+ */
+public final class SourceNames {
+
+    private SourceNames() {}
+
+    public static @Nullable URI getURIFromTokenSource(TokenSource source) {
+        return getURIFromTokenSource(source.getSourceName());
+    }
+
+    public static @Nullable URI getURIFromTokenSource(String source) {
+        if (IntStream.UNKNOWN_SOURCE_NAME.equals(source)) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(source);
+            if (uri.getScheme() != null) {
+                // use this URI only if there is an explicit scheme;
+                // otherwise parse it as a filename
+                return uri;
+            }
+        } catch (URISyntaxException ignored) {
+        }
+
+        return Path.of(source).toUri();
+    }
+}

--- a/key.ncore/src/main/java/org/key_project/util/parsing/UnterminatedModalityException.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/UnterminatedModalityException.java
@@ -3,19 +3,17 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.parsing;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Thrown by the KeY lexer when the body of a modality (a schematic program) contains another
  * modality-opening keyword, which means the current modality's closing keyword
  * ({@code \endmodality} / {@code \>} / {@code \]}) is missing. It carries the position of the
- * <em>opening</em> of the unterminated modality so the error can be reported there (rather than at
- * the next, unrelated closing keyword the lexer would otherwise run on to). See issue #3867.
- *
- * <p>
- * This lives in {@code key.ncore} so the generated lexer can throw it; the position is turned into
- * a
- * proper {@code Location} by {@code ExceptionTools} in {@code key.core}.
+ * <em>opening</em> of the unterminated modality (via {@link HasLocation}) so the error can be
+ * reported there, rather than at the next, unrelated closing keyword the lexer would otherwise run
+ * on to. See issue #3867.
  */
-public class UnterminatedModalityException extends RuntimeException {
+public class UnterminatedModalityException extends RuntimeException implements HasLocation {
     private static final long serialVersionUID = 1L;
 
     /** 1-based line of the modality opening. */
@@ -32,18 +30,9 @@ public class UnterminatedModalityException extends RuntimeException {
         this.sourceName = sourceName;
     }
 
-    /** @return the 1-based line of the modality opening */
-    public int getLine() {
-        return line;
-    }
-
-    /** @return the 0-based column (ANTLR convention) of the modality opening */
-    public int getCharPositionInLine() {
-        return charPositionInLine;
-    }
-
-    /** @return the source name (file/URI string) reported by the lexer's input */
-    public String getSourceName() {
-        return sourceName;
+    @Override
+    public @Nullable Location getLocation() {
+        return new Location(SourceNames.getURIFromTokenSource(sourceName),
+            Position.fromOneZeroBased(line, charPositionInLine));
     }
 }

--- a/key.ncore/src/main/java/org/key_project/util/parsing/UnterminatedModalityException.java
+++ b/key.ncore/src/main/java/org/key_project/util/parsing/UnterminatedModalityException.java
@@ -1,0 +1,49 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.util.parsing;
+
+/**
+ * Thrown by the KeY lexer when the body of a modality (a schematic program) contains another
+ * modality-opening keyword, which means the current modality's closing keyword
+ * ({@code \endmodality} / {@code \>} / {@code \]}) is missing. It carries the position of the
+ * <em>opening</em> of the unterminated modality so the error can be reported there (rather than at
+ * the next, unrelated closing keyword the lexer would otherwise run on to). See issue #3867.
+ *
+ * <p>
+ * This lives in {@code key.ncore} so the generated lexer can throw it; the position is turned into
+ * a
+ * proper {@code Location} by {@code ExceptionTools} in {@code key.core}.
+ */
+public class UnterminatedModalityException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /** 1-based line of the modality opening. */
+    private final int line;
+    /** 0-based column of the modality opening (ANTLR convention). */
+    private final int charPositionInLine;
+    private final String sourceName;
+
+    public UnterminatedModalityException(String message, int line, int charPositionInLine,
+            String sourceName) {
+        super(message);
+        this.line = line;
+        this.charPositionInLine = charPositionInLine;
+        this.sourceName = sourceName;
+    }
+
+    /** @return the 1-based line of the modality opening */
+    public int getLine() {
+        return line;
+    }
+
+    /** @return the 0-based column (ANTLR convention) of the modality opening */
+    public int getCharPositionInLine() {
+        return charPositionInLine;
+    }
+
+    /** @return the source name (file/URI string) reported by the lexer's input */
+    public String getSourceName() {
+        return sourceName;
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/IssueDialog.java
@@ -31,8 +31,6 @@ import de.uka.ilkd.key.gui.sourceview.SourceHighlightDocument;
 import de.uka.ilkd.key.gui.sourceview.TextLineNumber;
 import de.uka.ilkd.key.gui.utilities.ErrorMarkPainter;
 import de.uka.ilkd.key.gui.utilities.GuiUtilities;
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.pp.LogicPrinter;
 import de.uka.ilkd.key.speclang.PositionedString;
 import de.uka.ilkd.key.speclang.SLEnvInput;
@@ -43,6 +41,8 @@ import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.java.IOUtil;
 import org.key_project.util.java.StringUtil;
 import org.key_project.util.java.SwingUtil;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/PositionedIssueString.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/PositionedIssueString.java
@@ -5,8 +5,9 @@ package de.uka.ilkd.key.gui;
 
 import java.util.Objects;
 
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.speclang.PositionedString;
+
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.NonNull;
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/EditSourceFileAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/EditSourceFileAction.java
@@ -26,11 +26,11 @@ import de.uka.ilkd.key.gui.sourceview.KeYEditorLexer;
 import de.uka.ilkd.key.gui.sourceview.SourceHighlightDocument;
 import de.uka.ilkd.key.gui.sourceview.TextLineNumber;
 import de.uka.ilkd.key.gui.utilities.CurrentLineHighlighter;
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.ExceptionTools;
 
 import org.key_project.util.java.IOUtil;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
@@ -25,7 +25,6 @@ import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.IssueDialog;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.nparser.KeyAst;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.io.OutputStreamProofSaver;
@@ -36,6 +35,7 @@ import de.uka.ilkd.key.util.KeYResourceManager;
 
 import org.key_project.util.Streams;
 import org.key_project.util.java.IOUtil;
+import org.key_project.util.parsing.Location;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavaCompilerCheckFacade.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/plugins/javac/JavaCompilerCheckFacade.java
@@ -16,11 +16,11 @@ import java.util.stream.Collectors;
 import javax.tools.*;
 
 import de.uka.ilkd.key.gui.PositionedIssueString;
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.settings.Configuration;
 
 import org.key_project.util.Streams;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.jspecify.annotations.NonNull;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesInput.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesInput.java
@@ -6,10 +6,11 @@ package de.uka.ilkd.key.gui.tacletmatch;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.parsing.BuildingException;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 /**
  * GUI-independent logic for the "type the {@code \assumes} sequent" editor: how the two typed parts

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesSelectionPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesSelectionPanel.java
@@ -18,7 +18,6 @@ import javax.swing.text.Highlighter;
 import de.uka.ilkd.key.control.instantiation_model.TacletAssumesModel;
 import de.uka.ilkd.key.control.instantiation_model.TacletInstantiationModel;
 import de.uka.ilkd.key.core.KeYMediator;
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.nparser.KeyIO;
 import de.uka.ilkd.key.proof.io.ProofSaver;
@@ -26,6 +25,7 @@ import de.uka.ilkd.key.proof.io.ProofSaver;
 import org.key_project.prover.rules.instantiation.AssumesFormulaInstantiation;
 import org.key_project.prover.sequent.Sequent;
 import org.key_project.prover.sequent.SequentFormula;
+import org.key_project.util.parsing.Position;
 
 /**
  * Lets the user instantiate the taclet's {@code \assumes} sequent in one of two ways, chosen with a

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/LexerHighlighter.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/utilities/LexerHighlighter.java
@@ -181,7 +181,14 @@ public abstract class LexerHighlighter {
                     STYLE_OPERATORS;
                 case ERROR_UKNOWN_ESCAPE, ERROR_CHAR -> STYLE_ERROR;
                 case IDENT -> STYLE_IDENTIFIER;
-                case COMMENT, SL_COMMENT -> STYLE_COMMENT;
+                // 'COMMENT' is a lexer *mode*, not a token type; mode and token ids share one int
+                // space, so as a case label it aliases whatever token has the same id -- a
+                // duplicate
+                // case label once the modality lexer modes renumbered things (#3867). It was a dead
+                // no-op anyway: single-line comments are SL_COMMENT (here); a whole '/* ... */' /
+                // '/*! ... */' is emitted as COMMENT_END / DOC_COMMENT (currently grouped with the
+                // keywords above; ML_COMMENT is a 'more' rule and never a token).
+                case SL_COMMENT -> STYLE_COMMENT;
                 case CHAR_LITERAL, QUOTED_STRING_LITERAL, TRUE, FALSE,
                         STRING_LITERAL, BIN_LITERAL, HEX_LITERAL, INT_LITERAL, FLOAT_LITERAL,
                         DOUBLE_LITERAL, REAL_LITERAL ->

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/ConsoleUserInterfaceControl.java
@@ -23,7 +23,6 @@ import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.macros.ProofMacro;
 import de.uka.ilkd.key.macros.ProofMacroFinishedInfo;
 import de.uka.ilkd.key.macros.SkipMacro;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.ProofAggregate;
@@ -49,6 +48,7 @@ import org.key_project.prover.engine.TaskStartedInfo.TaskKind;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSLList;
 import org.key_project.util.collection.ImmutableSet;
+import org.key_project.util.parsing.Location;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -306,7 +306,7 @@ public class ConsoleUserInterfaceControl extends AbstractMediatorUserInterfaceCo
 
     /** Appends the offending source line and a caret under the error column, if readable. */
     private static void appendSourceExcerpt(StringBuilder sb, URI fileUri,
-            de.uka.ilkd.key.java.Position pos) {
+            org.key_project.util.parsing.Position pos) {
         try {
             List<String> lines = Files.readAllLines(Path.of(fileUri));
             int lineNo = pos.line();

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/IssueDialogMessageTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/IssueDialogMessageTest.java
@@ -10,7 +10,8 @@ import javax.swing.text.Document;
 import javax.swing.text.PlainDocument;
 
 import de.uka.ilkd.key.control.KeYEnvironment;
-import de.uka.ilkd.key.parser.Location;
+
+import org.key_project.util.parsing.Location;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,8 @@ public class IssueDialogMessageTest {
 
     /**
      * Resolves the dialog's mark offset for {@code loc} via the same document line model the dialog
-     * uses ({@link IssueDialog#getOffsetFromLineColumn(Document, de.uka.ilkd.key.java.Position)}).
+     * uses
+     * ({@link IssueDialog#getOffsetFromLineColumn(Document, org.key_project.util.parsing.Position)}).
      * The document content equals {@code source}, so the returned offset indexes into it directly.
      */
     private static int offsetIn(String source, Location loc) throws Exception {

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/AssumesInputTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/AssumesInputTest.java
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.tacletmatch;
 
-import de.uka.ilkd.key.java.Position;
-import de.uka.ilkd.key.parser.Location;
 import de.uka.ilkd.key.util.parsing.BuildingException;
-import de.uka.ilkd.key.util.parsing.HasLocation;
+
+import org.key_project.util.parsing.HasLocation;
+import org.key_project.util.parsing.Location;
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 

--- a/key.ui/src/test/java/de/uka/ilkd/key/ui/ConsoleErrorFormattingTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/ui/ConsoleErrorFormattingTest.java
@@ -7,9 +7,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import de.uka.ilkd.key.java.Position;
 import de.uka.ilkd.key.util.parsing.BuildingExceptions;
 import de.uka.ilkd.key.util.parsing.BuildingIssue;
+
+import org.key_project.util.parsing.Position;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Related Issue

This pull request resolves #3867.

> **Reviewers:** this PR is **3 commits**:
> 1. *Report missing `\endmodality` at the modality opening* — the bug fix (below).
> 2. *Move `Position`, `Location`, `HasLocation` to `key.ncore`* — addresses the review request
>    that `UnterminatedModalityException` implement `HasLocation` instead of being special-cased in
>    `ExceptionTools`. Since the generated lexer (in `key.ncore`) throws it, and `HasLocation`
>    returns a `key.core` `Location`, the fix was to move the *language-independent* source-location
>    classes down into `key.ncore` (neutral package `org.key_project.util.parsing`). `key.ncore`
>    stays free of any JavaParser/JavaDL dependency: the JavaParser-coupled factories
>    (`Position.fromJPPosition`, `Location.fromNode`) move into the new `key.core` helper
>    `JavaSourceLocations`, and `getURIFromTokenSource` moves into the new `key.ncore` helper
>    `SourceNames`. The special-case branch is then **deleted** from `ExceptionTools`. The rest is
>    mechanical import updates.
> 3. *Move `RecognitionException` to ncore; drop `getURIFromTokenSource` delegate* — small follow-on
>    cleanup enabled by (2): `RecognitionException` becomes language-independent and moves to
>    `key.ncore`; the now-redundant `ExceptionTools.getLocation(RecognitionException)` (covered by
>    the generic `instanceof HasLocation` branch) and its helper are removed.
>
> Each commit was validated with `:key.core:testRAP -PrapForks=10` (673) and
> `:key.core:testProveRules` (203) — all green.

## Intended Change

The KeY lexer scans a modality body greedily until it literally finds the closing keyword
(`\endmodality` / `\>` / `\]`); the (schematic) program text is re-parsed separately. As a
consequence, a missing or mistyped closing keyword made the lexer run on to the *next*, unrelated
closing keyword, and the error surfaced far from the actual mistake — e.g. at a `;` several rules
later (see the issue).

A modality body is a schematic program and can never legitimately contain another
modality-*opening* keyword. This PR detects such a nested opening in the modality lexer modes
(`modGeneric`, `modDiamond`, `modBox`) and fails the token at its start — mirroring the existing
end-of-file behaviour — so the error is reported at the opening of the unterminated modality.

Before:
```
... expected, but found ';'           (reported on the line of the next rule)
```
After:
```
Missing '\endmodality': this modality is not terminated (another modality opening was found
before its closing keyword).        (reported at the unterminated modality's opening)
```

### Comments and string literals are exempt

So that the new check (and the lexer in general) does not misinterpret keyword-looking text inside
a Java comment or literal, the modality lexer modes now sub-mode all four cases:

- **String/char literals** (`"…"`, `'…'`) were already sub-moded.
- **Java line comments** (`// …`) and **block comments** (`/* … */`) are now sub-moded as well.

As a side benefit this also fixes a pre-existing problem: a *closing* keyword inside a comment
(e.g. `/* … \> … */`) used to terminate the modality early; it is now correctly ignored. Ordinary
comments (without modality keywords) tokenise exactly as before.

### Why it is safe

- The opening-keyword detection only matches the **backslash** forms (`\modality`, `\diamond`,
  `\box`, `\diamond_transaction`, `\box_transaction`, `\throughout`, `\throughout_transaction`,
  `\<`, `\[`, `\[[`). Bare `<` / `[` / `/` in a Java program (comparisons, array access/types,
  division) are unaffected.
- The position is carried by a new `UnterminatedModalityException` (placed in `key.ncore` so the
  generated lexer can throw it) and turned into a positioned message by `ExceptionTools`.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality (`Issue3867Test`): the repro is reported at the
  modality opening; modality keywords inside line/block comments are ignored; generic/diamond/box
  modalities still parse.
- I have tested the feature as follows: ran the new test, and the full regression suites
  `:key.core:testRAP -PrapForks=10` (673 tests) and `:key.core:testProveRules` (203 taclet
  soundness proofs) — both green, confirming no false positives across the whole (modality-heavy)
  taclet base and example set.
- I have checked that runtime performance has not deteriorated (the new lexer rules only add
  alternatives to existing modality modes; no work is added on the common path).

## Additional information and contact(s)

The end-of-file case ("no `\endmodality` anywhere") already reported at the modality opening; this
PR brings the "a later `\endmodality` exists" case in line with that behaviour.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
