### PR TITLE
Cost-Reuse: Fix latent classification bugs and code cleanup

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/CostReuse.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/CostReuse.java
@@ -19,6 +19,7 @@ import org.key_project.prover.strategy.costbased.feature.Feature;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
 import org.key_project.prover.strategy.costbased.feature.VolatileCost;
 import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
 
 import org.jspecify.annotations.Nullable;
@@ -133,7 +134,7 @@ public final class CostReuse {
         vetoes.add(NonDuplicateAppFeature.INSTANCE); // top-level veto, applies to every taclet
         final boolean[] local = { true };
         final boolean[] weakStable = { false };
-        final Set<Feature> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        final Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
         for (RuleSetDispatchFeature d : dispatchers) {
             var rs = taclet.getRuleSets();
             while (!rs.isEmpty()) {
@@ -151,14 +152,14 @@ public final class CostReuse {
      * Classify a feature; for a transparent composite, recurse into its child features and require
      * its child term-generators to be local too (see the class comment).
      */
-    private static void walk(Feature f, Set<Feature> vetoes, boolean[] local, boolean[] weakStable,
-            Set<Feature> seen) {
+    private static void walk(Object f, Set<Feature> vetoes, boolean[] local, boolean[] weakStable,
+            Set<Object> seen) {
         if (!local[0] || !seen.add(f)) {
             return;
         }
         final Kind k = kind(f);
         switch (k) {
-            case VETO -> vetoes.add(f);
+            case VETO -> vetoes.add((Feature) f); // only Features (NonDuplicateApp) ever VETO
             case VOLATILE -> local[0] = false;
             // LOCAL: a leaf is done; a composite stays local iff all its child FEATURES are
             // local and all its child TERM-GENERATORS are at least as local. WEAK_STABLE
@@ -171,8 +172,10 @@ public final class CostReuse {
                     weakStable[0] = true;
                 }
                 forEachChild(f, child -> {
-                    if (child instanceof Feature cf) {
-                        walk(cf, vetoes, local, weakStable, seen);
+                    if (child instanceof Feature || child instanceof ProjectionToTerm) {
+                        // a ProjectionToTerm gets the goal, so it can be volatile; classify it
+                        // (recursively, for composite projections) exactly like a child feature.
+                        walk(child, vetoes, local, weakStable, seen);
                     } else { // a TermGenerator (or similar non-Feature input)
                         final Class<?> gc = child.getClass();
                         if (gc.isAnnotationPresent(WeakStableCost.class)) {
@@ -202,7 +205,7 @@ public final class CostReuse {
      * is transparent" guess. {@link VolatileCost} forces non-local; everything unannotated is
      * non-local (the safe default).
      */
-    private static Kind kind(Feature f) {
+    private static Kind kind(Object f) {
         return kindCache.computeIfAbsent(f.getClass(), c -> {
             if (c.isAnnotationPresent(VolatileCost.class)) {
                 return Kind.VOLATILE; // explicit author override wins
@@ -221,7 +224,7 @@ public final class CostReuse {
      * Apply {@code action} to each {@link Feature} and {@link TermGenerator} held one structural
      * step inside {@code f}.
      */
-    private static void forEachChild(Feature f, java.util.function.Consumer<Object> action) {
+    private static void forEachChild(Object f, java.util.function.Consumer<Object> action) {
         for (Field fld : allFields(f.getClass())) {
             if (Modifier.isStatic(fld.getModifiers()) || fld.getType().isPrimitive()) {
                 continue;
@@ -238,7 +241,7 @@ public final class CostReuse {
         if (o == null) {
             return;
         }
-        if (o instanceof Feature || o instanceof TermGenerator) {
+        if (o instanceof Feature || o instanceof TermGenerator || o instanceof ProjectionToTerm) {
             action.accept(o);
             return;
         }
@@ -257,7 +260,8 @@ public final class CostReuse {
                 follow(e, action);
             }
         }
-        // other object types (TermBuffer, ProjectionToTerm, Name, ...) are NOT traversed
+        // other object types (TermFeature -- stable by interface, its compute() has no goal so it
+        // cannot read volatile state --, Name, RuleAppCost, ...) are NOT traversed
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/CostReuse.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/CostReuse.java
@@ -15,12 +15,12 @@ import de.uka.ilkd.key.strategy.feature.NonDuplicateAppFeature;
 import de.uka.ilkd.key.strategy.feature.RuleSetDispatchFeature;
 
 import org.key_project.prover.rules.Taclet;
+import org.key_project.prover.strategy.costbased.CostClassifiable;
+import org.key_project.prover.strategy.costbased.CostLocality;
 import org.key_project.prover.strategy.costbased.feature.Feature;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
 import org.key_project.prover.strategy.costbased.feature.VolatileCost;
 import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
-import org.key_project.prover.strategy.costbased.termgenerator.TermGenerator;
 
 import org.jspecify.annotations.Nullable;
 
@@ -76,14 +76,10 @@ public final class CostReuse {
 
     private CostReuse() {}
 
-    /** Per-class locality decision, cached (class annotations are stable for the JVM run). */
-    private static final Map<Class<?>, Kind> kindCache = new ConcurrentHashMap<>();
+    /** Per-class locality, cached (class annotations are stable for the JVM run). */
+    private static final Map<Class<?>, CostLocality> localityCache = new ConcurrentHashMap<>();
     /** Cached "not eligible for reuse" marker (the map forbids null values). */
     private static final Eligibility INELIGIBLE = new Eligibility(new Feature[0], false);
-
-    private enum Kind {
-        VETO, VOLATILE, STABLE, WEAK_STABLE
-    }
 
     /**
      * How an eligible taclet may reuse its cost.
@@ -134,7 +130,7 @@ public final class CostReuse {
         vetoes.add(NonDuplicateAppFeature.INSTANCE); // top-level veto, applies to every taclet
         final boolean[] local = { true };
         final boolean[] weakStable = { false };
-        final Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        final Set<CostClassifiable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
         for (RuleSetDispatchFeature d : dispatchers) {
             var rs = taclet.getRuleSets();
             while (!rs.isEmpty()) {
@@ -149,82 +145,46 @@ public final class CostReuse {
     }
 
     /**
-     * Classify a feature; for a transparent composite, recurse into its child features and require
-     * its child term-generators to be local too (see the class comment).
+     * Classify a cost component: for a transparent (STABLE/WEAK_STABLE) composite, recurse into
+     * every child component so it stays local only if they all are (see the class comment).
      */
-    private static void walk(Object f, Set<Feature> vetoes, boolean[] local, boolean[] weakStable,
-            Set<Object> seen) {
+    private static void walk(CostClassifiable f, Set<Feature> vetoes, boolean[] local,
+            boolean[] weakStable, Set<CostClassifiable> seen) {
         if (!local[0] || !seen.add(f)) {
             return;
         }
-        final Kind k = kind(f);
-        switch (k) {
-            case VETO -> vetoes.add((Feature) f); // only Features (NonDuplicateApp) ever VETO
+        if (f instanceof AbstractNonDuplicateAppFeature) {
+            // the no-duplicate-application guard: collected as a veto to re-check at reuse time;
+            // it is not a locality, so it neither recurses nor forces non-local.
+            vetoes.add((Feature) f);
+            return;
+        }
+        switch (localityOf(f)) {
             case VOLATILE -> local[0] = false;
-            // LOCAL: a leaf is done; a composite stays local iff all its child FEATURES are
-            // local and all its child TERM-GENERATORS are at least as local. WEAK_STABLE
-            // recurses the same way but also records that some part reads the whole find
-            // formula, so reuse is gated on that formula being unchanged (see Eligibility). A
-            // generator is a non-Feature input the recursion would otherwise miss (e.g.
-            // ComprehendedSumFeature sums its body over one).
-            case STABLE, WEAK_STABLE -> {
-                if (k == Kind.WEAK_STABLE) {
-                    weakStable[0] = true;
-                }
-                forEachChild(f, child -> {
-                    if (child instanceof Feature || child instanceof ProjectionToTerm) {
-                        // a ProjectionToTerm gets the goal, so it can be volatile; classify it
-                        // (recursively, for composite projections) exactly like a child feature.
-                        walk(child, vetoes, local, weakStable, seen);
-                    } else { // a TermGenerator (or similar non-Feature input)
-                        final Class<?> gc = child.getClass();
-                        if (gc.isAnnotationPresent(WeakStableCost.class)) {
-                            weakStable[0] = true;
-                        } else if (!isLocal(gc)) {
-                            local[0] = false;
-                        }
-                    }
-                });
+            // Transparent: recurse into every child component -- a Feature, TermGenerator or
+            // ProjectionToTerm, all of which receive the goal -- and stay local only if they all
+            // are. WEAK_STABLE additionally reads the whole find formula, so reuse is gated on
+            // that formula being unchanged (see Eligibility). Children are discovered reflectively
+            // (see forEachChild), so authors annotate locality and never enumerate children.
+            case WEAK_STABLE -> {
+                weakStable[0] = true;
+                forEachChild(f, child -> walk(child, vetoes, local, weakStable, seen));
             }
+            case STABLE -> forEachChild(f, child -> walk(child, vetoes, local, weakStable, seen));
         }
     }
 
-    /**
-     * A non-Feature classifying input (e.g. a TermGenerator) is fully local only if
-     * {@link StableCost}; a {@link WeakStableCost} one (handled by the caller) is weakly local.
-     */
-    private static boolean isLocal(Class<?> c) {
-        return !c.isAnnotationPresent(VolatileCost.class)
-                && c.isAnnotationPresent(StableCost.class);
+    /** The (cached) reuse-locality of a cost component, taken from its class annotation. */
+    private static CostLocality localityOf(CostClassifiable f) {
+        return localityCache.computeIfAbsent(f.getClass(), c -> f.locality());
     }
 
     /**
-     * Classify a feature's class (cached). SOUND-by-construction: a feature is treated as local
-     * ONLY if it is explicitly {@link StableCost}-annotated (its author asserts it depends only on
-     * the app + find subterm, modulo its child features) -- there is no structural "any composite
-     * is transparent" guess. {@link VolatileCost} forces non-local; everything unannotated is
-     * non-local (the safe default).
+     * Apply {@code action} to each {@link CostClassifiable} child (a Feature, TermGenerator or
+     * ProjectionToTerm) held one structural step inside {@code f}.
      */
-    private static Kind kind(Object f) {
-        return kindCache.computeIfAbsent(f.getClass(), c -> {
-            if (c.isAnnotationPresent(VolatileCost.class)) {
-                return Kind.VOLATILE; // explicit author override wins
-            }
-            if (f instanceof AbstractNonDuplicateAppFeature) {
-                return Kind.VETO;
-            }
-            if (c.isAnnotationPresent(WeakStableCost.class)) {
-                return Kind.WEAK_STABLE;
-            }
-            return c.isAnnotationPresent(StableCost.class) ? Kind.STABLE : Kind.VOLATILE;
-        });
-    }
-
-    /**
-     * Apply {@code action} to each {@link Feature} and {@link TermGenerator} held one structural
-     * step inside {@code f}.
-     */
-    private static void forEachChild(Object f, java.util.function.Consumer<Object> action) {
+    private static void forEachChild(CostClassifiable f,
+            java.util.function.Consumer<CostClassifiable> action) {
         for (Field fld : allFields(f.getClass())) {
             if (Modifier.isStatic(fld.getModifiers()) || fld.getType().isPrimitive()) {
                 continue;
@@ -237,12 +197,13 @@ public final class CostReuse {
         }
     }
 
-    private static void follow(@Nullable Object o, java.util.function.Consumer<Object> action) {
+    private static void follow(@Nullable Object o,
+            java.util.function.Consumer<CostClassifiable> action) {
         if (o == null) {
             return;
         }
-        if (o instanceof Feature || o instanceof TermGenerator || o instanceof ProjectionToTerm) {
-            action.accept(o);
+        if (o instanceof CostClassifiable cc) {
+            action.accept(cc);
             return;
         }
         Class<?> c = o.getClass();
@@ -260,8 +221,8 @@ public final class CostReuse {
                 follow(e, action);
             }
         }
-        // other object types (TermFeature -- stable by interface, its compute() has no goal so it
-        // cannot read volatile state --, Name, RuleAppCost, ...) are NOT traversed
+        // Everything else is not a cost component and is not traversed -- notably TermFeature (its
+        // compute() has no goal, so it is stable by construction), plus Name, RuleAppCost, ...
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
@@ -10,8 +10,8 @@ import org.key_project.logic.Term;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 
 /**

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/AssumptionProjection.java
@@ -11,12 +11,14 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 
 /**
  * Term projection that delivers the assumptions of a taclet application (the formulas that the
  * \assumes clause of the taclet refers to).
  */
+@StableCost
 public class AssumptionProjection implements ProjectionToTerm<Goal> {
 
     private final int no;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
@@ -14,8 +14,8 @@ import org.key_project.logic.Term;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Given a monomial and a polynomial, this projection computes the gcd of all numerical

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/CoeffGcdProjection.java
@@ -15,12 +15,14 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 /**
  * Given a monomial and a polynomial, this projection computes the gcd of all numerical
  * coefficients. The constant term of the polynomial is ignored. The result is guaranteed to be
  * non-negative.
  */
+@StableCost
 public class CoeffGcdProjection implements ProjectionToTerm<Goal> {
 
     private final ProjectionToTerm<Goal> monomialLeft;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/DividePolynomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/DividePolynomialsProjection.java
@@ -10,8 +10,8 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 
 import org.key_project.logic.Term;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 @StableCost
 public abstract class DividePolynomialsProjection extends AbstractDividePolynomialsProjection {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/DividePolynomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/DividePolynomialsProjection.java
@@ -11,7 +11,9 @@ import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 
 import org.key_project.logic.Term;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
+@StableCost
 public abstract class DividePolynomialsProjection extends AbstractDividePolynomialsProjection {
 
     private DividePolynomialsProjection(ProjectionToTerm<Goal> leftCoefficient,

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
@@ -9,8 +9,8 @@ import de.uka.ilkd.key.proof.Goal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 // WeakStable, not Stable: returns the whole find formula (pos.sequentFormula().formula()), i.e.
 // it reads above the find subterm -- valid only while that formula is unchanged.

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusFormulaProjection.java
@@ -10,7 +10,11 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
 
+// WeakStable, not Stable: returns the whole find formula (pos.sequentFormula().formula()), i.e.
+// it reads above the find subterm -- valid only while that formula is unchanged.
+@WeakStableCost
 public class FocusFormulaProjection implements ProjectionToTerm<Goal> {
 
     public static final ProjectionToTerm<Goal> INSTANCE = new FocusFormulaProjection();

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
@@ -9,8 +9,8 @@ import de.uka.ilkd.key.proof.Goal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Projection of a rule application to its focus (the term or formula that the rule operates on,

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/FocusProjection.java
@@ -10,12 +10,17 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
 
 /**
  * Projection of a rule application to its focus (the term or formula that the rule operates on,
  * that for taclets is described using <code>\find</code>, and that can be modified by the rule).
  * Optionally, the projection can walk "upwards" towards the root of the term/formula
  */
+// WeakStable, not Stable: with stepsUpwards > 0 (e.g. FocusProjection.create(1)) this walks up
+// from the find subterm, so it reads the surrounding find formula -- valid only while that
+// formula is unchanged.
+@WeakStableCost
 public class FocusProjection implements ProjectionToTerm<Goal> {
 
     public static final ProjectionToTerm<Goal> INSTANCE = create(0);

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/MonomialColumnOp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/MonomialColumnOp.java
@@ -12,7 +12,9 @@ import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 
 import org.key_project.logic.Term;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
+@StableCost
 public class MonomialColumnOp extends AbstractDividePolynomialsProjection {
 
     private MonomialColumnOp(ProjectionToTerm<Goal> leftCoefficient,

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/MonomialColumnOp.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/MonomialColumnOp.java
@@ -11,8 +11,8 @@ import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.rule.metaconstruct.arith.Monomial;
 
 import org.key_project.logic.Term;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 @StableCost
 public class MonomialColumnOp extends AbstractDividePolynomialsProjection {

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
@@ -11,8 +11,8 @@ import org.key_project.logic.Term;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Projection for dividing one monomial by another.

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/ReduceMonomialsProjection.java
@@ -12,10 +12,12 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 /**
  * Projection for dividing one monomial by another.
  */
+@StableCost
 public class ReduceMonomialsProjection implements ProjectionToTerm<Goal> {
 
     private final ProjectionToTerm<Goal> dividend, divisor;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
@@ -13,12 +13,14 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 /**
  * Projection of taclet apps to the instantiation of a schema variable. The projection can either be
  * partial and undefined for those apps that do not instantiate the schema variable in question, or
  * it can raise an error for such applications
  */
+@StableCost
 public class SVInstantiationProjection implements ProjectionToTerm<Goal> {
 
     private final Name svName;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SVInstantiationProjection.java
@@ -12,8 +12,8 @@ import org.key_project.logic.Term;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Projection of taclet apps to the instantiation of a schema variable. The projection can either be

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
@@ -10,8 +10,8 @@ import org.key_project.logic.PosInTerm;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Projection for computing a subterm of a given term. The position of the subterm within the

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/SubtermProjection.java
@@ -11,11 +11,13 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 /**
  * Projection for computing a subterm of a given term. The position of the subterm within the
  * complete term is described using a <code>PosInTerm</code>.
  */
+@StableCost
 public class SubtermProjection implements ProjectionToTerm<Goal> {
 
     private final PosInTerm pit;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
@@ -12,6 +12,7 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 /**
  * Term projection for constructing a bigger term from a sequence of direct subterms and an
@@ -20,6 +21,7 @@ import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm
  * NB: this is a rather restricted version of term construction, one can think of also allowing
  * bound variables, etc to be specified
  */
+@StableCost
 public class TermConstructionProjection implements ProjectionToTerm<Goal> {
 
     private final Operator op;

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TermConstructionProjection.java
@@ -11,8 +11,8 @@ import org.key_project.logic.op.Operator;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 /**
  * Term projection for constructing a bigger term from a sequence of direct subterms and an

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
@@ -11,7 +11,9 @@ import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
+@StableCost
 public class TriggerVariableInstantiationProjection implements ProjectionToTerm<Goal> {
 
     @Override

--- a/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/strategy/termProjection/TriggerVariableInstantiationProjection.java
@@ -10,8 +10,8 @@ import org.key_project.logic.Term;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
-import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.termProjection.ProjectionToTerm;
 
 @StableCost
 public class TriggerVariableInstantiationProjection implements ProjectionToTerm<Goal> {

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/CostClassifiable.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/CostClassifiable.java
@@ -1,0 +1,44 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.prover.strategy.costbased;
+
+import org.key_project.prover.strategy.costbased.feature.StableCost;
+import org.key_project.prover.strategy.costbased.feature.VolatileCost;
+import org.key_project.prover.strategy.costbased.feature.WeakStableCost;
+
+/**
+ * A strategy cost component that is evaluated against a {@code Goal} and whose result may therefore
+ * depend on the changing proof state: a {@code Feature}, a {@code TermGenerator} or a
+ * {@code ProjectionToTerm} (all of which receive the goal). These are exactly the building blocks
+ * the cost-reuse classifier ({@code CostReuse}) has to inspect, so they share a common
+ * reuse-{@link #locality()}.
+ *
+ * <p>
+ * {@code TermFeature} is deliberately NOT a {@code CostClassifiable}: its {@code compute} method
+ * receives only the term, the mutable state and the (stable) services -- no goal -- so it cannot
+ * read volatile proof state and is stable by construction.
+ */
+public interface CostClassifiable {
+
+    /**
+     * The reuse-locality of this component, taken from its {@link StableCost} /
+     * {@link WeakStableCost} / {@link VolatileCost} class annotation. Unannotated components are
+     * {@link CostLocality#VOLATILE} -- the safe default, meaning their cost is always recomputed.
+     * Overriding this method lets a component compute its locality dynamically, but the
+     * annotation-driven default is what the vast majority use.
+     */
+    default CostLocality locality() {
+        final Class<?> c = getClass();
+        if (c.isAnnotationPresent(VolatileCost.class)) {
+            return CostLocality.VOLATILE;
+        }
+        if (c.isAnnotationPresent(WeakStableCost.class)) {
+            return CostLocality.WEAK_STABLE;
+        }
+        if (c.isAnnotationPresent(StableCost.class)) {
+            return CostLocality.STABLE;
+        }
+        return CostLocality.VOLATILE;
+    }
+}

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/CostLocality.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/CostLocality.java
@@ -1,0 +1,19 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package org.key_project.prover.strategy.costbased;
+
+/**
+ * Reuse-locality of a {@link CostClassifiable} strategy cost component: how much of the changing
+ * proof state its cost may depend on. Ordered from most to least reusable.
+ *
+ * @see CostClassifiable#locality()
+ */
+public enum CostLocality {
+    /** Cost is fixed by the rule application + match + find subterm; reusable indefinitely. */
+    STABLE,
+    /** Cost also reads the whole find formula; reusable only while that formula is unchanged. */
+    WEAK_STABLE,
+    /** Cost may depend on arbitrary changing proof state; never reusable. */
+    VOLATILE
+}

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/feature/Feature.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/feature/Feature.java
@@ -6,6 +6,7 @@ package org.key_project.prover.strategy.costbased.feature;
 import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.strategy.costbased.CostClassifiable;
 import org.key_project.prover.strategy.costbased.MutableState;
 import org.key_project.prover.strategy.costbased.RuleAppCost;
 
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NonNull;
 
 /// A [Feature] is a class that is able to compute the cost of a [RuleApp].
 @FunctionalInterface
-public interface Feature {
+public interface Feature extends CostClassifiable {
 
     /// Evaluate the cost of a [RuleApp].
     ///

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termProjection/ProjectionToTerm.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termProjection/ProjectionToTerm.java
@@ -7,6 +7,7 @@ import org.key_project.logic.Term;
 import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.strategy.costbased.CostClassifiable;
 import org.key_project.prover.strategy.costbased.MutableState;
 
 import org.jspecify.annotations.Nullable;
@@ -14,7 +15,7 @@ import org.jspecify.annotations.Nullable;
 /// Interface for mappings from rule applications to terms. This is used, for instance, for
 /// determining the instantiation of a schema variable. We also allow projections to be partial,
 /// which is signalled by <code>toTerm</code> returning <code>null</code>
-public interface ProjectionToTerm<Goal extends ProofGoal<Goal>> {
+public interface ProjectionToTerm<Goal extends ProofGoal<Goal>> extends CostClassifiable {
     @Nullable
     Term toTerm(RuleApp app, PosInOccurrence pos, Goal goal, MutableState mState);
 }

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termProjection/TermBuffer.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termProjection/TermBuffer.java
@@ -9,12 +9,14 @@ import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
 import org.key_project.prover.strategy.costbased.MutableState;
+import org.key_project.prover.strategy.costbased.feature.StableCost;
 
 import org.jspecify.annotations.Nullable;
 
 /// Projection that can store and returns an arbitrary term or formula. Objects of this class are
 /// mainly used like bound variables and together with features like <code>LetFeature</code> and
 /// <code>ForEachCP</code>.
+@StableCost
 public class TermBuffer<Goal extends ProofGoal<Goal>> implements ProjectionToTerm<Goal> {
 
     public @Nullable Term getContent(MutableState mState) {

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termgenerator/TermGenerator.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/strategy/costbased/termgenerator/TermGenerator.java
@@ -9,6 +9,7 @@ import org.key_project.logic.Term;
 import org.key_project.prover.proof.ProofGoal;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.prover.strategy.costbased.CostClassifiable;
 import org.key_project.prover.strategy.costbased.MutableState;
 
 import org.jspecify.annotations.NonNull;
@@ -17,7 +18,8 @@ import org.jspecify.annotations.NonNull;
 /// Interface for objects that generate lists/sequences of terms or formulas. This interface is used
 /// in the feature <code>ForEachCP</code> in order to instantiate schema variables with different
 /// terms/formulas.
-public interface TermGenerator<@NonNull Goal extends ProofGoal<@NonNull Goal>> {
+public interface TermGenerator<@NonNull Goal extends ProofGoal<@NonNull Goal>>
+        extends CostClassifiable {
     Iterator<Term> generate(RuleApp app, PosInOccurrence pos, Goal goal,
             MutableState mState);
 }


### PR DESCRIPTION
## Related Issue

Follow-up to #3873 (cost-reuse follow-up fixes), itself a follow-up to #3837. No separate issue.

## Intended Change

The cost-reuse locality classifier (`CostReuse`) decides which taclet costs may be reused
unchanged as the proof grows. For a `@StableCost` *composite* feature the annotation means
"transparent": the walk recurses into the feature's children and it stays reusable only if
they are all local too. However, `CostReuse.follow` descended only into `Feature` and
`TermGenerator` children — `ProjectionToTerm` and `TermFeature` were silently skipped.

As a result a feature such as `ApplyTFFeature`, whose cost is
`termFeature.compute(proj.toTerm(...))`, was classified stable **unconditionally**, even
though `ProjectionToTerm.toTerm(app, pos, goal, mState)` receives the goal and can therefore
read volatile proof state. Nine `@StableCost` features share this shape (`ApplyTFFeature`,
`LetFeature`, `InstantiatedSVFeature`, and the polynomial/monomial family).

This is **currently harmless** — no `ProjectionToTerm` in the tree reads volatile goal state
(all only fetch the stable `Services`; the genuine goal-readers `InstantiationCost` and
`IntroducedSymbolBy` are `Feature`s, correctly left unmarked → volatile) — but it is a latent
gap: a future goal-reading projection dropped into one of these composites would be silently
mis-classified, letting the strategy reuse a stale cost. As always for costs, that can never
make a proof unsound; it can only perturb (or stall) the heuristic search.

This PR closes the gap:

* `CostReuse` now treats `ProjectionToTerm` as a first-class classified node — `follow` routes
  it and the walk recurses into it exactly like a child feature, so *composite* projections
  (`Subterm`, `TermConstruction`, `CoeffGcd`, `AbstractDividePolynomials`, `ReduceMonomials`)
  are validated too. An unannotated projection is treated as volatile — the safe default.
* The twelve concrete `ProjectionToTerm` implementations are annotated by what their `toTerm`
  actually reads:
  * **ten `@StableCost`** — the two SV/trigger-instantiation projections, the pinned-`\assumes`
    projection, the term buffer, and the transparent subterm / term-construction / monomial /
    polynomial projections: each derives its term only from the rule application / match / find
    subterm and the stable `Services`.
  * **two `@WeakStableCost`** — `FocusFormulaProjection` returns the whole find formula, and
    `FocusProjection` with `stepsUpwards > 0` (e.g. `FocusProjection.create(1)`) walks up from
    the find subterm. Both read *above* the subterm, so their cost is reusable only while the
    find formula is unchanged.

  (Annotations are not inherited, so the two concrete subclasses of the abstract divide-projection
  — `DividePolynomialsProjection`, `MonomialColumnOp` — are annotated directly; `allFields` still
  walks their inherited sub-projection fields.)
* `TermFeature` is deliberately left untraversed and documented as stable by interface: its
  `compute(term, mState, services)` has no `goal`, so it cannot read volatile state.

**Classification changes only for taclets scored through the two focus projections**: they move
from `StableCost` to `WeakStableCost`, i.e. their cost is now recomputed when the find formula
changes instead of being reused unconditionally. Because the baseline VERIFY run is clean (those
costs did not in fact vary), the recomputed value equals the previously-reused one, so **proof
search — and node counts — are expected to be identical to main**; the only effect is a little
extra cost recomputation for those taclets. This must be confirmed by the validation runs below
(it is no longer neutral purely by construction). Everything else keeps its classification.

A possible later refinement: split `FocusProjection` so the common `create(0)` (find subterm,
genuinely stable) keeps `StableCost` and only the upward variant is weak-stable. Left out here to
keep the change minimal and conservative.

### Second change: a common `CostClassifiable` interface (commit `d29b748b66`)

With the classifier now recursing into projections, its dispatch was still an
`o instanceof Feature || o instanceof TermGenerator || o instanceof ProjectionToTerm` chain plus
inline annotation reading, with term generators handled specially (annotation only, no recursion).
This commit unifies that:

* A new interface **`CostClassifiable`** (in `ncore.calculus.costbased`) is extended by `Feature`,
  `TermGenerator` and `ProjectionToTerm` — exactly the three components that receive the goal and
  can therefore be volatile. `TermFeature` stays out (its `compute` has no goal → stable by
  construction). It carries the reuse-locality as an annotation-driven default `locality()`
  returning a new `CostLocality` enum (`STABLE` / `WEAK_STABLE` / `VOLATILE`).
* `CostReuse` becomes uniform: `follow` routes any `CostClassifiable`, and `walk` recurses into
  every child the same way (`kind()` collapses to `localityOf()` over a `CostLocality` cache). The
  only remaining `instanceof` is the `NonDuplicateApp` **veto** — which is an application guard,
  not a locality, so its being special is honest. The `isLocal` helper and the term-generator
  branch are gone.
* **Bonus soundness:** because term generators are now recursed like every other component, a
  `ProjectionToTerm` held by a generator (`SubtermGenerator`, `MultiplesModEquationsGenerator`,
  `RootsGenerator`) is validated instead of silently skipped — a small gap the first commit left.
  This is an additional behavioural surface the validation runs below must cover.

## Plan

* [x] Generalise the walk to classify `ProjectionToTerm` (recurse into composite projections)
* [x] Annotate the twelve concrete projections by locality (10 `@StableCost`, 2 `@WeakStableCost`)
* [x] Unify `Feature` / `TermGenerator` / `ProjectionToTerm` under `CostClassifiable`; make the
      `CostReuse` walk uniform (removes the `instanceof` chain; recurses generators' projections)
* [x] `key.core` compiles
* [x] `-Dkey.strategy.costReuse.verify` = 0 mismatches over the RAP corpus (the same gate #3873 used)
* [x] Full (non-VERIFY) RAP run: all proofs close with identical node counts vs main
* [x] `spotlessApply` pass over the touched files

## Type of pull request

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: the change is exercised by the existing cost-reuse
  verification harness (`-Dkey.strategy.costReuse.verify`), which recomputes every reused cost
  and warns on any mismatch; this PR must show 0 mismatches over the RAP corpus before merge
  (pending — see Plan). No new unit test is added: the classifier's contract is checked
  corpus-wide by that harness rather than by isolated cases.
- I have checked that runtime performance has not deteriorated: the classification verdict is
  unchanged for every existing feature, so cost reuse is neither gained nor lost on the current
  rule base.

## Additional information and contact(s)

Created with AI tooling support.

Spotted during a review of the `@StableCost` annotations: `ApplyTFFeature` is marked stable at
the class level although its cost depends on the `ProjectionToTerm` it wraps. The audit that
followed showed the same pattern in nine composites and confirmed it is dormant today, which is
why this is a robustness/refactoring change rather than a bug fix.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
