### PR TITLE
Fix two soundness gaps in select/permission taclets

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heapRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/heapRules.key
@@ -553,7 +553,7 @@
 
         \replacewith(
             \if(elementOf(o, f, s) & f != java.lang.Object::#$created)
-                \then(x)
+                \then((beta)x)
                 \else(select<[beta]>(h, o, f))
             = sk ==>)
 
@@ -582,7 +582,7 @@
 
         \replacewith(
             \if(elementOf(o, f, s) & f != java.lang.Object::#$created)
-                \then(x)
+                \then((beta)x)
                 \else(select<[beta]>(h, o, f))
             = sk ==>)
 

--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/permission/permissionRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/permission/permissionRules.key
@@ -374,6 +374,7 @@
 
         \assumes(writePermissionObject(o, p) ==>)
         \find(readPermissionObject(o, p))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -385,6 +386,7 @@
 
         \assumes(readPermissionObject(o1, p) ==>)
         \find(readPermissionObject(o2, transferPermission(split, o1, o2, 0, p)))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -396,6 +398,7 @@
 
         \assumes(readPermissionObject(o1, p), transferPermission(split, o1, o2, 0, p) = p1 ==>)
         \find(readPermissionObject(o2, p1))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -407,6 +410,7 @@
 
         \assumes(writePermissionObject(o1, p) ==>)
         \find(readPermissionObject(o2, transferPermission(split, o1, o2, 0, p)))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -418,6 +422,7 @@
 
         \assumes(writePermissionObject(o1, p), transferPermission(split, o1, o2, 0, p) = p1 ==>)
         \find(readPermissionObject(o2, p1))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -428,6 +433,7 @@
 
         \assumes(writePermissionObject(o1, p) ==>)
         \find(writePermissionObject(o2, transferPermission(FALSE, o1, o2, 0, p)))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -438,6 +444,7 @@
 
         \assumes(writePermissionObject(o1, p2), transferPermission(FALSE, o1, o2, 0, p2) = p1 ==>)
         \find(writePermissionObject(o2, p1))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -448,6 +455,7 @@
 
         \assumes(writePermissionObject(o1, p) ==>)
         \find(writePermissionObject(o2, returnPermission(o1, o2, p)))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -458,6 +466,7 @@
 
         \assumes(writePermissionObject(o1, p2), returnPermission(o1, o2, p2) = p1 ==>)
         \find(writePermissionObject(o2, p1))
+        \sameUpdateLevel
         \replacewith(true)
         \heuristics(simplify)
     };
@@ -477,6 +486,7 @@
 
         \assumes(p2 = transferPermission(FALSE, o1, o2, 0, p1) ==>)
         \find(returnPermission(o2, o1, p2))
+        \sameUpdateLevel
         \replacewith(p1)
         \heuristics(simplify)
     };
@@ -487,6 +497,7 @@
 
         \assumes(writePermissionObject(o1, p) ==> o2 = o1)
         \find(readPermissionObject(o2, p))
+        \sameUpdateLevel
         \replacewith(false)
         \heuristics(simplify)
     };
@@ -497,6 +508,7 @@
 
         \assumes(writePermissionObject(o1, p) ==> o2 = o1)
         \find(writePermissionObject(o2, p))
+        \sameUpdateLevel
         \replacewith(false)
         \heuristics(simplify)
     };

--- a/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
@@ -16396,7 +16396,7 @@ simplifySelectOfMemset {
 \find(select<[beta]>(memset(h,s,x),o,f))
 \inSequentState\replacewith(sk) 
 \heuristics(concrete)
-Choices: programRules:Java}] \replacewith([equals(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),x,select<[beta]>(h,o,f)),sk)]==>[]) 
+Choices: programRules:Java}] \replacewith([equals(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o,f)),sk)]==>[]) 
 \heuristics(simplify_select)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16408,7 +16408,7 @@ simplifySelectOfMemsetEQ {
 \find(select<[beta]>(EQ,o,f))
 \inSequentState\replacewith(sk) 
 \heuristics(concrete)
-Choices: programRules:Java}] \replacewith([equals(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),x,select<[beta]>(h,o,f)),sk)]==>[]) 
+Choices: programRules:Java}] \replacewith([equals(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o,f)),sk)]==>[]) 
 \heuristics(simplify_select)
 Choices: programRules:Java}
 -----------------------------------------------------


### PR DESCRIPTION
## Intended Change

Two independent soundness issues in taclets, both discovered while generating  taclet proof obligations (`TacletProofObligationInput`).

### 1. `simplifySelectOfMemset(EQ)`: missing cast on the stored value

The rule misses a cast (`(beta)x`) in the then-part of the conditional, cf. the `selectOfMemset` axiom. Without the cast the taclet proof obligation is not valid for `x` outside `beta`.

### 2. `permissionRules.key`: twelve assumes-rewrites without update-context restriction

Taclets have an assumes and a find term that matches on term (not top level), hence, the `\sameUpdateLevel` modifier is needed.

## Plan

* [x] Fix `simplifySelectOfMemset(EQ)` (cast) and add `\sameUpdateLevel` to the twelve permission taclets
* [ ] Add `\lemma` annotations + taclet soundness proofs (`tacletProofs/`) for the affected rules, where the lemma translation supports them (the `\addrules`-based memset rules may not be translatable)

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the taclet rule base

## Ensuring quality

- I have tested the feature as follows: full `testRAP` green (in particular all `permissionHeap*` loadability and provability proofs, which exercise the twelve permission rules heavily), `testProveRules` green.
- I have checked that runtime performance has not deteriorated (RAP wall time unchanged).

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

Created with AI tooling support.