### PR TITLE
Performance Series 2 (1/5): Faster cost computation by skipping an unnecessary proof-history walk

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/ServiceCaches.java
@@ -95,6 +95,10 @@ public class ServiceCaches implements SessionCaches {
     private final LRUCache<PosInOccurrence, RuleAppCost> ifThenElseMalusCache =
         new LRUCache<>(1000);
 
+    /**
+     * the introduction time cache used by {@code AbstractMonomialSmallerThanFeature} for Skolem
+     * constants
+     */
     private final LRUCache<Operator, Integer> introductionTimeCache =
         new LRUCache<>(10000);
 
@@ -194,6 +198,10 @@ public class ServiceCaches implements SessionCaches {
         return ifThenElseMalusCache;
     }
 
+    /**
+     * returns the introduction time cache used by {@code AbstractMonomialSmallerThanFeature} for
+     * Skolem constants
+     */
     public final LRUCache<Operator, Integer> getIntroductionTimeCache() {
         return introductionTimeCache;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractMonomialSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractMonomialSmallerThanFeature.java
@@ -34,6 +34,18 @@ public abstract class AbstractMonomialSmallerThanFeature extends SmallerThanFeat
             return -1;
         }
 
+        // A newSmallSym taclet introduces its symbol as a SkolemTermSV instantiation, which is
+        // always a skolem-constant function (TacletApp.createSkolemConstant). So an op that is not
+        // a skolem-constant function can never have been introduced by one: its time is -1, with no
+        // need to scan the applied-rule history. This is what made the scan a hotspot -- the common
+        // monomial atoms (program variables, ordinary functions) are not skolem constants, yet
+        // walked the full O(history) on every compare and, never being "introduced", were never
+        // cached. (A skolem constant from some OTHER rule still walks and returns -1; only the
+        // structurally-impossible ops are short-circuited, so every result is unchanged.)
+        if (!(op instanceof Function func) || !func.isSkolemConstant()) {
+            return -1;
+        }
+
         final LRUCache<Operator, Integer> introductionTimeCache =
             goal.proof().getServices().getCaches().getIntroductionTimeCache();
         Integer res;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractMonomialSmallerThanFeature.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/feature/AbstractMonomialSmallerThanFeature.java
@@ -29,19 +29,30 @@ public abstract class AbstractMonomialSmallerThanFeature extends SmallerThanFeat
         this.Z = numbers.getNumberSymbol();
     }
 
+    /**
+     * if {@code op} is a Skolem constant the returned introduction time is the number of taclets
+     * applied before and including the taclet by which its was introduced. <ctrong>For all other
+     * operators the returned value is -1</strong>
+     *
+     * @param op the Operator whose introduction time is queried
+     * @param goal the Goal whose state is queried
+     * @return the introduction time or -1 if not yet introduced or op is not a Skolem constant
+     */
     protected int introductionTime(Operator op, Goal goal) {
         if (op == add || op == mul || op == Z) {
             return -1;
         }
 
-        // A newSmallSym taclet introduces its symbol as a SkolemTermSV instantiation, which is
-        // always a skolem-constant function (TacletApp.createSkolemConstant). So an op that is not
-        // a skolem-constant function can never have been introduced by one: its time is -1, with no
-        // need to scan the applied-rule history. This is what made the scan a hotspot -- the common
-        // monomial atoms (program variables, ordinary functions) are not skolem constants, yet
-        // walked the full O(history) on every compare and, never being "introduced", were never
-        // cached. (A skolem constant from some OTHER rule still walks and returns -1; only the
-        // structurally-impossible ops are short-circuited, so every result is unchanged.)
+        // A taclet with rule set "polySimp_newSmallSym" introduces its symbol as a SkolemTermSV
+        // instantiation, which is always a skolem-constant function
+        // (TacletApp.createSkolemConstant).
+        // So an op that is not a skolem-constant function can never have been introduced by one:
+        // its time is -1, with no need to scan the applied-rule history. This is what made the
+        // scan a hotspot -- the common monomial atoms (program variables, ordinary functions) are
+        // not skolem constants, yet walked the full O(history) on every compare and, never being
+        // "introduced", were never cached. (A skolem constant from some OTHER rule still walks and
+        // returns -1; only the structurally-impossible ops are short-circuited, so every result is
+        // unchanged.)
         if (!(op instanceof Function func) || !func.isSkolemConstant()) {
             return -1;
         }
@@ -58,13 +69,11 @@ public abstract class AbstractMonomialSmallerThanFeature extends SmallerThanFeat
             res = introductionTimeHelp(op, goal);
             // Do NOT cache the "not introduced (yet)" answer (-1): op may be introduced by a later
             // rule application, after which introductionTimeHelp would find a real time. Caching
-            // the
-            // -1 would freeze it, making the value depend on whether op happened to be first
-            // queried
-            // before or after its introduction -- i.e. on the access pattern (which features run,
-            // when). That makes term ordering, and hence OneStepSimplifier rewriting, subtly
-            // non-deterministic. A real introduction time, once found, is stable (the introducing
-            // rule stays in the applied-rule prefix), so it is safe to cache.
+            // the -1 would freeze it, making the value depend on whether op happened to be first
+            // queried before or after its introduction -- i.e. on the access pattern (which
+            // features run, when). That makes term ordering, and hence OneStepSimplifier rewriting,
+            // subtly non-deterministic. A real introduction time, once found, is stable (the
+            // introducing rule stays in the applied-rule prefix), so it is safe to cache.
             if (res != -1) {
                 synchronized (introductionTimeCache) {
                     introductionTimeCache.put(op, res);


### PR DESCRIPTION
## Intended Change

The strategy's cost computation includes an `IntroductionTime` feature that walks the proof history to find when an operator was first introduced. For operators that are not Skolem symbols this walk can never produce a useful result, so it is now skipped. This affects only the cost heuristic that guides proof search — it never changes soundness or which proofs can be closed.

## Benchmark

Automode time, median of 3 runs, serial forks (`-PrapForks=1`), isolated `user.home` per run; baseline = current main (8 representative proofs: 4 quantifier-heavy + 4 mixed). _ArrayList.remove.1 is high-variance run-to-run — treat as noise._

| proof | baseline (ms) | this PR (ms) | Δ |
|---|--:|--:|--:|
| PUZ031p1 | 13712 | 12557 | -8% |
| SimplifiedLinkedList.remove | 17469 | 16492 | -6% |
| Saddleback | 13026 | 11964 | -8% |
| SYN550p1 | 821 | 762 | -7% |
| symmArray | 12737 | 11276 | -11% |
| gemplusDecimal | 8378 | 7154 | -15% |
| coincidence | 2181 | 2032 | -7% |
| ArrayList.remove.1 | 3339 | 2497 | -25% |
| **TOTAL** | **71663** | **64734** | **-10%** |

## Plan

* [x] Add a focused per-PR benchmark to this description
* [x] Mark ready for review once the Performance Series 2 determinism gate passes (see overview)

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Part of **Performance Series 2** — see the overview (#3879) for the combined benchmark and series context.

Created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
