### PR TITLE
Taclet match dialog: readable \assumes candidates and smarter window placement

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesSelectionPanel.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/AssumesSelectionPanel.java
@@ -45,7 +45,7 @@ public class AssumesSelectionPanel extends JPanel {
     private static final long serialVersionUID = 1L;
 
     /** abbreviate candidate text longer than this in the list (full text on hover) */
-    private static final int ABBREV_LIMIT = 100;
+    private static final int ABBREV_LIMIT = 200;
 
     private static final Color OK_COLOR = new Color(0x1D9E75);
     private static final Color WARN_COLOR = new Color(0xBA7517);
@@ -445,7 +445,9 @@ public class AssumesSelectionPanel extends JPanel {
                 boolean isSelected, boolean cellHasFocus) {
             JLabel c = (JLabel) super.getListCellRendererComponent(l, value, index, isSelected,
                 cellHasFocus);
-            c.setText(TmText.truncateFirstLine(text((AssumesFormulaInstantiation) value),
+            // flatten a possibly multi-line, wrapped formula to one line so the whole thing shows
+            // (up to the abbreviation limit) instead of just its first wrapped segment
+            c.setText(TmText.collapseToLine(text((AssumesFormulaInstantiation) value),
                 ABBREV_LIMIT));
             c.setFont(TmStyle.mono(c));
             return c;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TacletMatchDialog.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TacletMatchDialog.java
@@ -80,8 +80,72 @@ public class TacletMatchDialog extends ApplyTacletDialog {
         pack();
 
         mainWindow.loadPreferences(this);
-        setLocationRelativeTo(parent);
+        positionDialog(parent);
         setVisible(true);
+    }
+
+    /**
+     * where the dialog was last closed, remembered for this session only (deliberately not
+     * persisted: on a restart the main window may sit elsewhere, so a stale absolute position would
+     * be worse than a fresh placement beside the sequent).
+     */
+    private static Point sessionLocation;
+
+    /**
+     * Places the dialog so it does not sit on top of the sequent view. The user frequently needs to
+     * read a variable name off the sequent, or drag a sub-term from it onto a field, so covering it
+     * is exactly what to avoid. Within a session the last position the user moved it to is reused;
+     * otherwise the dialog is put in the free space beside the sequent view, falling back to the
+     * screen edge that leaves the most of the sequent visible. Either way it ends up fully on
+     * screen.
+     */
+    private void positionDialog(MainWindow parent) {
+        Rectangle screen = usableScreen(parent);
+        Point target = sessionLocation != null ? sessionLocation : besideSequent(parent, screen);
+        // keep the window fully on screen (the remembered spot may be off a since-changed screen)
+        int x = Math.max(screen.x, Math.min(target.x, screen.x + screen.width - getWidth()));
+        int y = Math.max(screen.y, Math.min(target.y, screen.y + screen.height - getHeight()));
+        setLocation(x, y);
+    }
+
+    /** a spot beside the sequent view (right, else left, else the roomier screen edge). */
+    private Point besideSequent(MainWindow parent, Rectangle screen) {
+        Rectangle avoid = sequentBoundsOnScreen(parent);
+        int gap = 8;
+        int w = getWidth();
+        int rightX = avoid.x + avoid.width + gap;
+        int leftX = avoid.x - gap - w;
+        int x;
+        if (rightX + w <= screen.x + screen.width) {
+            x = rightX; // free space to the right of the sequent
+        } else if (leftX >= screen.x) {
+            x = leftX; // free space to the left of the sequent
+        } else {
+            // the sequent leaves no room beside it: dock to the edge with more space, so at least
+            // that much of the sequent stays visible
+            int roomRight = screen.x + screen.width - (avoid.x + avoid.width);
+            int roomLeft = avoid.x - screen.x;
+            x = roomRight >= roomLeft ? screen.x + screen.width - w : screen.x;
+        }
+        return new Point(x, avoid.y); // align with the top of the sequent (caller clamps to screen)
+    }
+
+    /** the sequent view's rectangle on screen, or the whole main window if it is not showing. */
+    private Rectangle sequentBoundsOnScreen(MainWindow parent) {
+        Component seq = parent.getGoalView();
+        if (seq != null && seq.isShowing()) {
+            return new Rectangle(seq.getLocationOnScreen(), seq.getSize());
+        }
+        return parent.getBounds();
+    }
+
+    /** the usable bounds (minus taskbar/menubar insets) of the screen the main window is on. */
+    private static Rectangle usableScreen(Window on) {
+        GraphicsConfiguration gc = on.getGraphicsConfiguration();
+        Rectangle b = gc.getBounds();
+        Insets in = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+        return new Rectangle(b.x + in.left, b.y + in.top,
+            b.width - in.left - in.right, b.height - in.top - in.bottom);
     }
 
     private void layoutDialog() {
@@ -275,6 +339,8 @@ public class TacletMatchDialog extends ApplyTacletDialog {
 
     @Override
     protected void closeDlg() {
+        // remember the position for the rest of this session; savePreferences persists the size
+        sessionLocation = getLocation();
         if (mainWindow != null) {
             mainWindow.savePreferences(this);
         }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TmText.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/tacletmatch/TmText.java
@@ -24,20 +24,14 @@ final class TmText {
     }
 
     /**
-     * the first line of {@code s}, truncated to {@code limit} characters with an ellipsis appended
-     * when it was longer.
-     */
-    static String truncateFirstLine(String s, int limit) {
-        String line = firstLine(s);
-        return line.length() > limit ? line.substring(0, limit) + " …" : line;
-    }
-
-    /**
-     * {@code s} flattened to a single line (newlines become spaces), truncated to {@code limit}
-     * characters with an ellipsis appended when it was longer.
+     * {@code s} flattened to a single line and truncated to {@code limit} characters with an
+     * ellipsis appended when it was longer. Every run of whitespace (the newlines and the alignment
+     * indentation the pretty-printer inserts when it wraps a term) collapses to a single space, so
+     * a
+     * multi-line formula reads as one continuous line instead of a stub followed by blank gaps.
      */
     static String collapseToLine(String s, int limit) {
-        String oneLine = (s == null ? "" : s).replace('\n', ' ');
+        String oneLine = (s == null ? "" : s).replaceAll("\\s+", " ").trim();
         return oneLine.length() > limit ? oneLine.substring(0, limit) + " …" : oneLine;
     }
 

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/TmTextTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/tacletmatch/TmTextTest.java
@@ -24,21 +24,15 @@ public class TmTextTest {
     }
 
     @Test
-    public void truncateFirstLine() {
-        assertEquals("abc", TmText.truncateFirstLine("abc", 10), "short text is unchanged");
-        assertEquals("abc", TmText.truncateFirstLine("abc", 3), "length exactly at the limit");
-        assertEquals("abc …", TmText.truncateFirstLine("abcd", 3), "longer than the limit");
-        assertEquals("ab", TmText.truncateFirstLine("ab\nlong second line", 10),
-            "only the first line is considered");
-        assertEquals("", TmText.truncateFirstLine(null, 5));
-    }
-
-    @Test
     public void collapseToLine() {
         assertEquals("a b c", TmText.collapseToLine("a\nb\nc", 80), "newlines become spaces");
         assertEquals("abc", TmText.collapseToLine("abc", 3), "length exactly at the limit");
         assertEquals("a b …", TmText.collapseToLine("a\nb\nc", 3),
             "flattened first, then truncated by character count");
+        assertEquals("a & b", TmText.collapseToLine("a\n        &   b", 80),
+            "wrapped-formula indentation collapses to a single space");
+        assertEquals("x", TmText.collapseToLine("\n  x\n  ", 80),
+            "leading and trailing whitespace is trimmed");
         assertEquals("", TmText.collapseToLine(null, 5));
     }
 


### PR DESCRIPTION
## Intended Change

Two usability fixes to the redesigned taclet-match dialog.

**1. Readable `\assumes` candidates in "Select from sequent" mode.**
When picking (rather than typing) an `\assumes` instantiation, each candidate
sequent formula was rendered with only its *first physical line*. A formula that
the pretty-printer wraps across several lines therefore showed a short stub — or
nothing at all, when it began with a newline, followed by blank space, and it
abbreviated far too early. The candidate now flattens the whole formula onto one
line, and the abbreviation limit is raised from 100
to 200 characters so more of the formula is visible before the ellipsis. The
full formula remains available on hover.

**2. Smarter window placement.**
The dialog was centred over the main window (`setLocationRelativeTo`), so it
covered the sequent view, exactly what the user needs in order to read a
variable name or drag a sub-term onto a field. It now auto-places itself beside
the sequent view: to the right if there is room, else to the left, else docked
to the roomier screen edge, always fully on screen. Within a session it reuses
the last position the user moved it to. The position is intentionally *not*
persisted across restarts (where the main window may sit elsewhere, a stale
absolute position would be worse than a fresh placement); the window *size* is
still persisted as before.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality (`TmTextTest.collapseToLine` now covers wrapped-formula indentation and trimming).
- I have tested the feature as follows: `:key.ui` compiles and passes spotless; the `de.uka.ilkd.key.gui.tacletmatch.*` test suite is green. Manually verified that a multi-line `\assumes` candidate now reads as one line, and that the dialog opens beside the sequent view instead of on top of it (and reopens where it was last moved).
- I have checked that runtime performance has not deteriorated (pure UI/text change).

## Additional information and contact(s)

Follow-up polish on top of the redesigned taclet-match dialog. Both changes are
confined to the `de.uka.ilkd.key.gui.tacletmatch` package.

Created with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
