### PR TITLE
Fix for DepthFirstGoalChooser: Keep enabled sibling goals on a split

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DepthFirstGoalChooser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/DepthFirstGoalChooser.java
@@ -73,10 +73,21 @@ public class DepthFirstGoalChooser extends DefaultGoalChooser {
 
         nextGoals = ImmutableList.nil();
 
-        // Only consider automatic goals
-        newGoals = newGoals.filter(Goal::isAutomatic);
+        // Locate the split point in selectedList using *all* new goals (see below), but only put
+        // the automatic ones back to work on.
+        final ImmutableList<Goal> automaticNewGoals = newGoals.filter(Goal::isAutomatic);
 
-        // Remove "node" and goals contained within "newGoals"
+        // Remove "node" and the goals contained within "newGoals".
+        //
+        // The split point is the goal the rule was applied to. A splitting rule reuses that goal
+        // object for one of its branches (advancing its node), so it may no longer match by node
+        // ("node == goal.node()") and has to be found by identity among the new goals instead. That
+        // membership test must run against *all* new goals, not only the automatic ones: if the
+        // reused goal was disabled (e.g. proof caching disabled the branch it can close by
+        // reference), filtering it out first hides the split point, so newGoalsInserted stays false
+        // and the *other*, still enabled, new goals are silently dropped from the work list --
+        // which
+        // stops automatic proof search while work remains.
         while (!selectedList.isEmpty()) {
             final @NonNull Goal goal = selectedList.head();
             selectedList = selectedList.tail();
@@ -86,7 +97,7 @@ public class DepthFirstGoalChooser extends DefaultGoalChooser {
                 nextGoals = selectedList;
 
                 if (!newGoalsInserted) {
-                    prevGoalList = insertNewGoals(newGoals, prevGoalList);
+                    prevGoalList = insertNewGoals(automaticNewGoals, prevGoalList);
                     newGoalsInserted = true;
                 }
             } else {

--- a/keyext.caching/src/test/java/de/uka/ilkd/key/proof/reference/ProofCachingSingleRunTest.java
+++ b/keyext.caching/src/test/java/de/uka/ilkd/key/proof/reference/ProofCachingSingleRunTest.java
@@ -1,0 +1,110 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.proof.reference;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.RuleAppListener;
+import de.uka.ilkd.key.prover.impl.ApplyStrategy;
+import de.uka.ilkd.key.settings.GeneralSettings;
+
+import org.key_project.prover.engine.impl.ApplyStrategyInfo;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.helper.FindResources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the proof-caching "search stops, restart needed" bug: a single automatic
+ * run followed by the caching close step must finish the proof, rather than stranding an enabled
+ * goal and requiring the user to restart.
+ *
+ * <p>
+ * The scenario mirrors what {@code CachingExtension} does in the GUI: while proving a second copy
+ * of a proof, goals that can be closed by reference to the first (closed) proof are disabled during
+ * the run and closed once it finishes. With the
+ * {@link de.uka.ilkd.key.prover.impl.DepthFirstGoalChooser}
+ * loss-recovery in place, disabling those sibling goals around a branching rule no longer drops an
+ * unrelated enabled goal from the work lists, so the proof closes in one pass.
+ */
+class ProofCachingSingleRunTest {
+    private static final Path testCaseDirectory =
+        Objects.requireNonNull(FindResources.getTestCasesDirectory());
+    private static final Path BIN = testCaseDirectory.resolve(
+        "../../../../../key.ui/examples/heap/WeideEtAl_02_BinarySearch/BinarySearch_search.key");
+
+    private static ApplyStrategyInfo<Proof, Goal> auto(Proof p, ImmutableList<Goal> goals) {
+        int maxSteps = p.getSettings().getStrategySettings().getMaxSteps();
+        long timeout = p.getSettings().getStrategySettings().getTimeout();
+        ApplyStrategy s = new ApplyStrategy(
+            p.getInitConfig().getProfile().<Proof, Goal>getSelectedGoalChooserBuilder().create());
+        return s.start(p, goals, maxSteps, timeout, false);
+    }
+
+    @Test
+    void cachingClosesInASingleRun() throws Exception {
+        GeneralSettings.noPruningClosed = false;
+        KeYEnvironment<DefaultUserInterfaceControl> e1 = KeYEnvironment.load(BIN);
+        Proof src = e1.getLoadedProof();
+        KeYEnvironment<DefaultUserInterfaceControl> e2 = KeYEnvironment.load(BIN);
+        Proof p2 = e2.getLoadedProof();
+        try {
+            auto(src, src.openEnabledGoals());
+            assertTrue(src.closed(), "cache source proof must close");
+
+            List<Proof> previous = new CopyOnWriteArrayList<>();
+            previous.add(src);
+            int[] disables = { 0 };
+            // mirror CachingExtension.ruleApplied: disable cache-hit new goals of a split
+            RuleAppListener caching = ev -> {
+                ImmutableList<Goal> ng = ev.getNewGoals();
+                if (ng.size() <= 1) {
+                    return;
+                }
+                for (Goal g : ng) {
+                    ClosedBy c = null;
+                    try {
+                        c = ReferenceSearcher.findPreviousProof(previous, g.node());
+                    } catch (Exception ignore) {
+                        // reference search failure -> just do not cache this goal
+                    }
+                    if (c != null) {
+                        g.setEnabled(false);
+                        g.node().register(c, ClosedBy.class);
+                        disables[0]++;
+                    }
+                }
+            };
+            p2.addRuleAppListener(caching);
+
+            // exactly one automatic run ...
+            auto(p2, p2.openEnabledGoals());
+            // ... then the caching close step (mirror CachingExtension.taskFinished)
+            p2.openGoals().stream().filter(g -> g.node().lookup(ClosedBy.class) != null)
+                    .collect(Collectors.toList()).forEach(g -> {
+                        g.setEnabled(true);
+                        p2.closeGoal(g);
+                    });
+
+            assertTrue(disables[0] > 0, "the caching scenario must actually disable some goals");
+            assertTrue(p2.closed(),
+                "proof must close in a single run; a stranded enabled goal here is the "
+                    + "'caching stops the search, restart needed' bug");
+        } finally {
+            GeneralSettings.noPruningClosed = true;
+            src.dispose();
+            p2.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Not related to a tracked issue. The bug surfaced while exercising proof caching and is reproducible on `main`.

## Intended Change

Fix automatic proof search stopping with an open goal, and requiring the user to restart it, when proof caching is enabled.

How to reproduce (on current main):

1. Load the example BinarySearch from the examples directory with proof caching on
2. Close it automatically
3. Reload the problem
4. Start the strategies (Full automation) 
5. Proof stops at Body Preserves Invariant but should be closed by caching

**Reason:**
`DepthFirstGoalChooser.updateGoalListHelp` locates, in its work list, the goal a rule was applied to (the "split point") so it can replace that goal with the rule's new goals. A splitting rule reuses the applied-to goal object for one of its branches (advancing its node), so the split point is found by identity among the new goals rather than by node. That membership test, however, ran against the new goals **after** they had been filtered to automatic goals. When the reused goal had been disabled — proof caching disables a branch it can close by reference — it was filtered out, the split point was not found, `newGoalsInserted` stayed `false`, and the rule's *other*, still-enabled, new goals were never inserted into the work list. `getNextGoal()` then eventually returns `null` while those goals still have applicable rules, so automatic proof search stops with an open goal and the user has to restart it for it to continue.

The fix matches the split point against **all** new goals (so a disabled reused goal is still found) and inserts only the automatic ones. Behaviour is unchanged when no new goal is disabled, i.e. for all ordinary proof search.

This is a pre-existing bug in `DepthFirstGoalChooser`, independent of any recent work; it is triggered whenever proof caching disables one branch of a splitting rule.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: added `ProofCachingSingleRunTest`, which proves a method, then proves a second copy with a reference-search listener that mirrors `CachingExtension` (disable cache-hit goals during the run, close them afterwards) and asserts the second proof closes in a **single** automatic run. It fails without the fix (an enabled goal is stranded, requiring a restart) and passes with it. I also verified the multi-core determinism regression test still yields bit-identical proofs (sequential == 4 workers), and that `TestReferenceSearcher` / `TestGoal` remain green.
- I have checked that runtime performance has not deteriorated: the change is a no-op whenever no new goal is disabled (the membership set is then identical), so ordinary proof search is byte-identical; only the proof-caching interaction differs.

## Additional information and contact(s)

The change is small (three lines of logic plus an explanatory comment) and self-contained in `DepthFirstGoalChooser`.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

Created with AI support
