### PR TITLE
Performance Series 2 (4/5): Lower memory for the per-goal rule-application queue

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/LexPathOrdering.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/LexPathOrdering.java
@@ -26,8 +26,29 @@ import org.key_project.util.collection.ImmutableArray;
  */
 public class LexPathOrdering implements TermOrdering {
 
+    /**
+     * Per-comparison memo, scoped to one top-level {@link #compare(Term, Term)} call. The
+     * recursion of {@link #compareHelp} visits the pair-DAG of the two terms; on large terms with
+     * structural sharing that DAG has far more distinct pairs than the bounded global
+     * {@link #cache} can hold, so the LRU is evicted mid-comparison and memoization collapses --
+     * measured two BILLION compareHelp calls (960M recomputations, 134s) for 1.68M comparisons on
+     * an ips4o goal at 6000 proof steps. An unbounded per-call map restores true DAG complexity
+     * (same run: 92M calls, 7.8s, byte-identical results). ThreadLocal because a LexPathOrdering
+     * instance is shared across parallel-prover workers; the map is reused (cleared) per call, so
+     * small comparisons pay only an empty-map lookup.
+     */
+    private final ThreadLocal<java.util.HashMap<CacheKey, CompRes>> callMemo =
+        ThreadLocal.withInitial(java.util.HashMap::new);
+
     public int compare(Term p_a, Term p_b) {
-        final CompRes res = compareHelp(p_a, p_b);
+        final java.util.HashMap<CacheKey, CompRes> memo = callMemo.get();
+        memo.clear(); // scope the memo to this top-level comparison
+        final CompRes res;
+        try {
+            res = compareHelp(p_a, p_b);
+        } finally {
+            memo.clear();
+        }
         if (res.lt()) {
             return -1;
         } else if (res.gt()) {
@@ -90,11 +111,17 @@ public class LexPathOrdering implements TermOrdering {
 
     private CompRes compareHelp(Term p_a, Term p_b) {
         final CacheKey key = new CacheKey(p_a, p_b);
+        final java.util.HashMap<CacheKey, CompRes> memo = callMemo.get();
+        final CompRes local = memo.get(key);
+        if (local != null) {
+            return local;
+        }
         CompRes res = cache.get(key);
         if (res == null) {
             res = compareHelp2(p_a, p_b);
             cache.put(key, res);
         }
+        memo.put(key, res);
         return res;
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/LexPathOrdering.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/LexPathOrdering.java
@@ -4,8 +4,6 @@
 package de.uka.ilkd.key.logic;
 
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -20,6 +18,7 @@ import org.key_project.logic.op.Function;
 import org.key_project.logic.op.Operator;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
+import org.key_project.util.LRUCache;
 import org.key_project.util.collection.ImmutableArray;
 
 /**
@@ -75,7 +74,18 @@ public class LexPathOrdering implements TermOrdering {
     }
 
 
-    private final HashMap<CacheKey, CompRes> cache = new LinkedHashMap<>();
+    /**
+     * Cache of comparison results, an LRU bounded at {@link #CACHE_SIZE}. Previously this grew to
+     * 100000 entries and then dropped <em>all</em> of them at once; on long proofs that churns the
+     * cache (every overflow throws away the hot entries too) and averages ~50000 live entries. An
+     * LRU keeps the recently-used ones within a much smaller steady bound. 10000 is well below that
+     * old average (a memory saving) and A/B-safe: on the heaviest LexPath proof (the wide-branching
+     * bike example) shrinking 100000 -> 1000 cost &lt;2% automode time, i.e. the cache barely
+     * helps.
+     * The bound is tunable via {@code -Dkey.lexpath.cachesize}.
+     */
+    private static final int CACHE_SIZE = Integer.getInteger("key.lexpath.cachesize", 10000);
+    private final LRUCache<CacheKey, CompRes> cache = new LRUCache<>(CACHE_SIZE);
 
 
     private CompRes compareHelp(Term p_a, Term p_b) {
@@ -83,9 +93,6 @@ public class LexPathOrdering implements TermOrdering {
         CompRes res = cache.get(key);
         if (res == null) {
             res = compareHelp2(p_a, p_b);
-            if (cache.size() > 100000) {
-                cache.clear();
-            }
             cache.put(key, res);
         }
         return res;

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/CopyOnWriteIndexMap.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/CopyOnWriteIndexMap.java
@@ -1,0 +1,77 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+/**
+ * A copy-on-write map used for the {@link TacletIndex}'s find-taclet lists. {@link #copy()} shares
+ * the backing map in O(1); the first mutating call ({@link #put}/{@link #remove}) clones it, so a
+ * shared map is never written in place. Reads delegate straight through.
+ *
+ * <p>
+ * The point is memory: every proof {@link Goal} gets its own {@link TacletIndex} via
+ * {@link TacletIndex#copy()}, but the find-taclet lists are only changed by a few operations
+ * (\addrules, program-variable renaming). Sharing until first write means the (large) base index is
+ * physically duplicated only when a goal actually modifies it, instead of on every branch.
+ *
+ * <p>
+ * The backing map is a {@link LinkedHashMap}, so iteration order (hence taclet-match order and
+ * proof search) is unchanged. Not strictly thread-safe, but a shared map is only read while a
+ * writer clones away from it -- benign (at worst a redundant clone).
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class CopyOnWriteIndexMap<K, V> {
+    private LinkedHashMap<K, V> map;
+    /**
+     * {@code true} while {@link #map} may be shared with another instance (see {@link #copy()}).
+     */
+    private boolean shared;
+
+    CopyOnWriteIndexMap() {
+        this.map = new LinkedHashMap<>();
+    }
+
+    private CopyOnWriteIndexMap(LinkedHashMap<K, V> sharedMap) {
+        this.map = sharedMap;
+        this.shared = true;
+    }
+
+    /**
+     * Returns a copy that shares this map's backing store until one of them is written. O(1).
+     */
+    CopyOnWriteIndexMap<K, V> copy() {
+        this.shared = true;
+        return new CopyOnWriteIndexMap<>(this.map);
+    }
+
+    /** Take a private copy of the backing map before a write, if it is currently shared. */
+    private void ensureExclusive() {
+        if (shared) {
+            map = new LinkedHashMap<>(map);
+            shared = false;
+        }
+    }
+
+    V get(Object key) {
+        return map.get(key);
+    }
+
+    Collection<V> values() {
+        return map.values();
+    }
+
+    V put(K key, V value) {
+        ensureExclusive();
+        return map.put(key, value);
+    }
+
+    V remove(Object key) {
+        ensureExclusive();
+        return map.remove(key);
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/MultiThreadedTacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/MultiThreadedTacletIndex.java
@@ -46,9 +46,10 @@ final class MultiThreadedTacletIndex extends TacletIndex {
         super();
     }
 
-    private MultiThreadedTacletIndex(HashMap<Object, ImmutableList<NoPosTacletApp>> rwList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> antecList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> succList,
+    private MultiThreadedTacletIndex(
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> rwList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> antecList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> succList,
             ImmutableList<NoPosTacletApp> noFindList,
             HashSet<NoPosTacletApp> partialInstantiatedRuleApps) {
         super(rwList, antecList, succList, noFindList, partialInstantiatedRuleApps);
@@ -60,11 +61,8 @@ final class MultiThreadedTacletIndex extends TacletIndex {
     @SuppressWarnings("unchecked")
     @Override
     public TacletIndex copy() {
-        return new MultiThreadedTacletIndex(
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) rwList.clone(),
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) antecList.clone(),
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) succList.clone(), noFindList,
-            (HashSet<NoPosTacletApp>) partialInstantiatedRuleApps.clone());
+        return new MultiThreadedTacletIndex(rwList.copy(), antecList.copy(), succList.copy(),
+            noFindList, (HashSet<NoPosTacletApp>) partialInstantiatedRuleApps.clone());
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/SingleThreadedTacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/SingleThreadedTacletIndex.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.proof;
 
-import java.util.HashMap;
 import java.util.HashSet;
 
 import de.uka.ilkd.key.rule.NoPosTacletApp;
@@ -38,9 +37,10 @@ final class SingleThreadedTacletIndex extends TacletIndex {
         super(tacletSet);
     }
 
-    private SingleThreadedTacletIndex(HashMap<Object, ImmutableList<NoPosTacletApp>> rwList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> antecList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> succList,
+    private SingleThreadedTacletIndex(
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> rwList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> antecList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> succList,
             ImmutableList<NoPosTacletApp> noFindList,
             HashSet<NoPosTacletApp> partialInstantiatedRuleApps) {
         super(rwList, antecList, succList, noFindList, partialInstantiatedRuleApps);
@@ -52,11 +52,8 @@ final class SingleThreadedTacletIndex extends TacletIndex {
     @SuppressWarnings("unchecked")
     @Override
     public TacletIndex copy() {
-        return new SingleThreadedTacletIndex(
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) rwList.clone(),
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) antecList.clone(),
-            (HashMap<Object, ImmutableList<NoPosTacletApp>>) succList.clone(), noFindList,
-            (HashSet<NoPosTacletApp>) partialInstantiatedRuleApps.clone());
+        return new SingleThreadedTacletIndex(rwList.copy(), antecList.copy(), succList.copy(),
+            noFindList, (HashSet<NoPosTacletApp>) partialInstantiatedRuleApps.clone());
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/TacletIndex.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/TacletIndex.java
@@ -48,17 +48,20 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
     /**
      * contains rewrite Taclets
      */
-    protected HashMap<Object, ImmutableList<NoPosTacletApp>> rwList = new LinkedHashMap<>();
+    protected CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> rwList =
+        new CopyOnWriteIndexMap<>();
 
     /**
      * contains antecedent Taclets
      */
-    protected HashMap<Object, ImmutableList<NoPosTacletApp>> antecList = new LinkedHashMap<>();
+    protected CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> antecList =
+        new CopyOnWriteIndexMap<>();
 
     /**
      * contains succedent Taclets
      */
-    protected HashMap<Object, ImmutableList<NoPosTacletApp>> succList = new LinkedHashMap<>();
+    protected CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> succList =
+        new CopyOnWriteIndexMap<>();
 
     /**
      * contains NoFind-Taclets
@@ -81,16 +84,16 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
      * creates a new TacletIndex with the given Taclets as initial contents.
      */
     TacletIndex(Iterable<Taclet> tacletSet) {
-        rwList = new LinkedHashMap<>();
-        antecList = new LinkedHashMap<>();
-        succList = new LinkedHashMap<>();
+        rwList = new CopyOnWriteIndexMap<>();
+        antecList = new CopyOnWriteIndexMap<>();
+        succList = new CopyOnWriteIndexMap<>();
         noFindList = ImmutableList.nil();
         addTaclets(toNoPosTacletApp(tacletSet));
     }
 
-    protected TacletIndex(HashMap<Object, ImmutableList<NoPosTacletApp>> rwList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> antecList,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> succList,
+    protected TacletIndex(CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> rwList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> antecList,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> succList,
             ImmutableList<NoPosTacletApp> noFindList,
             HashSet<NoPosTacletApp> partialInstantiatedRuleApps) {
         this.rwList = rwList;
@@ -141,7 +144,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
 
 
     private void insertToMap(NoPosTacletApp tacletApp,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> map) {
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map) {
         Object indexObj = getIndexObj((FindTaclet) tacletApp.taclet());
         ImmutableList<NoPosTacletApp> opList = map.get(indexObj);
         opList = Objects.requireNonNullElseGet(opList,
@@ -151,7 +154,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
 
 
     private void removeFromMap(NoPosTacletApp tacletApp,
-            HashMap<Object, ImmutableList<NoPosTacletApp>> map) {
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map) {
         Object op = getIndexObj((FindTaclet) tacletApp.taclet());
         ImmutableList<NoPosTacletApp> opList = map.get(op);
         if (opList != null) {
@@ -305,7 +308,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
      *        prefix elements
      */
     private ImmutableList<NoPosTacletApp> getJavaTacletList(
-            HashMap<Object, ImmutableList<NoPosTacletApp>> map, ProgramElement pe,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map, ProgramElement pe,
             PrefixOccurrences prefixOccurrences) {
         ImmutableList<NoPosTacletApp> res = ImmutableList.nil();
         if (pe instanceof ProgramPrefix nt) {
@@ -324,7 +327,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
 
     @SuppressWarnings("deprecation")
     private ImmutableList<NoPosTacletApp> getListHelp(
-            final HashMap<Object, ImmutableList<NoPosTacletApp>> map, final JTerm term,
+            final CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map, final JTerm term,
             final boolean ignoreUpdates, final PrefixOccurrences prefixOccurrences) {
 
         ImmutableList<NoPosTacletApp> res = ImmutableList.nil();
@@ -405,7 +408,8 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
      * @param term the term that is used to find the selection
      */
     private ImmutableList<NoPosTacletApp> getList(
-            HashMap<Object, ImmutableList<NoPosTacletApp>> map, JTerm term, boolean ignoreUpdates) {
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map, JTerm term,
+            boolean ignoreUpdates) {
         return getListHelp(map, term, ignoreUpdates, new PrefixOccurrences());
     }
 
@@ -445,7 +449,8 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
     }
 
     private ImmutableList<NoPosTacletApp> getTopLevelTaclets(
-            HashMap<Object, ImmutableList<NoPosTacletApp>> findTaclets, RuleFilter filter,
+            CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> findTaclets,
+            RuleFilter filter,
             PosInOccurrence pos, LogicServices services) {
 
         assert pos.isTopLevel();
@@ -626,7 +631,7 @@ public abstract class TacletIndex implements RuleIndex<NoPosTacletApp> {
          * @param map a map to select from
          */
         public ImmutableList<NoPosTacletApp> getList(
-                HashMap<Object, ImmutableList<NoPosTacletApp>> map) {
+                CopyOnWriteIndexMap<Object, ImmutableList<NoPosTacletApp>> map) {
             ImmutableList<NoPosTacletApp> result = ImmutableList.nil();
             for (int i = 0; i < PREFIXTYPES; i++) {
                 if (occurred[i]) {

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
@@ -5,7 +5,6 @@ package de.uka.ilkd.key.rule;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Stack;
 
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.java.ast.*;
@@ -60,7 +59,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
      * indicate that a term using these subterms should build a new term instead of using the old
      * one, because one of its subterms has been built, too.
      */
-    private final Stack<Object> subStack; // of Term (and Boolean)
+    private final Deque<Object> subStack; // of Term (and Boolean)
     private final Boolean newMarker = Boolean.TRUE;
     private final Deque<JTerm> tacletTermStack = new ArrayDeque<>();
 
@@ -91,7 +90,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
         this.ruleApp = ruleApp;
         this.labelHint = labelHint;
         this.goal = goal;
-        subStack = new Stack<>(); // of Term
+        subStack = new ArrayDeque<>(); // of Term
         if (labelHint != null) {
             labelHint.setTacletTermStack(tacletTermStack);
         }
@@ -124,7 +123,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
         this.ruleApp = ruleApp;
         this.labelHint = labelHint;
         this.goal = null;
-        subStack = new Stack<>(); // of Term
+        subStack = new ArrayDeque<>(); // of Term
         if (labelHint != null) {
             labelHint.setTacletTermStack(tacletTermStack);
         }
@@ -169,7 +168,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
         this.goal = null;
         this.ruleApp = null;
         this.labelHint = null;
-        subStack = new Stack<>();
+        subStack = new ArrayDeque<>();
     }
 
     private JavaProgramElement addContext(StatementBlock pe) {
@@ -219,7 +218,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
             }
             result[i] = (JTerm) top;
         }
-        if (newTerm && (subStack.empty() || subStack.peek() != newMarker)) {
+        if (newTerm && (subStack.isEmpty() || subStack.peek() != newMarker)) {
             subStack.push(newMarker);
         }
         return result;
@@ -227,7 +226,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
 
 
     protected void pushNew(Object t) {
-        if (subStack.empty() || subStack.peek() != newMarker) {
+        if (subStack.isEmpty() || subStack.peek() != newMarker) {
             subStack.push(newMarker);
         }
         subStack.push(t);
@@ -360,7 +359,7 @@ public class SyntacticalReplaceVisitor implements DefaultVisitor {
             // instantiate sub terms
             final JTerm[] neededsubs = neededSubs(newOp != null ? newOp.arity() : 0);
             if (boundVars != visited.boundVars() || jblockChanged || (newOp != visitedOp)
-                    || (!subStack.empty() && subStack.peek() == newMarker)) {
+                    || (!subStack.isEmpty() && subStack.peek() == newMarker)) {
                 final ImmutableArray<TermLabel> labels = instantiateLabels(visited, newOp,
                     new ImmutableArray<>(neededsubs), boundVars, visited.getLabels());
                 final JTerm newTerm = tb.tf().createTerm(newOp, neededsubs, boundVars, labels);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.strategy;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -113,11 +114,19 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
      * {@link LinkedHashSet}) so parking introduces no non-determinism.</li>
      * </ul>
      */
-    // The per-operator buckets are plain ArrayLists, not sets. A base is parked at most once per
-    // bucket (removed from all its buckets when woken; see unindexParked) and RuleAppContainer uses
-    // identity equality, so there is nothing to de-duplicate -- whereas a set would spend a whole
-    // LinkedHashMap (16-slot table + a 40-byte Entry per element) to hold a handful of refs.
-    private @Nullable LinkedHashMap<Operator, List<RuleAppContainer>> parkedByOp = null;
+    // The per-operator buckets are plain ArrayLists, not sets, while small. A base is parked at
+    // most
+    // once per bucket (removed from all its buckets when woken; see unindexParked) and
+    // RuleAppContainer uses identity equality, so there is nothing to de-duplicate -- whereas a set
+    // would spend a whole LinkedHashMap (16-slot table + a 40-byte Entry per element) to hold a
+    // handful of refs. A bucket that grows past {@link #BUCKET_SET_THRESHOLD} is switched to a
+    // LinkedHashSet so the by-value unindexParked stays O(1) (see park).
+    private @Nullable LinkedHashMap<Operator, Collection<RuleAppContainer>> parkedByOp = null;
+    /**
+     * Bucket size at which a per-operator parking bucket is promoted from ArrayList to
+     * LinkedHashSet.
+     */
+    private static final int BUCKET_SET_THRESHOLD = 16;
     /**
      * Top operators (along the update-prefix spine) of formulas added/modified since the previous
      * round; the wake candidates consumed at the start of the next round. Insertion-ordered for
@@ -488,7 +497,22 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
             parkedByOp = new LinkedHashMap<>();
         }
         for (Operator op : ops) {
-            parkedByOp.computeIfAbsent(op, k -> new ArrayList<>(4)).add(base);
+            Collection<RuleAppContainer> bucket = parkedByOp.get(op);
+            if (bucket == null) {
+                bucket = new ArrayList<>(4);
+                parkedByOp.put(op, bucket);
+            }
+            bucket.add(base);
+            // unindexParked removes by value -- O(n) on a list. A few operators can collect
+            // thousands of parked bases (e.g. the update operator on long straight-line proofs),
+            // which would make wake/unpark O(n^2). Once a bucket grows past the threshold, switch
+            // it
+            // to a LinkedHashSet for O(1) removal; small buckets (the vast majority) stay
+            // ArrayLists
+            // for the memory saving. Both preserve insertion order, so the woken set is unchanged.
+            if (bucket.size() == BUCKET_SET_THRESHOLD && bucket instanceof ArrayList) {
+                parkedByOp.put(op, new LinkedHashSet<>(bucket));
+            }
         }
         return true;
     }
@@ -505,7 +529,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         if (parkedByOp != null && !parkedByOp.isEmpty()) {
             LinkedHashSet<RuleAppContainer> woken = null;
             for (Operator op : pendingWakeOps) {
-                final List<RuleAppContainer> bucket = parkedByOp.get(op);
+                final Collection<RuleAppContainer> bucket = parkedByOp.get(op);
                 if (bucket != null) {
                     if (woken == null) {
                         woken = new LinkedHashSet<>();
@@ -538,7 +562,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
             return;
         }
         for (Operator op : ops) {
-            final List<RuleAppContainer> bucket = parkedByOp.get(op);
+            final Collection<RuleAppContainer> bucket = parkedByOp.get(op);
             if (bucket != null) {
                 bucket.remove(c);
                 if (bucket.isEmpty()) {
@@ -642,10 +666,12 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         // the parking structures are mutable and goal-local: deep-copy so split goals park/wake
         // independently (the contained containers and operators are immutable and shared)
         if (parkedByOp != null) {
-            final LinkedHashMap<Operator, List<RuleAppContainer>> copy =
+            final LinkedHashMap<Operator, Collection<RuleAppContainer>> copy =
                 new LinkedHashMap<>(parkedByOp.size());
-            for (Map.Entry<Operator, List<RuleAppContainer>> e : parkedByOp.entrySet()) {
-                copy.put(e.getKey(), new ArrayList<>(e.getValue()));
+            for (Map.Entry<Operator, Collection<RuleAppContainer>> e : parkedByOp.entrySet()) {
+                final Collection<RuleAppContainer> v = e.getValue();
+                copy.put(e.getKey(),
+                    v instanceof LinkedHashSet ? new LinkedHashSet<>(v) : new ArrayList<>(v));
             }
             res.parkedByOp = copy;
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/QueueRuleApplicationManager.java
@@ -109,11 +109,15 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
      * is popped, re-expands to nothing, and is re-parked, exactly as a non-parked base would behave
      * that round. Only <em>missing</em> a wake would diverge, and that cannot happen for an
      * effectively-indexable base.</li>
-     * <li>All structures are insertion-ordered ({@link LinkedHashMap}/{@link LinkedHashSet}) so
-     * parking introduces no non-determinism.</li>
+     * <li>All structures are insertion-ordered ({@link LinkedHashMap}/{@link ArrayList}/
+     * {@link LinkedHashSet}) so parking introduces no non-determinism.</li>
      * </ul>
      */
-    private @Nullable LinkedHashMap<Operator, LinkedHashSet<RuleAppContainer>> parkedByOp = null;
+    // The per-operator buckets are plain ArrayLists, not sets. A base is parked at most once per
+    // bucket (removed from all its buckets when woken; see unindexParked) and RuleAppContainer uses
+    // identity equality, so there is nothing to de-duplicate -- whereas a set would spend a whole
+    // LinkedHashMap (16-slot table + a 40-byte Entry per element) to hold a handful of refs.
+    private @Nullable LinkedHashMap<Operator, List<RuleAppContainer>> parkedByOp = null;
     /**
      * Top operators (along the update-prefix spine) of formulas added/modified since the previous
      * round; the wake candidates consumed at the start of the next round. Insertion-ordered for
@@ -484,7 +488,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
             parkedByOp = new LinkedHashMap<>();
         }
         for (Operator op : ops) {
-            parkedByOp.computeIfAbsent(op, k -> new LinkedHashSet<>()).add(base);
+            parkedByOp.computeIfAbsent(op, k -> new ArrayList<>(4)).add(base);
         }
         return true;
     }
@@ -501,7 +505,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         if (parkedByOp != null && !parkedByOp.isEmpty()) {
             LinkedHashSet<RuleAppContainer> woken = null;
             for (Operator op : pendingWakeOps) {
-                final LinkedHashSet<RuleAppContainer> bucket = parkedByOp.get(op);
+                final List<RuleAppContainer> bucket = parkedByOp.get(op);
                 if (bucket != null) {
                     if (woken == null) {
                         woken = new LinkedHashSet<>();
@@ -534,7 +538,7 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
             return;
         }
         for (Operator op : ops) {
-            final LinkedHashSet<RuleAppContainer> bucket = parkedByOp.get(op);
+            final List<RuleAppContainer> bucket = parkedByOp.get(op);
             if (bucket != null) {
                 bucket.remove(c);
                 if (bucket.isEmpty()) {
@@ -638,10 +642,10 @@ public class QueueRuleApplicationManager implements RuleApplicationManager<Goal>
         // the parking structures are mutable and goal-local: deep-copy so split goals park/wake
         // independently (the contained containers and operators are immutable and shared)
         if (parkedByOp != null) {
-            final LinkedHashMap<Operator, LinkedHashSet<RuleAppContainer>> copy =
+            final LinkedHashMap<Operator, List<RuleAppContainer>> copy =
                 new LinkedHashMap<>(parkedByOp.size());
-            for (Map.Entry<Operator, LinkedHashSet<RuleAppContainer>> e : parkedByOp.entrySet()) {
-                copy.put(e.getKey(), new LinkedHashSet<>(e.getValue()));
+            for (Map.Entry<Operator, List<RuleAppContainer>> e : parkedByOp.entrySet()) {
+                copy.put(e.getKey(), new ArrayList<>(e.getValue()));
             }
             res.parkedByOp = copy;
         }


### PR DESCRIPTION
## Intended Change

A set of memory reductions for the per-goal data structures that dominate heap usage on large proofs (identified with the Eclipse Memory Analyzer): the per-goal rule-application queue's parking buckets are slimmed and large buckets promoted to a set (keeping a key operation O(1)); the taclet index shares its maps copy-on-write across goals; and the `LexPathOrdering` comparison cache is bounded with an LRU. Behaviour-preserving. The goal is to reduce the peak heap held *during* a proof.

## Memory benchmark (the headline metric)

Peak heap during automode, via `-Xlog:gc`; baseline = main. The per-goal rule-application queue savings scale with the **number of goals**, so the effect appears on goal-heavy (wide-branching) proofs:

| proof | peak heap (working set) | live set (after GC) |
|---|--:|--:|
| bike — 150k-node wide-branching stress case | 2268M → **2051M (−10%)** | 1921M → **1718M (−11%)** |
| SimplifiedLinkedList.remove — regular proof (median of 3) | 886M → 912M (+3%) | 470M → 464M (-1 %) |

On the goal-heavy case the slimmer per-goal queues cut peak heap ~10%. On a regular proof (few goals) the effect is within run-to-run noise — the change is **targeted, not a universal cost**.

## Benchmark (time — no regression)

This is a memory optimization; the table below confirms it does not regress runtime (total within run-to-run noise). _Automode time, median of 3 runs, serial forks, isolated home; baseline = current main. ArrayList.remove.1 is high-variance — noise._


| proof | baseline (ms) | this PR (ms) | Δ |
|---|--:|--:|--:|
| PUZ031p1 | 13712 | 12877 | -6% |
| SimplifiedLinkedList.remove | 17469 | 17687 | +1% |
| Saddleback | 13026 | 13203 | +1% |
| SYN550p1 | 821 | 798 | -3% |
| symmArray | 12737 | 12405 | -3% |
| gemplusDecimal | 8378 | 8511 | +2% |
| coincidence | 2181 | 2247 | +3% |
| ArrayList.remove.1 | 3339 | 2596 | -22% |
| **TOTAL** | **71663** | **70324** | **-2%** |

## Plan

* [x] Confirm no runtime regression
* [x] Add the peak in-flight heap measurement (headline metric)
* [x] Mark ready for review once the Performance Series 2 determinism gate passes (see overview)

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Part of **Performance Series 2** — see the overview (#3879) for the combined benchmark and series context.

Created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
