### PR TITLE
Fix: Automode button in Strategy Pane could not be used to stop automode

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -674,7 +674,7 @@ public final class MainWindow extends JFrame {
         toolBar.setRollover(true);
 
         DropdownSelectionButton autoComp = createAutomationComponent();
-        toolBar.add(createWiderAutoModeButton(autoComp.getActionComponent()));
+        toolBar.add(autoComp.getActionComponent());
         toolBar.add(autoComp.getSelectionComponent());
         toolBar.addSeparator();
         toolBar.addSeparator();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -674,7 +674,7 @@ public final class MainWindow extends JFrame {
         toolBar.setRollover(true);
 
         DropdownSelectionButton autoComp = createAutomationComponent();
-        toolBar.add(autoComp.getActionComponent());
+        toolBar.add(createWiderAutoModeButton(autoComp.getActionComponent()));
         toolBar.add(autoComp.getSelectionComponent());
         toolBar.addSeparator();
         toolBar.addSeparator();
@@ -857,9 +857,7 @@ public final class MainWindow extends JFrame {
         return automationComponent;
     }
 
-    private JComponent createWiderAutoModeButton() {
-        JButton b = new JButton(autoModeAction);
-        b.putClientProperty("hideActionText", Boolean.TRUE);
+    private JComponent createWiderAutoModeButton(JComponent b) {
         // the following rigmarole is to make the button slightly wider
         JPanel p = new JPanel();
         p.setLayout(new GridBagLayout());

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroMenu.java
@@ -143,8 +143,7 @@ public class ProofMacroMenu extends JMenu {
             menuItem.setAccelerator(macroKey);
         }
 
-        menuItem.addActionListener(
-            new ProofMacroUserAction(mediator, macro, posInOcc, mediator.getSelectedProof()));
+        menuItem.addActionListener(new ProofMacroUserAction(mediator, macro, posInOcc));
         return menuItem;
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/StrategySelectionView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/StrategySelectionView.java
@@ -148,6 +148,7 @@ public final class StrategySelectionView extends JPanel implements TabPanel {
         // //////////////////////////////////////////////////////////////////////
 
         this.btnGo = new JButton();
+        this.btnGo.putClientProperty("isAutoButton", Boolean.TRUE);
 
         JPanel timeout = createDefaultPanel(components);
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroAutomationAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroAutomationAction.java
@@ -8,6 +8,7 @@ import javax.swing.Icon;
 
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.actions.useractions.ProofMacroUserAction;
 import de.uka.ilkd.key.macros.ProofMacro;
 import de.uka.ilkd.key.ui.MediatorProofControl;
 
@@ -50,9 +51,10 @@ public class MacroAutomationAction extends AutoModeAction {
             proofControl.stopAutoMode();
         } else {
             if ((e.getModifiers() & ActionEvent.SHIFT_MASK) != 0) {
-                proofControl.runMacro(mediator.getSelectedProof().root(), macro, null);
+                new ProofMacroUserAction(mediator, macro, mediator.getSelectedProof().root(), null)
+                        .actionPerformed(e);
             } else {
-                proofControl.runMacro(mediator.getSelectedNode(), macro, null);
+                new ProofMacroUserAction(mediator, macro, null).actionPerformed(e);
             }
         }
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroAutomationAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroAutomationAction.java
@@ -9,6 +9,7 @@ import javax.swing.Icon;
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.macros.ProofMacro;
+import de.uka.ilkd.key.ui.MediatorProofControl;
 
 /**
  * Automation action that executes a proof macro.
@@ -38,16 +39,21 @@ public class MacroAutomationAction extends AutoModeAction {
         super(mainWindow, icon);
         this.macro = macro;
         setName(macro.getName());
-        setTooltip(macro.getDescription());
+        setTooltip(macro.getDescription() + " (shift-click = run on whole proof)");
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         KeYMediator mediator = getMediator();
+        MediatorProofControl proofControl = mediator.getUI().getProofControl();
         if (mediator.isInAutoMode()) {
-            getMediator().getUI().getProofControl().stopAutoMode();
+            proofControl.stopAutoMode();
         } else {
-            mediator.getUI().getProofControl().runMacro(mediator.getSelectedNode(), macro, null);
+            if ((e.getModifiers() & ActionEvent.SHIFT_MASK) != 0) {
+                proofControl.runMacro(mediator.getSelectedProof().root(), macro, null);
+            } else {
+                proofControl.runMacro(mediator.getSelectedNode(), macro, null);
+            }
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroKeyBinding.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/MacroKeyBinding.java
@@ -52,8 +52,7 @@ public class MacroKeyBinding extends AbstractAction {
         }
 
         if (macro.canApplyTo(mediator.getSelectedNode(), posInOcc)) {
-            new ProofMacroUserAction(mediator, macro, posInOcc, mediator.getSelectedProof())
-                    .actionPerformed(e);
+            new ProofMacroUserAction(mediator, macro, posInOcc).actionPerformed(e);
         }
     }
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofMacroUserAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/useractions/ProofMacroUserAction.java
@@ -5,7 +5,7 @@ package de.uka.ilkd.key.gui.actions.useractions;
 
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.macros.ProofMacro;
-import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.Node;
 
 import org.key_project.prover.sequent.PosInOccurrence;
 
@@ -24,11 +24,22 @@ public class ProofMacroUserAction extends ProofModifyingUserAction {
      */
     private final PosInOccurrence pio;
 
-    public ProofMacroUserAction(KeYMediator mediator, ProofMacro macro, PosInOccurrence pio,
-            Proof proof) {
-        super(mediator, proof);
+    /// Root of the subtree to run the macro from. If null, it is run from the selected node.
+    private final Node node;
+
+    public ProofMacroUserAction(KeYMediator mediator, ProofMacro macro, PosInOccurrence pio) {
+        super(mediator, mediator.getSelectedProof());
         this.macro = macro;
         this.pio = pio;
+        this.node = mediator.getSelectedNode();
+    }
+
+    public ProofMacroUserAction(KeYMediator mediator, ProofMacro macro, Node node,
+            PosInOccurrence pio) {
+        super(mediator, mediator.getSelectedProof());
+        this.macro = macro;
+        this.pio = pio;
+        this.node = node;
     }
 
     @Override
@@ -41,6 +52,10 @@ public class ProofMacroUserAction extends ProofModifyingUserAction {
         if (mediator.isInAutoMode()) {
             return;
         }
-        mediator.getUI().getProofControl().runMacro(mediator.getSelectedNode(), macro, pio);
+        if (node == null) {
+            mediator.getUI().getProofControl().runMacro(mediator.getSelectedNode(), macro, pio);
+        } else {
+            mediator.getUI().getProofControl().runMacro(node, macro, pio);
+        }
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -190,6 +190,10 @@ public final class IconFactory {
      * toolbar automation icons created by {@link #automationWithOverlay(int, String)}.
      */
     public static final int TOOLBAR_INDICATOR_EXTRA_SPACE = 5;
+    /**
+     * Additional horizontal space in pixels for wider auto buttons.
+     */
+    public static final int TOOLBAR_EXTRA_WIDTH = 14;
 
     private IconFactory() {
     }
@@ -393,7 +397,7 @@ public final class IconFactory {
 
     public static Icon iconWithOverlay(Icon baseIcon, String letter) {
         BufferedImage image =
-            new BufferedImage(baseIcon.getIconWidth() + TOOLBAR_INDICATOR_EXTRA_SPACE,
+            new BufferedImage(baseIcon.getIconWidth() + TOOLBAR_INDICATOR_EXTRA_SPACE + 2 * TOOLBAR_EXTRA_WIDTH,
                 baseIcon.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = image.createGraphics();
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -401,7 +405,7 @@ public final class IconFactory {
             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
 
         // Draw base icon
-        baseIcon.paintIcon(null, g2d, 0, 0);
+        baseIcon.paintIcon(null, g2d, TOOLBAR_EXTRA_WIDTH, 0);
 
         if (letter == null) {
             return new ImageIcon(image);
@@ -420,7 +424,7 @@ public final class IconFactory {
         // Position letter in bottom-right corner
         int x = baseIcon.getIconWidth() - textWidth;
 
-        g2d.drawString(letter, x + 5, baseIcon.getIconHeight());
+        g2d.drawString(letter, x + TOOLBAR_INDICATOR_EXTRA_SPACE + TOOLBAR_EXTRA_WIDTH, baseIcon.getIconHeight());
         g2d.dispose();
 
         return new ImageIcon(image);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -397,7 +397,8 @@ public final class IconFactory {
 
     public static Icon iconWithOverlay(Icon baseIcon, String letter) {
         BufferedImage image =
-            new BufferedImage(baseIcon.getIconWidth() + TOOLBAR_INDICATOR_EXTRA_SPACE + 2 * TOOLBAR_EXTRA_WIDTH,
+            new BufferedImage(
+                baseIcon.getIconWidth() + TOOLBAR_INDICATOR_EXTRA_SPACE + 2 * TOOLBAR_EXTRA_WIDTH,
                 baseIcon.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = image.createGraphics();
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -424,7 +425,8 @@ public final class IconFactory {
         // Position letter in bottom-right corner
         int x = baseIcon.getIconWidth() - textWidth;
 
-        g2d.drawString(letter, x + TOOLBAR_INDICATOR_EXTRA_SPACE + TOOLBAR_EXTRA_WIDTH, baseIcon.getIconHeight());
+        g2d.drawString(letter, x + TOOLBAR_INDICATOR_EXTRA_SPACE + TOOLBAR_EXTRA_WIDTH,
+            baseIcon.getIconHeight());
         g2d.dispose();
 
         return new ImageIcon(image);


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

The automod ebutton in the strategy pane could no longer be used to stop an automode run as it was blocked by the glass pane which prevents interactions with a running proof. This PR enables the stopping feature again.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: manual test

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
