### PR TITLE
Performance Series 2 (2/5): Faster term equality modulo renaming via a hash pre-filter

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/JTerm.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/JTerm.java
@@ -119,6 +119,13 @@ public interface JTerm
     boolean containsJavaBlockRecursive();
 
     /**
+     * Hash code modulo bound renaming, computed lazily and cached. Two terms that are equal modulo
+     * renaming share this value, so a mismatch is a cheap proof of inequality (used by
+     * {@code RenamingTermProperty}).
+     */
+    int hashCodeModRenaming();
+
+    /**
      * Checks if this {@link JTerm} or one of its direct or indirect children has a
      * {@link de.uka.ilkd.key.logic.op.Transformer} operator. Cached; used by
      * {@link de.uka.ilkd.key.rule.RewriteTaclet#checkPrefix} to skip the prefix walk in the common

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermImpl.java
@@ -83,6 +83,12 @@ class TermImpl implements JTerm {
     /** caches whether this term or a (direct/indirect) child has a {@link Transformer} operator. */
     private ThreeValuedTruth containsTransformerRecursive = ThreeValuedTruth.UNKNOWN;
 
+    /**
+     * Cached renaming-invariant hashCode ({@link RenamingTermProperty#hashCodeModThisProperty}),
+     * used to fast-reject unequal pairs in equality modulo renaming. {@code 0} = not yet computed.
+     */
+    private int hashcodeModRenaming = 0;
+
     // -------------------------------------------------------------------------
     // constructors
     // -------------------------------------------------------------------------
@@ -418,6 +424,19 @@ class TermImpl implements JTerm {
             this.containsJavaBlockRecursive = result;
         }
         return containsJavaBlockRecursive == ThreeValuedTruth.TRUE;
+    }
+
+    /**
+     * Renaming-invariant hashCode, computed lazily on first use and cached. Used by
+     * {@link RenamingTermProperty} to fast-reject pairs that cannot be equal modulo renaming.
+     */
+    public int hashCodeModRenaming() {
+        if (hashcodeModRenaming == 0) {
+            final int h = de.uka.ilkd.key.logic.equality.RenamingTermProperty.RENAMING_TERM_PROPERTY
+                    .hashCodeModThisProperty(this);
+            hashcodeModRenaming = h == 0 ? 1 : h;
+        }
+        return hashcodeModRenaming;
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/equality/RenamingTermProperty.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/equality/RenamingTermProperty.java
@@ -5,6 +5,7 @@ package de.uka.ilkd.key.logic.equality;
 
 import de.uka.ilkd.key.java.NameAbstractionTable;
 import de.uka.ilkd.key.java.ast.JavaProgramElement;
+import de.uka.ilkd.key.logic.JTerm;
 import de.uka.ilkd.key.logic.JavaBlock;
 import de.uka.ilkd.key.logic.op.JModality;
 import de.uka.ilkd.key.logic.op.ProgramVariable;
@@ -57,6 +58,14 @@ public class RenamingTermProperty implements Property<Term> {
     public <V> boolean equalsModThisProperty(Term term1, Term term2, V... v) {
         if (term2 == term1) {
             return true;
+        }
+        // Fast reject via the renaming-invariant hashCode (cached per term, see
+        // JTerm#hashCodeModRenaming): if it differs the terms cannot be equal modulo renaming, so
+        // the O(term) unifyHelp walk is skipped. Benefits every equals-mod-renaming caller
+        // (quantifier cost heuristics, taclet matching, sequent-redundancy checks).
+        if (term1 instanceof JTerm t1 && term2 instanceof JTerm t2
+                && t1.hashCodeModRenaming() != t2.hashCodeModRenaming()) {
+            return false;
         }
         return unifyHelp(term1, term2, ImmutableList.nil(),
             ImmutableList.nil(), null);


### PR DESCRIPTION
## Intended Change

`RenamingTermProperty.equalsModThisProperty` decides whether two terms are equal up to renaming of bound variables (alpha-equivalence), and is evaluated very frequently during proof search. This adds a renaming-invariant `hashCode` pre-filter: two terms with different renaming-invariant hash codes cannot be alpha-equivalent, so they are rejected in constant time before the more expensive structural comparison. Behaviour-preserving — the hash is renaming-invariant, so the pre-filter only ever rejects pairs that are genuinely unequal.

## Benchmark

Automode time, median of 3 runs, serial forks (`-PrapForks=1`), isolated `user.home` per run; baseline = current main (8 representative proofs: 4 quantifier-heavy + 4 mixed). _ArrayList.remove.1 is high-variance run-to-run — treat as noise._

| proof | baseline (ms) | this PR (ms) | Δ |
|---|--:|--:|--:|
| PUZ031p1 | 13712 | 12644 | -8% |
| SimplifiedLinkedList.remove | 17469 | 15789 | -10% |
| Saddleback | 13026 | 12241 | -6% |
| SYN550p1 | 821 | 754 | -8% |
| symmArray | 12737 | 10768 | -15% |
| gemplusDecimal | 8378 | 8536 | +2% |
| coincidence | 2181 | 2171 | -0% |
| ArrayList.remove.1 | 3339 | 2689 | -19% |
| **TOTAL** | **71663** | **65592** | **-8%** |

## Plan

* [x] Add a focused per-PR benchmark to this description
* [x] Mark ready for review once the Performance Series 2 determinism gate passes (see overview)

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Part of **Performance Series 2** — see the overview (#3879) for the combined benchmark and series context.

Created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
