### PR TITLE
Performance Series 2 (3/5): Incremental taclet re-indexing for a single added taclet

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletAppIndex.java
@@ -332,6 +332,22 @@ public class TacletAppIndex {
             succIndex.addTaclets(newTaclets, getServices(), tacletIndex, newRuleListener);
     }
 
+    /**
+     * Like {@link #updateIndices(SetRuleFilter)}, but the freshly added taclets are supplied as a
+     * small dedicated index rather than as a membership filter over the full {@link #tacletIndex}.
+     * The re-index walk then sees only those taclets as match candidates -- avoiding the
+     * per-position scan of the full operator bucket through {@link SetRuleFilter#filter} -- while
+     * reusing the identical {@code getList}/match logic, so the resulting apps are unchanged. Used
+     * for the common single-taclet add; the goal's rule filter is still applied (the candidate
+     * filter passed here is {@link TacletFilter#TRUE}).
+     */
+    private void updateIndices(final TacletIndex newTacletsIndex) {
+        antecIndex = antecIndex.addTaclets(TacletFilter.TRUE, getServices(), newTacletsIndex,
+            newRuleListener);
+        succIndex = succIndex.addTaclets(TacletFilter.TRUE, getServices(), newTacletsIndex,
+            newRuleListener);
+    }
+
 
     /**
      * updates the internal caches after a new Taclet with instantiation information has been added
@@ -360,10 +376,18 @@ public class TacletAppIndex {
             return;
         }
 
-        final SetRuleFilter newTaclets = new SetRuleFilter();
-        newTaclets.addRuleToSet(tacletApp.taclet());
+        // Re-index only the freshly added taclet: feed the walk a one-taclet index instead of
+        // filtering the full operator buckets per position (see updateIndices(TacletIndex)). The
+        // single-threaded index is used deliberately -- the multi-threaded matcher only
+        // parallelizes
+        // above 256 taclets, so a one-taclet index always takes its sequential path anyway;
+        // building
+        // the lightweight single-threaded index directly makes that explicit and is robust if that
+        // threshold ever changes.
+        final TacletIndex newTacletsIndex = new SingleThreadedTacletIndex();
+        newTacletsIndex.add(tacletApp);
 
-        updateIndices(newTaclets);
+        updateIndices(newTacletsIndex);
     }
 
     /**

--- a/key.core/src/test/java/de/uka/ilkd/key/proof/TestTermTacletAppIndex.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/proof/TestTermTacletAppIndex.java
@@ -5,6 +5,8 @@ package de.uka.ilkd.key.proof;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import de.uka.ilkd.key.java.ServiceCaches;
@@ -19,8 +21,10 @@ import de.uka.ilkd.key.util.HelperClassForTests;
 import org.key_project.logic.PosInTerm;
 import org.key_project.prover.proof.rulefilter.SetRuleFilter;
 import org.key_project.prover.proof.rulefilter.TacletFilter;
+import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.sequent.SequentFormula;
+import org.key_project.prover.strategy.NewRuleListener;
 import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableList;
 
@@ -216,6 +220,115 @@ public class TestTermTacletAppIndex {
         for (NoPosTacletApp aP_toCheck : p_toCheck) {
             assertTrue(p_template.contains(aP_toCheck.taclet()));
         }
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Single-taclet re-index via a one-taclet "mini index" (TacletAppIndex.updateIndices) must
+    // produce exactly the same apps -- same order, same listener firing -- as the SetRuleFilter
+    // path that scans the full operator buckets. These tests pin that equivalence.
+    // ----------------------------------------------------------------------------------------------
+
+    /** Records, in order, the apps reported to a {@link NewRuleListener}. */
+    private static final class RecordingListener implements NewRuleListener {
+        final List<String> fired = new ArrayList<>();
+
+        @Override
+        public void ruleAdded(RuleApp rule, PosInOccurrence pos) {
+            fired.add(rule.rule().name() + "@" + pos);
+        }
+
+        @Override
+        public void rulesAdded(ImmutableList<? extends RuleApp> rules, PosInOccurrence pos) {
+            for (RuleApp r : rules) {
+                ruleAdded(r, pos);
+            }
+        }
+    }
+
+    /** Normal unit test: the documented {@code checkTermIndex3} result, via the mini-index path. */
+    @Test
+    public void testReindexViaMiniIndex() {
+        Services serv = TacletForTests.services();
+
+        TacletIndex ruleIdx = TacletIndexKit.getKit().createTacletIndex();
+        ruleIdx.add(remove_f);
+        ruleIdx.add(remove_zero);
+
+        JTerm term = TacletForTests.parseTerm("f(f(zero))=one");
+        SequentFormula cfma = new SequentFormula(term);
+        PosInOccurrence pio = new PosInOccurrence(cfma, PosInTerm.getTopLevel(), false);
+
+        TermTacletAppIndex termIdx = TermTacletAppIndex.create(pio, serv, ruleIdx,
+            NullNewRuleListener.INSTANCE, TacletFilter.TRUE, noCache);
+
+        TacletIndex mini = new SingleThreadedTacletIndex();
+        mini.add(remove_ff);
+        termIdx =
+            termIdx.addTaclets(TacletFilter.TRUE, pio, serv, mini, NullNewRuleListener.INSTANCE);
+
+        checkTermIndex3(pio, termIdx);
+    }
+
+    /** Differential test: mini-index path == SetRuleFilter path, across taclets and both sides. */
+    @Test
+    public void testMiniIndexEquivalentToFilterPath() {
+        Services serv = TacletForTests.services();
+        NoPosTacletApp[] toAdd = { remove_f, remove_ff, remove_zero, ruleRewriteNonH1H2,
+            ruleAntecH1, ruleSucc, ruleMisMatch, notfreeconflict };
+
+        for (String termStr : new String[] { "f(f(f(zero)))=one", "f(zero)=one" }) {
+            SequentFormula cfma = new SequentFormula(TacletForTests.parseTerm(termStr));
+            for (boolean antec : new boolean[] { true, false }) {
+                PosInOccurrence pio = new PosInOccurrence(cfma, PosInTerm.getTopLevel(), antec);
+                for (NoPosTacletApp t : toAdd) {
+                    assertMiniIndexMatchesFilter(serv, pio, t);
+                }
+            }
+        }
+    }
+
+    private void assertMiniIndexMatchesFilter(Services serv, PosInOccurrence pio,
+            NoPosTacletApp toAdd) {
+        final String msg = toAdd.taclet().name() + (pio.isInAntec() ? " (antec)" : " (succ)");
+
+        TacletIndex fullIdx = TacletIndexKit.getKit().createTacletIndex();
+        TermTacletAppIndex base = TermTacletAppIndex.create(pio, serv, fullIdx,
+            NullNewRuleListener.INSTANCE, TacletFilter.TRUE, noCache);
+
+        // OLD: SetRuleFilter selecting toAdd out of the full index
+        fullIdx.add(toAdd);
+        SetRuleFilter filter = new SetRuleFilter();
+        filter.addRuleToSet(toAdd.taclet());
+        RecordingListener recOld = new RecordingListener();
+        TermTacletAppIndex idxOld = base.addTaclets(filter, pio, serv, fullIdx, recOld);
+
+        // NEW: one-taclet mini-index + accept-all filter
+        TacletIndex mini = new SingleThreadedTacletIndex();
+        mini.add(toAdd);
+        RecordingListener recNew = new RecordingListener();
+        TermTacletAppIndex idxNew = base.addTaclets(TacletFilter.TRUE, pio, serv, mini, recNew);
+
+        assertEquals(recOld.fired, recNew.fired, "fired apps differ: " + msg);
+        assertSameAppsEverywhere(pio, idxOld, idxNew, msg);
+    }
+
+    private void assertSameAppsEverywhere(PosInOccurrence pos, TermTacletAppIndex a,
+            TermTacletAppIndex b, String msg) {
+        assertEquals(appNames(a.getTacletAppAt(pos, TacletFilter.TRUE)),
+            appNames(b.getTacletAppAt(pos, TacletFilter.TRUE)),
+            "apps differ at " + pos + ": " + msg);
+        final JTerm t = (JTerm) pos.subTerm();
+        for (int i = 0; i < t.arity(); i++) {
+            assertSameAppsEverywhere(pos.down(i), a, b, msg);
+        }
+    }
+
+    private static List<String> appNames(ImmutableList<NoPosTacletApp> apps) {
+        List<String> res = new ArrayList<>();
+        for (NoPosTacletApp a : apps) {
+            res.add(a.taclet().name().toString());
+        }
+        return res;
     }
 
 }


### PR DESCRIPTION
## Intended Change

Each time a single taclet is added to a goal, `TacletAppIndex` rebuilt its rule-application index over the entire taclet set. This change re-indexes only the one newly added taclet, via a small one-taclet index, instead of rebuilding everything. Behaviour-preserving.

## Benchmark

Automode time, median of 3 runs, serial forks (`-PrapForks=1`), isolated `user.home` per run; baseline = current main (8 representative proofs: 4 quantifier-heavy + 4 mixed). _ArrayList.remove.1 is high-variance run-to-run — treat as noise._

| proof | baseline (ms) | this PR (ms) | Δ |
|---|--:|--:|--:|
| PUZ031p1 | 13712 | 12808 | -7% |
| SimplifiedLinkedList.remove | 17469 | 17412 | -0% |
| Saddleback | 13026 | 12341 | -5% |
| SYN550p1 | 821 | 782 | -5% |
| symmArray | 12737 | 11195 | -12% |
| gemplusDecimal | 8378 | 8161 | -3% |
| coincidence | 2181 | 2161 | -1% |
| ArrayList.remove.1 | 3339 | 2448 | -27% |
| **TOTAL** | **71663** | **67308** | **-6%** |

## Plan

* [x] Add a focused per-PR benchmark to this description
* [x] Mark ready for review once the Performance Series 2 determinism gate passes (see overview)

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Part of **Performance Series 2** — see the overview (#3879) for the combined benchmark and series context.

Created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
