### PR TITLE
Performance Series 2 (5/5): Faster quantifier-instantiation heuristic, plus code cleanup

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HandleArith.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/HandleArith.java
@@ -28,6 +28,22 @@ public class HandleArith {
 
     private HandleArith() {}
 
+    /** The operator of {@code t} after stripping leading negations. */
+    private static Operator strippedOp(JTerm t) {
+        Operator op = t.op();
+        while (op == Junctor.NOT) {
+            t = t.sub(0);
+            op = t.op();
+        }
+        return op;
+    }
+
+    /** Whether {@code t} (ignoring leading negations) is an integer {@code >=} or {@code <=}. */
+    private static boolean isArithComparison(JTerm t, IntegerLDT ig) {
+        final Operator op = strippedOp(t);
+        return op == ig.getGreaterOrEquals() || op == ig.getLessOrEquals();
+    }
+
     /**
      * try to prove atom by using polynomial
      *
@@ -36,6 +52,12 @@ public class HandleArith {
      *         <code>problem</code> if it cann't be proved.
      */
     public static JTerm provedByArith(JTerm problem, Services services) {
+        final IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
+        if (!isArithComparison(problem, integerLDT) && strippedOp(problem) != Equality.EQUALS) {
+            // neither an (in)equality nor an equality: formatArithTerm yields false and
+            // provedArithEqual returns the problem unchanged -- bail before locking the cache.
+            return problem;
+        }
         final LRUCache<JTerm, JTerm> provedByArithCache =
             services.getCaches().getProvedByArithFstCache();
         JTerm result;
@@ -47,7 +69,6 @@ public class HandleArith {
         }
 
         TermBuilder tb = services.getTermBuilder();
-        IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
 
         final JTerm trueT = tb.tt();
         final JTerm falseT = tb.ff();
@@ -127,6 +148,13 @@ public class HandleArith {
      * @return trueT if true, falseT if false, and atom if can't be prove;
      */
     public static JTerm provedByArith(JTerm problem, JTerm axiom, Services services) {
+        final IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
+        if (!isArithComparison(problem, integerLDT) || !isArithComparison(axiom, integerLDT)) {
+            // not an arithmetic implication: formatArithTerm would yield false for one side and
+            // this method returns the unproved problem -- bail before allocating the key and
+            // taking the cache lock.
+            return problem;
+        }
         final Pair<JTerm, JTerm> key = new Pair<>(problem, axiom);
         final LRUCache<Pair<JTerm, JTerm>, JTerm> provedByArithCache =
             services.getCaches().getProvedByArithSndCache();
@@ -139,7 +167,6 @@ public class HandleArith {
         }
 
         final TermBuilder tb = services.getTermBuilder();
-        final IntegerLDT integerLDT = services.getTypeConverter().getIntegerLDT();
         final ServiceCaches caches = services.getCaches();
 
         final JTerm cd = formatArithTerm(problem, tb, integerLDT, caches);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/MultiTrigger.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/MultiTrigger.java
@@ -15,101 +15,116 @@ import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableMapEntry;
 import org.key_project.util.collection.ImmutableSet;
 
+/**
+ * A trigger built from several uni-trigger {@link #elements} that, taken together, bind all
+ * universal variables of a clause. A match requires matching every element and merging their
+ * substitutions into one that is consistent and total on {@link #clauseVariables}.
+ */
 class MultiTrigger implements Trigger {
 
-    private final ImmutableSet<Trigger> triggers;
+    /** The uni-trigger elements that jointly have to cover {@link #clauseVariables}. */
+    private final ImmutableSet<Trigger> elements;
 
-    private final ImmutableSet<QuantifiableVariable> qvs;
+    /** The universal variables of the clause this multi-trigger must bind. */
+    private final ImmutableSet<QuantifiableVariable> clauseVariables;
 
     private final Term clause;
 
-    MultiTrigger(ImmutableSet<Trigger> triggers, ImmutableSet<QuantifiableVariable> qvs,
+    MultiTrigger(ImmutableSet<Trigger> elements, ImmutableSet<QuantifiableVariable> clauseVariables,
             Term clause) {
-        this.triggers = triggers;
-        this.qvs = qvs;
+        this.elements = elements;
+        this.clauseVariables = clauseVariables;
         this.clause = clause;
     }
 
     @Override
     public ImmutableSet<Substitution> getSubstitutionsFromTerms(ImmutableSet<Term> targetTerms,
             Services services) {
-        ImmutableList<Substitution> res = ImmutableList.nil();
+        ImmutableList<Substitution> total = ImmutableList.nil();
 
-        ImmutableSet<Substitution> mulsubs =
-            setMultiSubstitution(triggers.iterator(), targetTerms, services);
+        final ImmutableSet<Substitution> combined =
+            combineElementSubstitutions(elements.iterator(), targetTerms, services);
 
-        for (Substitution sub : mulsubs) {
-            if (sub.isTotalOn(qvs)) {
-                res = res.prepend(sub);
+        for (Substitution sub : combined) {
+            if (sub.isTotalOn(clauseVariables)) {
+                total = total.prepend(sub);
             }
         }
 
-        return DefaultImmutableSet.fromImmutableList(res);
+        return DefaultImmutableSet.fromImmutableList(total);
     }
 
-    /** help function for getMultiSubstitution */
-    private ImmutableSet<Substitution> setMultiSubstitution(Iterator<? extends Trigger> ts,
-            ImmutableSet<Term> terms, Services services) {
-        ImmutableList<Substitution> res = ImmutableList.nil();
-        if (ts.hasNext()) {
-            ImmutableSet<Substitution> subi = ts.next().getSubstitutionsFromTerms(terms, services);
-            ImmutableSet<Substitution> nextSubs = setMultiSubstitution(ts, terms, services);
-            if (nextSubs.isEmpty()) {
-                return subi;
-            } else if (subi.isEmpty()) {
-                return nextSubs;
+    /**
+     * Matches every remaining element against the target terms and combines the per-element
+     * substitution sets by taking the cross product and merging each compatible pair (incompatible
+     * pairs are dropped). Used by {@link #getSubstitutionsFromTerms}.
+     */
+    private ImmutableSet<Substitution> combineElementSubstitutions(
+            Iterator<? extends Trigger> remainingElements, ImmutableSet<Term> terms,
+            Services services) {
+        ImmutableList<Substitution> result = ImmutableList.nil();
+        if (remainingElements.hasNext()) {
+            ImmutableSet<Substitution> headSubs =
+                remainingElements.next().getSubstitutionsFromTerms(terms, services);
+            ImmutableSet<Substitution> tailSubs =
+                combineElementSubstitutions(remainingElements, terms, services);
+            if (tailSubs.isEmpty()) {
+                return headSubs;
+            } else if (headSubs.isEmpty()) {
+                return tailSubs;
             }
-            for (Substitution sub0 : nextSubs) {
-                for (Substitution subiSub : subi) {
-                    final Substitution sub1 = unifySubstitution(sub0, subiSub);
-                    if (sub1 != null) {
-                        res = res.prepend(sub1);
+            for (Substitution tailSub : tailSubs) {
+                for (Substitution headSub : headSubs) {
+                    final Substitution merged = mergeIfCompatible(tailSub, headSub);
+                    if (merged != null) {
+                        result = result.prepend(merged);
                     }
                 }
 
             }
         }
-        return DefaultImmutableSet.fromImmutableList(res);
+        return DefaultImmutableSet.fromImmutableList(result);
     }
 
     /**
-     * unify two substitution, if same variable are bound with same term return a new substitution
-     * with all universal quantifiable variables in two substituition, otherwise return null
+     * Merges two substitutions: if they bind every shared variable to the same term, returns a new
+     * substitution containing all bindings of both; otherwise (a conflicting binding) returns
+     * {@code null}.
      */
-    private Substitution unifySubstitution(Substitution sub0, Substitution sub1) {
-        final ImmutableMap<QuantifiableVariable, Term> varMap1 = sub1.getVarMap();
-        ImmutableMap<QuantifiableVariable, Term> resMap = varMap1;
+    private Substitution mergeIfCompatible(Substitution left, Substitution right) {
+        final ImmutableMap<QuantifiableVariable, Term> rightMap = right.getVarMap();
+        ImmutableMap<QuantifiableVariable, Term> mergedMap = rightMap;
 
-        for (final ImmutableMapEntry<QuantifiableVariable, Term> en : sub0.getVarMap()) {
-            QuantifiableVariable key = en.key();
-            Term value = en.value();
-            if (varMap1.containsKey(key)) {
-                if (!(varMap1.get(key).equals(value))) {
+        for (final ImmutableMapEntry<QuantifiableVariable, Term> entry : left.getVarMap()) {
+            QuantifiableVariable key = entry.key();
+            Term value = entry.value();
+            if (rightMap.containsKey(key)) {
+                if (!(rightMap.get(key).equals(value))) {
                     return null;
                 }
             }
-            resMap = resMap.put(key, value);
+            mergedMap = mergedMap.put(key, value);
         }
-        return new Substitution(resMap);
+        return new Substitution(mergedMap);
     }
 
     @Override
-    public boolean equals(Object arg0) {
-        if (!(arg0 instanceof MultiTrigger a)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof MultiTrigger otherTrigger)) {
             return false;
         }
 
-        return a.triggers.equals(triggers);
+        return otherTrigger.elements.equals(elements);
     }
 
     @Override
     public int hashCode() {
-        return triggers.hashCode();
+        return elements.hashCode();
     }
 
     @Override
     public String toString() {
-        return String.valueOf(triggers);
+        return String.valueOf(elements);
     }
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Substitution.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/Substitution.java
@@ -15,6 +15,7 @@ import org.key_project.logic.TermCreationException;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
+import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableSet;
 
@@ -94,10 +95,79 @@ public class Substitution {
 
     /**
      * Try to apply the substitution to a term, introducing casts if necessary (may never be the
-     * case any more, XXX)
+     * case any more, XXX).
+     * <p>
+     * Fast path: all variables are substituted in a single traversal ({@link #applyGroundOnePass}).
+     * This is sound because the substitution is ground (the instances contain no free variables, so
+     * no capture can happen); shadowing of a substituted variable by a binder inside {@code t} is
+     * respected. If a cast is required (the slow, possibly dead path), it falls back to the
+     * per-variable substitution {@link #applyWithoutCastsPerVar}.
      */
     public Term applyWithoutCasts(Term t, Services services) {
         assert isGround() : "non-ground substitutions are not yet implemented: " + this;
+        final TermBuilder tb = services.getTermBuilder();
+        try {
+            return applyGroundOnePass((JTerm) t, ImmutableList.nil(), tb);
+        } catch (TermCreationException e) {
+            return applyWithoutCastsPerVar(t, services);
+        }
+    }
+
+    /**
+     * Substitute every variable of {@link #varMap} in a single traversal of {@code t}. A variable
+     * occurrence is replaced unless it is shadowed, i.e. re-bound by a binder above it (tracked in
+     * {@code boundAbove}). Subterms in which no substituted variable occurs free are returned
+     * unchanged.
+     */
+    private JTerm applyGroundOnePass(JTerm t, ImmutableList<QuantifiableVariable> boundAbove,
+            TermBuilder tb) {
+        // Variable leaves (the most common node) are handled directly, without the freeVars
+        // bookkeeping of containsSubstVar.
+        if (t.op() instanceof QuantifiableVariable qv) {
+            final Term inst = varMap.get(qv);
+            return inst != null && !boundAbove.contains(qv) ? (JTerm) inst : t;
+        }
+        if (!containsSubstVar(t)) {
+            return t;
+        }
+        final int arity = t.arity();
+        final JTerm[] newSubs = new JTerm[arity];
+        boolean changed = false;
+        for (int i = 0; i < arity; i++) {
+            final JTerm sub = t.sub(i);
+            ImmutableList<QuantifiableVariable> below = boundAbove;
+            final var boundHere = t.varsBoundHere(i);
+            for (int j = 0; j < boundHere.size(); j++) {
+                below = below.prepend(boundHere.get(j));
+            }
+            newSubs[i] = applyGroundOnePass(sub, below, tb);
+            if (newSubs[i] != sub) {
+                changed = true;
+            }
+        }
+        if (!changed) {
+            return t;
+        }
+        return tb.tf().createTerm(t.op(), newSubs, t.boundVars(), t.getLabels());
+    }
+
+    /** Whether any variable of {@link #varMap} occurs free in {@code t}. */
+    private boolean containsSubstVar(JTerm t) {
+        final ImmutableSet<QuantifiableVariable> free = t.freeVars();
+        if (free.isEmpty()) {
+            return false;
+        }
+        final Iterator<QuantifiableVariable> it = varMap.keyIterator();
+        while (it.hasNext()) {
+            if (free.contains(it.next())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Per-variable substitution (one {@link ClashFreeSubst} pass per variable), with casts. */
+    private Term applyWithoutCastsPerVar(Term t, Services services) {
         final TermBuilder tb = services.getTermBuilder();
         final Iterator<QuantifiableVariable> it = varMap.keyIterator();
         while (it.hasNext()) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggerUtils.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggerUtils.java
@@ -53,10 +53,9 @@ class TriggerUtils {
             ImmutableSet<? extends QuantifiableVariable> set1) {
         ImmutableSet<QuantifiableVariable> res = DefaultImmutableSet.nil();
         if (!set0.isEmpty() && !set1.isEmpty()) {
-            for (QuantifiableVariable aSet0 : set0) {
-                final QuantifiableVariable el = aSet0;
-                if (set1.contains(el)) {
-                    res = res.add(el);
+            for (QuantifiableVariable element : set0) {
+                if (set1.contains(element)) {
+                    res = res.add(element);
                 }
             }
         }
@@ -69,13 +68,16 @@ class TriggerUtils {
             ImmutableSet<? extends QuantifiableVariable> set2) {
 
         final int size0 = set0.size();
-        final int size1 = set0.size();
-        final int size2 = set0.size();
+        final int size1 = set1.size();
+        final int size2 = set2.size();
 
         if (size0 == 0 || size1 == 0 || size2 == 0) {
             return DefaultImmutableSet.nil();
         }
 
+        // Intersect the two smaller sets first (smaller intermediate result), leaving the largest
+        // set for the outer intersection. The three-way result is order-independent, so this only
+        // affects work, not the outcome.
         if (size0 < size2 && size1 < size2) {
             return intersect(intersect(set0, set1), set2);
         } else if (size0 < size1 && size2 < size1) {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggersSet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TriggersSet.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.strategy.quantifierHeuristics;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -50,7 +49,7 @@ public class TriggersSet {
         this.allTerm = allTerm;
         replacementWithMVs =
             ReplacerOfQuanVariablesWithMetavariables.createSubstitutionForVars(allTerm, services);
-        uniQuantifiedVariables = getAllUQS(allTerm);
+        uniQuantifiedVariables = collectUniversalVariables(allTerm);
         initTriggers(services);
     }
 
@@ -78,14 +77,14 @@ public class TriggersSet {
      * @param allterm
      * @return return all univesal variables of <code>allterm</code>
      */
-    private ImmutableSet<QuantifiableVariable> getAllUQS(JTerm allterm) {
+    private ImmutableSet<QuantifiableVariable> collectUniversalVariables(JTerm allterm) {
         final var op = allterm.op();
         if (op == Quantifier.ALL) {
             QuantifiableVariable v = allterm.varsBoundHere(0).get(0);
-            return getAllUQS(allterm.sub(0)).add(v);
+            return collectUniversalVariables(allterm.sub(0)).add(v);
         }
         if (op == Quantifier.EX) {
-            return getAllUQS(allterm.sub(0));
+            return collectUniversalVariables(allterm.sub(0));
         }
         return DefaultImmutableSet.nil();
     }
@@ -94,15 +93,15 @@ public class TriggersSet {
      * initial all <code>Trigger</code>s by finding triggers in every clauses
      */
     private void initTriggers(Services services) {
-        final QuantifiableVariable var = allTerm.varsBoundHere(0).get(0);
-        final var it =
+        final QuantifiableVariable firstVariable = allTerm.varsBoundHere(0).get(0);
+        final var clauses =
             TriggerUtils.iteratorByOperator(TriggerUtils.discardQuantifiers(allTerm), Junctor.AND);
-        while (it.hasNext()) {
-            final var clause = (JTerm) it.next();
-            // a trigger should contain the first variable of allTerm
-            if (clause.freeVars().contains(var)) {
-                ClauseTrigger ct = new ClauseTrigger(clause);
-                ct.createTriggers(services);
+        while (clauses.hasNext()) {
+            final var clause = (JTerm) clauses.next();
+            // a trigger must contain the first variable of the quantified formula
+            if (clause.freeVars().contains(firstVariable)) {
+                ClauseTriggerFinder finder = new ClauseTriggerFinder(clause);
+                finder.createTriggers(services);
             }
         }
     }
@@ -116,14 +115,15 @@ public class TriggersSet {
      *        multi-trigger
      * @return a <code>Trigger</code> with <code>trigger</code> as its term
      */
-    private Trigger createUniTrigger(JTerm trigger, ImmutableSet<QuantifiableVariable> qvs,
-            boolean isUnify, boolean isElement) {
-        Trigger t = termToTrigger.get(trigger);
-        if (t == null) {
-            t = new UniTrigger(trigger, qvs, isUnify, isElement, this);
-            termToTrigger.put(trigger, t);
+    private Trigger createUniTrigger(JTerm trigger,
+            ImmutableSet<QuantifiableVariable> universalVariables, boolean isUnify,
+            boolean isElement) {
+        Trigger cached = termToTrigger.get(trigger);
+        if (cached == null) {
+            cached = new UniTrigger(trigger, universalVariables, isUnify, isElement, this);
+            termToTrigger.put(trigger, cached);
         }
-        return t;
+        return cached;
     }
 
     /**
@@ -133,9 +133,9 @@ public class TriggersSet {
      * @param qvs all universal varaibles of all <code>clause</code>
      * @return the MultTrigger for the given triggers
      */
-    private Trigger createMultiTrigger(ImmutableSet<Trigger> trs, JTerm clause,
-            ImmutableSet<QuantifiableVariable> qvs) {
-        return new MultiTrigger(trs, qvs, clause);
+    private Trigger createMultiTrigger(ImmutableSet<Trigger> elements, JTerm clause,
+            ImmutableSet<QuantifiableVariable> clauseVariables) {
+        return new MultiTrigger(elements, clauseVariables, clause);
     }
 
     /**
@@ -150,20 +150,21 @@ public class TriggersSet {
      * variables in the literal in. Afterwards, a set of multi-triggers will be constructed by
      * combining thoes elements so that all variables in clause should be include by some of them.
      */
-    private class ClauseTrigger {
+    private class ClauseTriggerFinder {
 
         final JTerm clause;
         /** all unversal variables of <code>clause</code> */
-        final ImmutableSet<QuantifiableVariable> selfUQVS;
+        final ImmutableSet<QuantifiableVariable> clauseVariables;
         /**
          * elements which are uni-trigges and will be used to construct several multi-triggers for
          * <code>clause</code>
          */
         private ImmutableSet<Trigger> elementsOfMultiTrigger = DefaultImmutableSet.nil();
 
-        public ClauseTrigger(JTerm clause) {
+        public ClauseTriggerFinder(JTerm clause) {
             this.clause = clause;
-            selfUQVS = TriggerUtils.intersect(this.clause.freeVars(), uniQuantifiedVariables);
+            clauseVariables =
+                TriggerUtils.intersect(this.clause.freeVars(), uniQuantifiedVariables);
 
         }
 
@@ -173,18 +174,18 @@ public class TriggersSet {
          * multi-triggers from those elements.
          */
         public void createTriggers(Services services) {
-            final var it = TriggerUtils.iteratorByOperator(clause, Junctor.OR);
-            while (it.hasNext()) {
-                final JTerm oriTerm = (JTerm) it.next();
-                for (JTerm term : expandIfThenElse(oriTerm, services)) {
-                    JTerm t = term;
-                    if (t.op() == Junctor.NOT) {
-                        t = t.sub(0);
+            final var literals = TriggerUtils.iteratorByOperator(clause, Junctor.OR);
+            while (literals.hasNext()) {
+                final JTerm literal = (JTerm) literals.next();
+                for (JTerm term : expandIfThenElse(literal, services)) {
+                    JTerm positive = term;
+                    if (positive.op() == Junctor.NOT) {
+                        positive = positive.sub(0);
                     }
-                    recAddTriggers(t, services);
+                    addMaximalUniTriggers(positive, services);
                 }
             }
-            setMultiTriggers(elementsOfMultiTrigger.iterator());
+            buildCoveringMultiTriggers(elementsOfMultiTrigger.iterator());
         }
 
         /**
@@ -192,18 +193,18 @@ public class TriggersSet {
          * @param services the Services
          * @return true if find any trigger from <code>term</code>
          */
-        private boolean recAddTriggers(JTerm term, Services services) {
+        private boolean addMaximalUniTriggers(JTerm term, Services services) {
             if (!mightContainTriggers(term)) {
                 return false;
             }
 
             final ImmutableSet<QuantifiableVariable> uniVarsInTerm =
-                TriggerUtils.intersect(term.freeVars(), selfUQVS);
+                TriggerUtils.intersect(term.freeVars(), clauseVariables);
 
             boolean foundSubtriggers = false;
             for (int i = 0; i < term.arity(); i++) {
                 final JTerm subTerm = term.sub(i);
-                final boolean found = recAddTriggers(subTerm, services);
+                final boolean found = addMaximalUniTriggers(subTerm, services);
 
                 if (found && uniVarsInTerm.subset(subTerm.freeVars())) {
                     foundSubtriggers = true;
@@ -218,53 +219,51 @@ public class TriggersSet {
             return true;
         }
 
-        private Set<JTerm> expandIfThenElse(JTerm t, TermServices services) {
-            final Set<JTerm>[] possibleSubs = new Set[t.arity()];
+        @SuppressWarnings("unchecked")
+        private Set<JTerm> expandIfThenElse(JTerm term, TermServices services) {
+            final Set<JTerm>[] possibleSubs = new Set[term.arity()];
             boolean changed = false;
-            for (int i = 0; i != t.arity(); ++i) {
-                final JTerm oriSub = t.sub(i);
-                possibleSubs[i] = expandIfThenElse(oriSub, services);
+            for (int i = 0; i != term.arity(); ++i) {
+                final JTerm originalSub = term.sub(i);
+                possibleSubs[i] = expandIfThenElse(originalSub, services);
                 changed = changed || possibleSubs[i].size() != 1
-                        || possibleSubs[i].iterator().next() != oriSub;
+                        || possibleSubs[i].iterator().next() != originalSub;
             }
 
-            final Set<JTerm> res = new LinkedHashSet<>();
-            if (t.op() == IfThenElse.IF_THEN_ELSE) {
-                res.addAll(possibleSubs[1]);
-                res.addAll(possibleSubs[2]);
+            final Set<JTerm> expansions = new LinkedHashSet<>();
+            if (term.op() == IfThenElse.IF_THEN_ELSE) {
+                expansions.addAll(possibleSubs[1]);
+                expansions.addAll(possibleSubs[2]);
             }
 
             if (!changed) {
-                res.add(t);
-                return res;
+                expansions.add(term);
+                return expansions;
             }
 
-            final JTerm[] chosenSubs = new JTerm[t.arity()];
-            res.addAll(combineSubterms(t, possibleSubs, chosenSubs, t.boundVars(), 0, services));
-            return res;
+            final JTerm[] chosenSubs = new JTerm[term.arity()];
+            expansions.addAll(
+                combineSubterms(term, possibleSubs, chosenSubs, term.boundVars(), 0, services));
+            return expansions;
         }
 
-        private Set<JTerm> combineSubterms(JTerm oriTerm, Set<JTerm>[] possibleSubs,
-                JTerm[] chosenSubs,
-                ImmutableArray<QuantifiableVariable> boundVars, int i,
+        private Set<JTerm> combineSubterms(JTerm originalTerm, Set<JTerm>[] possibleSubs,
+                JTerm[] chosenSubs, ImmutableArray<QuantifiableVariable> boundVars, int i,
                 TermServices services) {
-            final HashSet<JTerm> set = new LinkedHashSet<>();
+            final Set<JTerm> result = new LinkedHashSet<>();
             if (i >= possibleSubs.length) {
-                final JTerm res = services.getTermFactory().createTerm(oriTerm.op(), chosenSubs,
-                    boundVars, null);
-
-
-                set.add(res);
-                return set;
+                final JTerm combined = services.getTermFactory().createTerm(originalTerm.op(),
+                    chosenSubs, boundVars, null);
+                result.add(combined);
+                return result;
             }
 
-
-            for (JTerm term : possibleSubs[i]) {
-                chosenSubs[i] = term;
-                set.addAll(
-                    combineSubterms(oriTerm, possibleSubs, chosenSubs, boundVars, i + 1, services));
+            for (JTerm chosen : possibleSubs[i]) {
+                chosenSubs[i] = chosen;
+                result.addAll(combineSubterms(originalTerm, possibleSubs, chosenSubs, boundVars,
+                    i + 1, services));
             }
-            return set;
+            return result;
         }
 
         /**
@@ -321,65 +320,67 @@ public class TriggersSet {
             if (!isAcceptableTrigger(term, services)) {
                 return;
             }
-            final boolean isUnify = !term.freeVars().subset(selfUQVS);
-            final boolean isElement = !selfUQVS.subset(term.freeVars());
+            final boolean isUnify = !term.freeVars().subset(clauseVariables);
+            final boolean isElement = !clauseVariables.subset(term.freeVars());
             final ImmutableSet<QuantifiableVariable> uniVarsInTerm =
-                TriggerUtils.intersect(term.freeVars(), selfUQVS);
-            Trigger t = createUniTrigger(term, uniVarsInTerm, isUnify, isElement);
+                TriggerUtils.intersect(term.freeVars(), clauseVariables);
+            Trigger trigger = createUniTrigger(term, uniVarsInTerm, isUnify, isElement);
             if (isElement) {
-                elementsOfMultiTrigger = elementsOfMultiTrigger.add(t);
+                elementsOfMultiTrigger = elementsOfMultiTrigger.add(trigger);
             } else {
-                allTriggers = allTriggers.add(t);
+                allTriggers = allTriggers.add(trigger);
             }
         }
 
 
         /**
-         * find all possible combination of <code>ts</code>. Once a combination of elements contains
-         * all variables of this clause, it will be used to construct the multi-trigger which will
-         * be add to triggers set
+         * Enumerate combinations of the multi-trigger elements and register each combination that
+         * covers all clause variables as a multi-trigger (via {@link #tryAddCoveringMultiTrigger}).
+         * A covering combination is not extended further, so only minimal covering sets are kept.
          *
-         * @param ts elements of multi-triggers at the beginning
-         * @return a set of triggers
+         * @param remainingElements the elements still to be combined
+         * @return the non-covering partial combinations (used internally for the recursion)
          */
-        private Set<ImmutableSet<Trigger>> setMultiTriggers(Iterator<Trigger> ts) {
-            Set<ImmutableSet<Trigger>> res = new LinkedHashSet<>();
-            if (ts.hasNext()) {
-                final Trigger trigger = ts.next();
-                ImmutableSet<Trigger> tsi = DefaultImmutableSet.<Trigger>nil().add(trigger);
-                res.add(tsi);
-                Set<ImmutableSet<Trigger>> nextTriggers = setMultiTriggers(ts);
+        private Set<ImmutableSet<Trigger>> buildCoveringMultiTriggers(
+                Iterator<Trigger> remainingElements) {
+            Set<ImmutableSet<Trigger>> partialCombinations = new LinkedHashSet<>();
+            if (remainingElements.hasNext()) {
+                final Trigger element = remainingElements.next();
+                ImmutableSet<Trigger> singleton = DefaultImmutableSet.<Trigger>nil().add(element);
+                partialCombinations.add(singleton);
+                Set<ImmutableSet<Trigger>> tailCombinations =
+                    buildCoveringMultiTriggers(remainingElements);
 
-                res.addAll(nextTriggers);
-                for (ImmutableSet<Trigger> nextTrigger : nextTriggers) {
-                    ImmutableSet<Trigger> next = nextTrigger;
-                    next = next.add(trigger);
-                    if (addMultiTrigger(next)) {
+                partialCombinations.addAll(tailCombinations);
+                for (ImmutableSet<Trigger> tailCombination : tailCombinations) {
+                    ImmutableSet<Trigger> combination = tailCombination.add(element);
+                    // A covering combination becomes a multi-trigger and is not extended further;
+                    // its supersets would be redundant.
+                    if (tryAddCoveringMultiTrigger(combination)) {
                         continue;
                     }
-                    res.add(next);
+                    partialCombinations.add(combination);
                 }
             }
-            return res;
+            return partialCombinations;
         }
 
         /**
-         * try to construct a multi-trigger by given <code>ts</code>
+         * If the given combination of elements together covers all universal variables of the
+         * clause, build a multi-trigger from it, add it to the trigger set and return {@code true};
+         * otherwise return {@code false}.
          *
-         * @param trs a set of trigger
-         * @return true if <code>trs</code> contains all universal varaibles of this clause, and add
-         *         the contstructed multi-trigger to triggers set
+         * @param combination a set of uni-trigger elements
          */
-        private boolean addMultiTrigger(ImmutableSet<Trigger> trs) {
-            ImmutableSet<QuantifiableVariable> mulqvs =
-                DefaultImmutableSet.nil();
-            for (Trigger tr : trs) {
-                mulqvs =
-                    mulqvs.union(((JTerm) tr.getTriggerTerm()).freeVars());
+        private boolean tryAddCoveringMultiTrigger(ImmutableSet<Trigger> combination) {
+            ImmutableSet<QuantifiableVariable> coveredVariables = DefaultImmutableSet.nil();
+            for (Trigger element : combination) {
+                coveredVariables =
+                    coveredVariables.union(((JTerm) element.getTriggerTerm()).freeVars());
             }
-            if (selfUQVS.subset(mulqvs)) {
-                Trigger mt = createMultiTrigger(trs, clause, selfUQVS);
-                allTriggers = allTriggers.add(mt);
+            if (clauseVariables.subset(coveredVariables)) {
+                Trigger multiTrigger = createMultiTrigger(combination, clause, clauseVariables);
+                allTriggers = allTriggers.add(multiTrigger);
                 return true;
             }
             return false;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/UniTrigger.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/quantifierHeuristics/UniTrigger.java
@@ -17,55 +17,65 @@ import org.key_project.util.collection.ImmutableMap;
 import org.key_project.util.collection.ImmutableSet;
 
 
+/**
+ * A trigger consisting of a single term. Matching it against a target term yields the substitutions
+ * for the quantified variables; results are cached per target term.
+ */
 class UniTrigger implements Trigger {
 
     private final Term trigger;
-    private final ImmutableSet<QuantifiableVariable> uqvs;
+    /** The universal variables this trigger binds. */
+    private final ImmutableSet<QuantifiableVariable> universalVariables;
 
-    private final TriggersSet triggerSetThisBelongsTo;
+    private final TriggersSet owningTriggerSet;
 
+    /**
+     * If {@code true} the trigger carries a non-universal (existential) variable and may therefore
+     * only be matched by (two-sided) unification, not by basic matching.
+     */
     private final boolean onlyUnify;
     private final boolean isElementOfMultitrigger;
 
     private final LRUCache<Term, ImmutableSet<Substitution>> matchResults =
         new LRUCache<>(1000);
 
-    UniTrigger(Term trigger, ImmutableSet<QuantifiableVariable> uqvs, boolean isUnify,
-            boolean isElementOfMultitrigger, TriggersSet triggerSetThisBelongsTo) {
+    UniTrigger(Term trigger, ImmutableSet<QuantifiableVariable> universalVariables,
+            boolean onlyUnify,
+            boolean isElementOfMultitrigger, TriggersSet owningTriggerSet) {
         this.trigger = trigger;
-        this.uqvs = uqvs;
-        this.onlyUnify = isUnify;
+        this.universalVariables = universalVariables;
+        this.onlyUnify = onlyUnify;
         this.isElementOfMultitrigger = isElementOfMultitrigger;
-        this.triggerSetThisBelongsTo = triggerSetThisBelongsTo;
+        this.owningTriggerSet = owningTriggerSet;
     }
 
     @Override
-    public ImmutableSet<Substitution> getSubstitutionsFromTerms(ImmutableSet<Term> targetTerm,
+    public ImmutableSet<Substitution> getSubstitutionsFromTerms(ImmutableSet<Term> targetTerms,
             Services services) {
-        ImmutableSet<Substitution> allsubs = DefaultImmutableSet.nil();
-        for (Term aTargetTerm : targetTerm) {
-            allsubs = allsubs.union(getSubstitutionsFromTerm(aTargetTerm, services));
+        ImmutableSet<Substitution> allSubs = DefaultImmutableSet.nil();
+        for (Term target : targetTerms) {
+            allSubs = allSubs.union(cachedSubstitutionsForTerm(target, services));
         }
-        return allsubs;
+        return allSubs;
     }
 
-    private ImmutableSet<Substitution> getSubstitutionsFromTerm(Term t, Services services) {
-        ImmutableSet<Substitution> res = matchResults.get(t);
-        if (res == null) {
-            res = getSubstitutionsFromTermHelp(t, services);
-            matchResults.put(t, res);
+    private ImmutableSet<Substitution> cachedSubstitutionsForTerm(Term target, Services services) {
+        ImmutableSet<Substitution> subs = matchResults.get(target);
+        if (subs == null) {
+            subs = computeSubstitutionsForTerm(target, services);
+            matchResults.put(target, subs);
         }
-        return res;
+        return subs;
     }
 
-    private ImmutableSet<Substitution> getSubstitutionsFromTermHelp(Term t, Services services) {
-        ImmutableSet<Substitution> newSubs = DefaultImmutableSet.nil();
-        if (t.freeVars().size() > 0 || t.op() instanceof Quantifier) {
-            newSubs = Matching.twoSidedMatching(this, t, services);
+    private ImmutableSet<Substitution> computeSubstitutionsForTerm(Term target, Services services) {
+        ImmutableSet<Substitution> subs = DefaultImmutableSet.nil();
+        if (target.freeVars().size() > 0 || target.op() instanceof Quantifier) {
+            subs = Matching.twoSidedMatching(this, target, services);
         } else if (!onlyUnify) {
-            newSubs = Matching.basicMatching(this, t);
+            subs = Matching.basicMatching(this, target);
         }
-        return newSubs;
+        return subs;
     }
 
 
@@ -74,11 +84,11 @@ class UniTrigger implements Trigger {
         return trigger;
     }
 
-    public boolean equals(Object arg0) {
-        if (!(arg0 instanceof UniTrigger a)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof UniTrigger otherTrigger)) {
             return false;
         }
-        return a.trigger.equals(trigger);
+        return otherTrigger.trigger.equals(trigger);
     }
 
     public int hashCode() {
@@ -90,41 +100,37 @@ class UniTrigger implements Trigger {
     }
 
     ImmutableSet<QuantifiableVariable> getUniVariables() {
-        return uqvs;
+        return universalVariables;
     }
 
     public TriggersSet getTriggerSetThisBelongsTo() {
-        return triggerSetThisBelongsTo;
+        return owningTriggerSet;
     }
 
 
 
     /**
-     * use similar algorithm as basic matching to detect loop
-     *
-     * @param candidate
-     * @param searchTerm
+     * Loop test: reject a candidate trigger if matching it against the search term produces a
+     * substitution that defines some variable cyclically in terms of itself (which would loop
+     * during instantiation). Uses the same matching as basic matching to find the substitutions.
      */
     public static boolean passedLoopTest(Term candidate, Term searchTerm) {
-        final ImmutableSet<Substitution> substs =
+        final ImmutableSet<Substitution> substitutions =
             BasicMatching.getSubstitutions(candidate, searchTerm);
 
-        for (Substitution subst1 : substs) {
-            final Substitution subst = subst1;
-            if (containsLoop(subst)) {
+        for (Substitution substitution : substitutions) {
+            if (containsCycle(substitution)) {
                 return false;
             }
         }
         return true;
     }
 
-    /**
-     * Test whether this substitution constains loop. It is mainly used for unitrigger's loop test.
-     */
-    private static boolean containsLoop(Substitution subst) {
-        final var it = subst.getVarMap().keyIterator();
-        while (it.hasNext()) {
-            if (containsLoop(subst.getVarMap(), it.next())) {
+    /** Whether some variable of the substitution is (transitively) defined in terms of itself. */
+    private static boolean containsCycle(Substitution substitution) {
+        final var keys = substitution.getVarMap().keyIterator();
+        while (keys.hasNext()) {
+            if (reachesItself(substitution.getVarMap(), keys.next())) {
                 return true;
             }
         }
@@ -132,45 +138,47 @@ class UniTrigger implements Trigger {
     }
 
     /**
-     * Code copied from logic.EqualityConstraint
+     * Worklist reachability check (originally adapted from EqualityConstraint): starting from the
+     * term bound to {@code var}, follow variable bindings transitively and report whether
+     * {@code var}
+     * is reached again -- i.e. whether its definition is cyclic.
      */
-    private static boolean containsLoop(
+    private static boolean reachesItself(
             ImmutableMap<QuantifiableVariable, Term> varMap,
             QuantifiableVariable var) {
-        ImmutableList<QuantifiableVariable> body = ImmutableList.nil();
-        ImmutableList<Term> fringe = ImmutableList.nil();
-        Term checkForCycle = varMap.get(var);
+        ImmutableList<QuantifiableVariable> visited = ImmutableList.nil();
+        ImmutableList<Term> pending = ImmutableList.nil();
+        Term current = varMap.get(var);
 
-        if (checkForCycle.op() == var) {
+        if (current.op() == var) {
             return false;
         }
 
         while (true) {
-            for (var quantifiableVariable : checkForCycle.freeVars()) {
-                final QuantifiableVariable termVar = quantifiableVariable;
-                if (!body.contains(termVar)) {
-                    final var termVarterm = (JTerm) varMap.get(termVar);
-                    if (termVarterm != null) {
-                        if (termVarterm.freeVars().contains(var)) {
+            for (var freeVar : current.freeVars()) {
+                if (!visited.contains(freeVar)) {
+                    final var boundTerm = (JTerm) varMap.get(freeVar);
+                    if (boundTerm != null) {
+                        if (boundTerm.freeVars().contains(var)) {
                             return true;
                         }
-                        fringe = fringe.prepend(termVarterm);
+                        pending = pending.prepend(boundTerm);
                     }
 
-                    if (termVar == var) {
+                    if (freeVar == var) {
                         return true;
                     }
 
-                    body = body.prepend(termVar);
+                    visited = visited.prepend(freeVar);
                 }
             }
 
-            if (fringe.isEmpty()) {
+            if (pending.isEmpty()) {
                 return false;
             }
 
-            checkForCycle = fringe.head();
-            fringe = fringe.tail();
+            current = pending.head();
+            pending = pending.tail();
         }
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.strategy.quantifierHeuristics;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.*;
 import de.uka.ilkd.key.logic.op.JFunction;
@@ -13,15 +16,18 @@ import de.uka.ilkd.key.rule.TacletForTests;
 
 import org.key_project.logic.Name;
 import org.key_project.logic.Namespace;
+import org.key_project.logic.Term;
 import org.key_project.logic.op.Function;
 import org.key_project.logic.op.QuantifiableVariable;
 import org.key_project.logic.sort.Sort;
+import org.key_project.util.collection.ImmutableSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 // most Code are copyed from Logic.TestUpdateFactory
@@ -218,6 +224,150 @@ public class TestTriggersSet {
         assertEquals(1, triggerNum);
         var trigger2 = ts.getAllTriggers().iterator().next().getTriggerTerm();
         assertEquals(trigger1, trigger2);
+    }
+
+    // --- Characterization tests ---------------------------------------------------------------
+    // These pin the CURRENT trigger-set output to guard the cleanup/restructure refactor; they are
+    // a behavior-preservation net, NOT a statement that the current output is ideal. Cases marked
+    // "SCRUTINIZE" are deliberate-tuning candidates for the later inequality/specificity step and
+    // must not be treated as desirable behavior to keep forever.
+
+    private ImmutableSet<Trigger> triggersOf(String formula) {
+        return TriggersSet.create(parseTerm(formula), proof.getServices()).getAllTriggers();
+    }
+
+    @Test
+    public void existentialInnerVariableYieldsUniTrigger() {
+        // forall x. exists y. prs(x,y): the existential variable is carried in the trigger; still a
+        // single uni-trigger (matched two-sidedly because it contains a non-universal variable).
+        final JTerm all = parseTerm("\\forall r x;(\\exists s y;(prs(x,y)))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(1, triggers.size());
+        assertEquals(all.sub(0).sub(0), triggers.iterator().next().getTriggerTerm()); // prs(x,y)
+    }
+
+    @Test
+    public void conjunctionYieldsOneTriggerPerClause() {
+        // forall x. (pr(x) & pr(frr(x))): the matrix is AND-split into two clauses, each
+        // contributing its own trigger.
+        final JTerm all = parseTerm("\\forall r x;(pr(x) & pr(frr(x)))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(2, triggers.size());
+        final Set<Term> expected = new HashSet<>();
+        expected.add(all.sub(0).sub(0)); // pr(x)
+        expected.add(all.sub(0).sub(1).sub(0)); // frr(x) inside pr(frr(x))
+        final Set<Term> actual = new HashSet<>();
+        for (Trigger tr : triggers) {
+            actual.add(tr.getTriggerTerm());
+        }
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bodyWithoutOuterVariableHasNoTriggers() {
+        // forall x. forall y. ps(y): no literal mentions the OUTER variable x, so the
+        // first-variable
+        // requirement rejects every candidate -> no triggers at all. (Refactor-fragile invariant.)
+        final ImmutableSet<Trigger> triggers = triggersOf("\\forall r x;(\\forall s y;(ps(y)))");
+        assertEquals(0, triggers.size());
+    }
+
+    @Test
+    public void negatedGuardLiteralTriggersFromGuard() {
+        // The canonical quantifier shape forall x. (!guard | post) == (guard -> post): the NOT
+        // is stripped, so triggers come from BOTH the guard and the post (here frr(x) and pr(x)).
+        final JTerm all = parseTerm("\\forall r x;(!pr(frr(x)) | pr(x))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(2, triggers.size());
+        final Set<Term> expected = new HashSet<>();
+        expected.add(all.sub(0).sub(0).sub(0).sub(0)); // frr(x), inside !pr(frr(x))
+        expected.add(all.sub(0).sub(1)); // pr(x)
+        final Set<Term> actual = new HashSet<>();
+        for (Trigger tr : triggers) {
+            assertTrue(tr instanceof UniTrigger);
+            actual.add(tr.getTriggerTerm());
+        }
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void negatedLiteralParticipatesInMultiTrigger() {
+        // forall x,y. (!pr(x) | ps(y)): the negated guard (covering only x) joins ps(y) in one
+        // multi-trigger; the clause term keeps the negation, the matched element strips it.
+        final ImmutableSet<Trigger> triggers =
+            triggersOf("\\forall r x;(\\forall s y;(!pr(x) | ps(y)))");
+        assertEquals(1, triggers.size());
+        assertTrue(triggers.iterator().next() instanceof MultiTrigger);
+    }
+
+    @Test
+    public void uniTriggerDescendsPastPredicate() {
+        // pr(frr(x)) -> the term argument frr(x), not the predicate literal.
+        final JTerm all = parseTerm("\\forall r x;(pr(frr(x)))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(1, triggers.size());
+        assertEquals(all.sub(0).sub(0), triggers.iterator().next().getTriggerTerm()); // frr(x)
+    }
+
+    @Test
+    public void uniTriggerPicksInnermostSubterm() {
+        // pr(frr(f2rr(x))) -> f2rr(x): descends to the INNERMOST subterm still containing the bound
+        // variable, i.e. a very general trigger. SCRUTINIZE (over-general -> excess instantiation).
+        final JTerm all = parseTerm("\\forall r x;(pr(frr(f2rr(x))))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(1, triggers.size());
+        assertEquals(all.sub(0).sub(0).sub(0), triggers.iterator().next().getTriggerTerm()); // f2rr(x)
+    }
+
+    @Test
+    public void fullCoverUniTriggerPreferredOverElements() {
+        // prs(x,y) covers both clause variables -> single uni-trigger; partial pr(x) is dropped.
+        final JTerm all = parseTerm("\\forall r x;(\\forall s y;(prs(x,y) | pr(x)))");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(1, triggers.size());
+        final Trigger only = triggers.iterator().next();
+        assertTrue(only instanceof UniTrigger);
+        assertEquals(all.sub(0).sub(0).sub(0), only.getTriggerTerm()); // prs(x,y)
+    }
+
+    @Test
+    public void multiTriggerAcrossLiterals() {
+        // pr(x) | ps(y): neither literal covers {x,y} -> one multi-trigger over the clause.
+        final ImmutableSet<Trigger> triggers =
+            triggersOf("\\forall r x;(\\forall s y;(pr(x) | ps(y)))");
+        assertEquals(1, triggers.size());
+        assertTrue(triggers.iterator().next() instanceof MultiTrigger);
+    }
+
+    @Test
+    public void multiTriggerPowersetEnumeratesCoveringCombinations() {
+        // pr(x) | pr(frr(x)) | ps(y): the two x-elements {pr(x), frr(x)} each combine with ps(y)
+        // into TWO minimal covering multi-triggers (supersets pruned). Pins the powerset
+        // cardinality
+        // so the restructure step must preserve it.
+        final ImmutableSet<Trigger> triggers =
+            triggersOf("\\forall r x;(\\forall s y;(pr(x) | pr(frr(x)) | ps(y)))");
+        assertEquals(2, triggers.size());
+        for (Trigger tr : triggers) {
+            assertTrue(tr instanceof MultiTrigger);
+        }
+    }
+
+    @Test
+    public void equalityExcludedButSubtermStillTriggers() {
+        // frr(x) = r_a: the equality op is excluded (isAcceptableTrigger), but subterm frr(x) still
+        // triggers. Pins the equality handling, relevant to the later inequality knob. SCRUTINIZE.
+        final JTerm all = parseTerm("\\forall r x;(frr(x) = r_a)");
+        final ImmutableSet<Trigger> triggers =
+            TriggersSet.create(all, proof.getServices()).getAllTriggers();
+        assertEquals(1, triggers.size());
+        assertEquals(all.sub(0).sub(0), triggers.iterator().next().getTriggerTerm()); // frr(x)
     }
 
     @Test


### PR DESCRIPTION
## Intended Change

Code-quality cleanup of the quantifier-instantiation heuristic plus two behaviour-preserving speed-ups: (1) trigger-set construction is clarified and now has characterization tests, and a dead set-size heuristic is fixed; (2) ground substitutions are applied in a single term traversal instead of one pass per variable (~3.6 -> 1); (3) the arithmetic prover is skipped for non-arithmetic literals, which dominate (~98% even on arithmetic proofs). Behaviour-preserving (identical proof node counts across runAllProofs).

## Benchmark

Automode time, median of 3 runs, serial forks (`-PrapForks=1`), isolated `user.home` per run; baseline = current main (8 representative proofs: 4 quantifier-heavy + 4 mixed). _ArrayList.remove.1 is high-variance run-to-run — treat as noise._ The gains **concentrate on quantifier-heavy proofs** (PUZ031p1, SYN550p1), as expected.

| proof | baseline (ms) | this PR (ms) | Δ |
|---|--:|--:|--:|
| PUZ031p1 | 13712 | 7939 | -42% |
| SimplifiedLinkedList.remove | 17469 | 16651 | -5% |
| Saddleback | 13026 | 12586 | -3% |
| SYN550p1 | 821 | 630 | -23% |
| symmArray | 12737 | 12129 | -5% |
| gemplusDecimal | 8378 | 8452 | +1% |
| coincidence | 2181 | 2220 | +2% |
| ArrayList.remove.1 | 3339 | 3137 | -6% |
| **TOTAL** | **71663** | **63744** | **-11%** |

## Plan

* [x] Add a focused per-PR benchmark to this description
* [x] Mark ready for review once the Performance Series 2 determinism gate passes (see overview)

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality (`TestTriggersSet` characterization tests).
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

Part of **Performance Series 2** — see the overview (#3879) for the combined benchmark and series context.

Created with AI tooling support.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
