### PR TITLE
Fix fast-click auto-mode crash: overlapping runs + proof breaking proof listeners

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/control/DefaultProofControl.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/control/DefaultProofControl.java
@@ -31,9 +31,11 @@ public class DefaultProofControl extends AbstractProofControl {
     private final UserInterfaceControl ui;
 
     /**
-     * The currently running {@link Thread}.
+     * The currently running {@link Thread}, or {@code null} if no auto mode / macro run is active.
+     * {@code volatile} so the null-out from the run thread's {@code finally} is visible to callers
+     * of {@link #isInAutoMode()} / {@link #startAutoMode} / {@link #runMacro} on other threads.
      */
-    private Thread autoModeThread;
+    private volatile Thread autoModeThread;
 
     /**
      * Constructor.
@@ -132,7 +134,7 @@ public class DefaultProofControl extends AbstractProofControl {
      * {@inheritDoc}
      */
     @Override
-    public void runMacro(Node node, ProofMacro macro,
+    public synchronized void runMacro(Node node, ProofMacro macro,
             PosInOccurrence posInOcc) {
         if (!isInAutoMode()) {
             autoModeThread = new MacroThread(node, macro, posInOcc);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -43,6 +43,8 @@ import org.key_project.util.lookup.Lookup;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -76,6 +78,8 @@ public class Proof implements ProofObject<Goal>, Named {
      * list with prooftree listeners of this proof attention: firing events makes use of array
      * list's random access nature
      */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Proof.class);
+
     private final List<ProofTreeListener> listenerList = new LinkedList<>();
 
     /**
@@ -813,9 +817,7 @@ public class Proof implements ProofObject<Goal>, Named {
     public void fireProofExpanded(Node node) {
         ProofTreeEvent e = new ProofTreeEvent(this, node);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofExpanded(e);
-            }
+            notifyListeners(listenerList, l -> l.proofExpanded(e));
         }
     }
 
@@ -825,9 +827,7 @@ public class Proof implements ProofObject<Goal>, Named {
     protected void fireProofIsBeingPruned(Node below) {
         ProofTreeEvent e = new ProofTreeEvent(this, below);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofIsBeingPruned(e);
-            }
+            notifyListeners(listenerList, l -> l.proofIsBeingPruned(e));
         }
     }
 
@@ -837,9 +837,7 @@ public class Proof implements ProofObject<Goal>, Named {
     protected void fireProofPruned(Node below) {
         ProofTreeEvent e = new ProofTreeEvent(this, below);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofPruned(e);
-            }
+            notifyListeners(listenerList, l -> l.proofPruned(e));
         }
     }
 
@@ -850,9 +848,7 @@ public class Proof implements ProofObject<Goal>, Named {
     public void fireProofStructureChanged() {
         ProofTreeEvent e = new ProofTreeEvent(this);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofStructureChanged(e);
-            }
+            notifyListeners(listenerList, l -> l.proofStructureChanged(e));
         }
     }
 
@@ -863,9 +859,7 @@ public class Proof implements ProofObject<Goal>, Named {
     protected void fireProofGoalRemoved(Goal goal) {
         ProofTreeEvent e = new ProofTreeEvent(this, goal);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofGoalRemoved(e);
-            }
+            notifyListeners(listenerList, l -> l.proofGoalRemoved(e));
         }
     }
 
@@ -876,9 +870,7 @@ public class Proof implements ProofObject<Goal>, Named {
     protected void fireProofGoalsAdded(ImmutableList<Goal> goals) {
         ProofTreeEvent e = new ProofTreeEvent(this, goals);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofGoalsAdded(e);
-            }
+            notifyListeners(listenerList, l -> l.proofGoalsAdded(e));
         }
     }
 
@@ -897,9 +889,7 @@ public class Proof implements ProofObject<Goal>, Named {
     public void fireProofGoalsChanged() {
         ProofTreeEvent e = new ProofTreeEvent(this, openGoals());
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofGoalsChanged(e);
-            }
+            notifyListeners(listenerList, l -> l.proofGoalsChanged(e));
         }
     }
 
@@ -914,9 +904,7 @@ public class Proof implements ProofObject<Goal>, Named {
         }
         ProofTreeEvent e = new ProofTreeEvent(this);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.proofClosed(e);
-            }
+            notifyListeners(listenerList, l -> l.proofClosed(e));
         }
     }
 
@@ -928,9 +916,7 @@ public class Proof implements ProofObject<Goal>, Named {
     protected void fireNotesChanged(Node node) {
         ProofTreeEvent e = new ProofTreeEvent(this, node);
         synchronized (listenerList) {
-            for (ProofTreeListener listener : listenerList) {
-                listener.notesChanged(e);
-            }
+            notifyListeners(listenerList, l -> l.notesChanged(e));
         }
     }
 
@@ -1158,13 +1144,44 @@ public class Proof implements ProofObject<Goal>, Named {
     }
 
     /**
+     * Notifies all {@code listeners} of an event, isolating each callback. A proof listener is a
+     * passive observer; several fire from within a running rule application (e.g.
+     * {@link #fireRuleApplied} is called from {@code Goal.apply}). If a listener throws, that must
+     * not abort the proof search and leave the proof inconsistent. So a throwing listener is logged
+     * and removed from {@code listeners}, and the remaining listeners are still notified. The
+     * caller
+     * must hold the monitor of {@code listeners}.
+     *
+     * @param listeners the listeners to notify (a throwing listener is pruned from this list)
+     * @param notify the notification to deliver to each listener
+     * @param <L> the listener type
+     */
+    private static <L> void notifyListeners(List<L> listeners, Consumer<L> notify) {
+        List<L> broken = null;
+        for (L listener : listeners) {
+            try {
+                notify.accept(listener);
+            } catch (Exception e) {
+                LOGGER.error("proof listener {} threw while handling an event and will be "
+                    + "unregistered to keep the proof consistent", listener.getClass().getName(),
+                    e);
+                if (broken == null) {
+                    broken = new ArrayList<>();
+                }
+                broken.add(listener);
+            }
+        }
+        if (broken != null) {
+            listeners.removeAll(broken);
+        }
+    }
+
+    /**
      * fires the event that a rule has been applied
      */
     protected void fireRuleApplied(ProofEvent p_e) {
         synchronized (ruleAppListenerList) {
-            for (RuleAppListener ral : ruleAppListenerList) {
-                ral.ruleApplied(p_e);
-            }
+            notifyListeners(ruleAppListenerList, ral -> ral.ruleApplied(p_e));
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroWorker.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroWorker.java
@@ -70,6 +70,15 @@ public class ProofMacroWorker extends SwingWorker<ProofMacroFinishedInfo, Void>
     private Exception exception;
     private final List<InteractionListener> interactionListeners = new ArrayList<>();
 
+    /** Whether {@link #doInBackground()} has begun; distinguishes cancel-before-start. */
+    private volatile boolean backgroundStarted = false;
+    /**
+     * Callback run exactly once when this worker's background task has truly ended (returned, or
+     * was
+     * cancelled before it started). Used to release the automode re-entrancy guard.
+     */
+    private Runnable onTerminated;
+
     /**
      * Instantiates a new proof macro worker.
      *
@@ -88,8 +97,30 @@ public class ProofMacroWorker extends SwingWorker<ProofMacroFinishedInfo, Void>
         this.posInOcc = posInOcc;
     }
 
+    /**
+     * Registers a callback run exactly once when this worker's background task has truly finished,
+     * used to release the automode re-entrancy guard.
+     *
+     * @param onTerminated the callback
+     */
+    public void setOnTerminated(Runnable onTerminated) {
+        this.onTerminated = onTerminated;
+    }
+
+    private void signalTerminated() {
+        final Runnable callback;
+        synchronized (this) {
+            callback = onTerminated;
+            onTerminated = null;
+        }
+        if (callback != null) {
+            callback.run();
+        }
+    }
+
     @Override
     protected ProofMacroFinishedInfo doInBackground() {
+        backgroundStarted = true;
         final ProverTaskListener ptl = mediator.getUI();
         Proof selectedProof = node.proof();
         info = ProofMacroFinishedInfo.getDefaultInfo(macro, selectedProof);
@@ -106,6 +137,8 @@ public class ProofMacroWorker extends SwingWorker<ProofMacroFinishedInfo, Void>
         } catch (final Exception exception) {
             // This should actually never happen.
             this.exception = exception;
+        } finally {
+            signalTerminated();
         }
 
         return info;
@@ -135,6 +168,10 @@ public class ProofMacroWorker extends SwingWorker<ProofMacroFinishedInfo, Void>
                 selectOpenGoalBelow();
             }
             emitProofMacroFinished(node, macro, posInOcc, info);
+        }
+        if (!backgroundStarted) {
+            // doInBackground never ran (cancelled before it started); release the guard here.
+            signalTerminated();
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/MediatorProofControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/MediatorProofControl.java
@@ -45,6 +45,15 @@ public class MediatorProofControl extends AbstractProofControl {
     private final AbstractMediatorUserInterfaceControl ui;
     private AutoModeWorker worker;
 
+    /**
+     * True while an automode/macro run is active or still winding down; released only when the
+     * worker's background task has truly ended. Prevents a second run from starting on the same
+     * proof before the first has fully stopped -- fast-clicking the auto button otherwise overlaps
+     * two provers on one proof and corrupts it.
+     */
+    private final java.util.concurrent.atomic.AtomicBoolean autoModeActive =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+
     public MediatorProofControl(AbstractMediatorUserInterfaceControl ui) {
         super(ui, ui);
         this.ui = ui;
@@ -81,6 +90,9 @@ public class MediatorProofControl extends AbstractProofControl {
         if (goals.isEmpty()) {
             ui.notify(new GeneralInformationEvent("No enabled goals available."));
             return;
+        }
+        if (!autoModeActive.compareAndSet(false, true)) {
+            return; // a run is still active or winding down; do not overlap it
         }
         worker = new AutoModeWorker(proof, goals, ptl);
         ui.getMediator().initiateAutoMode(proof, true, false);
@@ -137,8 +149,12 @@ public class MediatorProofControl extends AbstractProofControl {
      */
     @Override
     public void runMacro(Node node, ProofMacro macro, PosInOccurrence posInOcc) {
+        if (!autoModeActive.compareAndSet(false, true)) {
+            return; // a run is still active or winding down; do not overlap it
+        }
         KeYMediator mediator = ui.getMediator();
         final ProofMacroWorker worker = new ProofMacroWorker(node, macro, mediator, posInOcc);
+        worker.setOnTerminated(() -> autoModeActive.set(false));
         interactionListeners.forEach(worker::addInteractionListener);
         mediator.initiateAutoMode(node.proof(), true, false);
         mediator.addInterruptedListener(worker);
@@ -159,6 +175,7 @@ public class MediatorProofControl extends AbstractProofControl {
         private final ImmutableList<Goal> goals;
         private final ApplyStrategy applyStrategy;
         private ProofSearchInformation<Proof, Goal> info;
+        private volatile boolean backgroundStarted = false;
 
         public AutoModeWorker(final Proof proof, final ImmutableList<Goal> goals,
                 ProverTaskListener ptl) {
@@ -189,6 +206,11 @@ public class MediatorProofControl extends AbstractProofControl {
             } finally {
                 // make it possible to free memory and falsify the isAutoMode() property
                 worker = null;
+                if (!backgroundStarted) {
+                    // doInBackground never ran (cancelled before it started); release the guard
+                    // here.
+                    autoModeActive.set(false);
+                }
                 // Clear strategy
                 synchronized (applyStrategy) {// wait for apply Strategy to terminate
                     applyStrategy.removeProverTaskObserver(ui);
@@ -215,14 +237,19 @@ public class MediatorProofControl extends AbstractProofControl {
 
         @Override
         protected ProofSearchInformation<Proof, Goal> doInBackground() {
-            boolean stopMode =
-                proof.getSettings().getStrategySettings().getActiveStrategyProperties()
-                        .getProperty(StrategyProperties.STOPMODE_OPTIONS_KEY)
-                        .equals(StrategyProperties.STOPMODE_NONCLOSE);
+            backgroundStarted = true;
+            try {
+                boolean stopMode =
+                    proof.getSettings().getStrategySettings().getActiveStrategyProperties()
+                            .getProperty(StrategyProperties.STOPMODE_OPTIONS_KEY)
+                            .equals(StrategyProperties.STOPMODE_NONCLOSE);
 
-            info = applyStrategy.start(proof, goals, ui.getMediator().getMaxAutomaticSteps(),
-                ui.getMediator().getAutomaticApplicationTimeout(), stopMode);
-            return info;
+                info = applyStrategy.start(proof, goals, ui.getMediator().getMaxAutomaticSteps(),
+                    ui.getMediator().getAutomaticApplicationTimeout(), stopMode);
+                return info;
+            } finally {
+                autoModeActive.set(false);
+            }
         }
     }
 }

--- a/keyext.slicing/src/main/java/org/key_project/slicing/DependencyTracker.java
+++ b/keyext.slicing/src/main/java/org/key_project/slicing/DependencyTracker.java
@@ -73,6 +73,12 @@ public class DependencyTracker implements RuleAppListener, ProofTreeListener {
      * @see DependencyAnalyzer
      */
     private AnalysisResults analysisResults = null;
+    /**
+     * Set once tracking failed with an exception (after which {@link Proof} unregisters this
+     * tracker, see {@link #ruleApplied(ProofEvent)}). The dependency graph is then incomplete, so
+     * {@link #analyze} no longer returns results.
+     */
+    private boolean trackingDisabled = false;
 
     /**
      * Construct a new tracker for a proof.
@@ -264,6 +270,24 @@ public class DependencyTracker implements RuleAppListener, ProofTreeListener {
 
     @Override
     public void ruleApplied(ProofEvent e) {
+        if (trackingDisabled) {
+            return;
+        }
+        try {
+            trackRuleApplication(e);
+        } catch (RuntimeException ex) {
+            // Proof.fireRuleApplied isolates listeners: it logs this failure and unregisters the
+            // tracker, so a tracking error cannot break the ongoing proof search. Here we only
+            // record that tracking became incomplete, so that a later analyze() does not return a
+            // slice computed from the partial dependency graph; then rethrow for the proof to
+            // handle.
+            trackingDisabled = true;
+            analysisResults = null;
+            throw ex;
+        }
+    }
+
+    private void trackRuleApplication(ProofEvent e) {
         if (e.getSource() != proof) {
             throw new IllegalStateException(
                 "dependency tracker received rule application on wrong proof");
@@ -471,6 +495,10 @@ public class DependencyTracker implements RuleAppListener, ProofTreeListener {
      * @return analysis results (null if proof is not closed)
      */
     public AnalysisResults analyze(boolean doDependencyAnalysis, boolean doDeduplicateRuleApps) {
+        if (trackingDisabled) {
+            // the dependency graph is incomplete after a tracking failure; do not return a slice
+            return null;
+        }
         if (analysisResults != null
                 && analysisResults.didDependencyAnalysis == doDependencyAnalysis
                 && analysisResults.didDeduplicateRuleApps == doDeduplicateRuleApps

--- a/keyext.slicing/src/test/java/org/key_project/slicing/ProofListenerIsolationTest.java
+++ b/keyext.slicing/src/test/java/org/key_project/slicing/ProofListenerIsolationTest.java
@@ -1,0 +1,63 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.slicing;
+
+import java.nio.file.Path;
+
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.proof.RuleAppListener;
+import de.uka.ilkd.key.settings.GeneralSettings;
+
+import org.key_project.util.helper.FindResources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@code Proof} isolates its listeners: a {@link RuleAppListener} such as the slicing
+ * {@link DependencyTracker} is notified from within {@code Goal.apply} (via
+ * {@code Proof.fireRuleApplied}), so if it throws, the exception must not abort the proof search
+ * and
+ * leave the proof inconsistent. Instead the proof logs the failure, unregisters the offending
+ * listener, and carries on. This is the general safety net behind the {@link DependencyTracker}
+ * fast-click crash (a tracking failure used to escape into the proof search).
+ */
+public class ProofListenerIsolationTest {
+    private static final Path testCaseDirectory = FindResources.getTestCasesDirectory();
+
+    @Test
+    void aThrowingRuleAppListenerDoesNotBreakTheProofAndIsUnregistered() throws Exception {
+        GeneralSettings.noPruningClosed = false;
+        var file = testCaseDirectory.resolve(
+            "issues/3834/SumAndMax(SumAndMax__sumAndMax((I)).JML normal_behavior operation contract.0.proof");
+        var env = KeYEnvironment.load(file);
+        try {
+            var proof = env.getLoadedProof();
+
+            // A rogue listener that always throws when a rule is applied.
+            int[] callCount = { 0 };
+            RuleAppListener rogue = e -> {
+                callCount[0]++;
+                throw new IllegalStateException("boom from a rogue rule-app listener");
+            };
+            proof.addRuleAppListener(rogue);
+
+            // Re-run auto mode so rules are applied and the listener fires.
+            proof.pruneProof(proof.findAny(x -> x.serialNr() == 13));
+            env.getProofControl().startAutoMode(proof, proof.openEnabledGoals());
+            env.getProofControl().waitWhileAutoMode();
+
+            // The rogue listener did not stop the proof search ...
+            assertTrue(proof.closed(), "a throwing listener must not stop the proof from closing");
+            // ... and it was unregistered after its first failure, so it fires at most once.
+            assertEquals(1, callCount[0],
+                "a throwing rule-app listener should be unregistered after it throws");
+        } finally {
+            env.dispose();
+            GeneralSettings.noPruningClosed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Intended Change

Rapidly clicking the auto-mode / apply-strategy toolbar button can crash the proof with a stray
exception on a `SwingWorker` thread. The crash turned out to be **layered** — two independent
causes, both fixed here.

### Layer 1 — overlapping auto-mode/macro runs

Starting the automatic proof search (auto mode or a proof macro) while a previous run on the same
proof is still winding down runs two provers on one `Proof` concurrently and corrupts shared proof
state. The symptom is a stray exception on a `SwingWorker` thread — e.g. `NullPointerException` in
`NamespaceSet.copy` (from `Goal.adaptNamespacesNewGoals`), `AssertionFailure: Expected an empty leaf
node`, or a null `SemisequentTacletAppIndex.succIndex`.

Root cause: `MediatorProofControl` guards re-entry only through the mediator's `inAutoMode` flag,
which `ProofMacroWorker.done()` clears. But `SwingWorker.done()` fires on **cancellation**, while the
cooperative `doInBackground` is still applying rules — so the flag drops while the run is still
winding down and the next click starts a second, overlapping run.

This PR adds an explicit re-entrancy guard (`AtomicBoolean autoModeActive`) in
`MediatorProofControl`: `startAutoMode`/`runMacro` claim it on entry and it is released **only when
the worker's background task has truly finished** (`doInBackground`'s `finally`, with a backstop for
the cancelled-before-start case). A new run is refused while one is active or winding down, so two
runs can never prove the same proof at once. It also hardens the analogous guard in
`DefaultProofControl` (volatile `autoModeThread`, synchronized `runMacro`); that control already
released at true completion and the CLI runs blocking, so this is defence-in-depth only.

### Layer 2 — a listener must not be able to break the proof

Proof` notifies all `RuleAppListener`s and
`ProofTreeListener`s with bare dispatch loops, so *any* observer (now or in the future) could break
the proof. Rather than have each listener guard itself, this PR isolates them at the firing site: a
new `Proof.notifyListeners` helper wraps every callback — a listener that throws is logged and
**unregistered**, and the remaining listeners are still notified. `fireRuleApplied` and the
`fireProof*` dispatches all route through it, so no listener can corrupt the proof.

The problem appeared in this case (but it is not specific to the `DependencyTracker`) with the slicing extension's *always track* setting on, `DependencyTracker` is registered as a `RuleAppListener`, so its `ruleApplied(..)` runs **inside `Goal.apply`** (via `Proof.fireRuleApplied`), after the proof tree and namespaces have already been updated for the step.
When tracking failed there — e.g. `IllegalStateException: found formula that was not produced by any
rule!` on a loop-scope invariant while auto mode re-applied the loop-scope rule — the exception
propagated out of `Goal.apply`, aborting the run mid-application and leaving the proof inconsistent.
That broken state is what then produced the `NullPointerException` in `Goal.adaptNamespacesNewGoals`
on the next step.

`DependencyTracker` additionally records, on a tracking failure, that its dependency graph became
incomplete, so a later `analyze()` returns no slice rather than one built from a partial graph.

> The deeper reason the tracker can miss a loop-scope formula on a re-run is a separate
> slicing-correctness question (the naming part was addressed by the #3834 fix already on main); this
> PR makes any listener **fail safe** rather than fatally.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows:
  - Layer 1: reproduced the corruption headlessly (two concurrent auto-mode runs on one proof
    corrupt it reliably; interrupting a single run and *waiting* does not), confirmed that the GUI
    genuinely runs two auto-mode workers on one proof when fast-clicking, and verified that the guard
    prevents the overlap. Final check: fast-clicking the auto button in the GUI no longer crashes.
  - Layer 2: added `ProofListenerIsolationTest` — a `RuleAppListener` that always throws neither
    stops the proof from closing nor keeps firing (it is unregistered after its first failure).
    Verified it fails without the guard.
- I have checked that runtime performance has not deteriorated: the re-entrancy guard is a single
  atomic CAS per run start; listener isolation only wraps the existing dispatch in a try/catch — no
  effect on the proof-search hot path.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

## Additional Information and contact(s)

Created with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
