### PR TITLE
Fix NPE when copying a namespace set with a root sub-namespace

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/logic/NamespaceSet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/NamespaceSet.java
@@ -317,8 +317,14 @@ public class NamespaceSet {
     }
 
     public NamespaceSet getParent() {
-        var newSpaces = new HashMap<>(namespaces);
-        namespaces.forEach((a, b) -> newSpaces.put(a, b.parent()));
+        var newSpaces = new HashMap<Class<?>, Namespace<?>>();
+        // a namespace without an enclosing layer has no parent; represent that as an empty
+        // namespace rather than a null map value, so the "no null values" invariant the other
+        // map operations (copy, copyWithParent, getCompression) rely on keeps holding
+        namespaces.forEach((a, b) -> {
+            Namespace<?> parent = b.parent();
+            newSpaces.put(a, parent != null ? parent : new Namespace<>());
+        });
         return new NamespaceSet(newSpaces, documentation.parent());
     }
 

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/NamespaceSetTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/NamespaceSetTest.java
@@ -1,0 +1,38 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.logic;
+
+import org.key_project.logic.MetaSpace;
+import org.key_project.logic.Namespace;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class NamespaceSetTest {
+
+    /**
+     * {@link NamespaceSet#getParent()} must not leave {@code null} values in the namespace map: a
+     * sub-namespace without an enclosing layer has no parent. Copying such a parent set — as
+     * {@code Goal.adaptNamespacesNewGoals} does for the additional goals of a splitting rule
+     * applied
+     * interactively — otherwise fails with a {@link NullPointerException} in
+     * {@code Namespace.copy}.
+     * Regression test for that crash.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getParentOfRootNamespacesIsCopyable() {
+        // every sub-namespace is a root (no parent), so getParent() sees a null parent for each
+        NamespaceSet roots = new NamespaceSet(new Namespace<>(), new Namespace<>(),
+            new Namespace<>(), new Namespace<>(), new Namespace<>(), new Namespace<>(),
+            new Namespace<>(), new Namespace<>(), new Namespace<>(),
+            new MetaSpace(new MetaSpace()));
+
+        NamespaceSet parent = roots.getParent();
+        assertNotNull(assertDoesNotThrow(parent::copy,
+            "copying a parent namespace set must tolerate a missing (root) parent layer"));
+    }
+}


### PR DESCRIPTION
## Intended Change

Applying a **splitting** taclet interactively (e.g. dragging a formula into an
instantiation field and pressing *Apply*) could crash with a
`NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "org.key_project.logic.Namespace.copy()" because "v" is null
    at de.uka.ilkd.key.logic.NamespaceSet.lambda$copy$0(NamespaceSet.java:106)
    at de.uka.ilkd.key.logic.NamespaceSet.copy(NamespaceSet.java:106)
    at de.uka.ilkd.key.proof.Goal.adaptNamespacesNewGoals(Goal.java:715)
    at de.uka.ilkd.key.proof.Goal.apply(Goal.java:683)
    ...
```

**Root cause.** `NamespaceSet.getParent()` built its map by storing each
namespace's parent as the value:

```java
namespaces.forEach((a, b) -> newSpaces.put(a, b.parent()));   // b.parent() may be null
```

A sub-namespace without an enclosing layer has no parent, so `b.parent()` is
`null` and the resulting map holds a `null` value. `copy()` (and likewise
`copyWithParent()` / `getCompression()`) then call `v.copy()` on that value and
throw. For the second and later goals of a splitting rule,
`Goal.adaptNamespacesNewGoals` does
`localNamespaces.getParent().copy().copyWithParent()`, which is where it blew up.

**Fix.** `getParent()` now substitutes an empty namespace for a missing parent
layer, so the "the map holds no null values" invariant that the other map
operations rely on keeps holding.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality (`NamespaceSetTest.getParentOfRootNamespacesIsCopyable`, which fails with the original NPE and passes with the fix).
- I have tested the feature as follows: `:key.core` compiles and passes spotless; the new regression test is green (and verified red without the fix).
- I have checked that runtime performance has not deteriorated (the change only avoids inserting a null map value).

## Additional information and contact(s)

Created with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
