### PR TITLE
Interactive Proof Replayer

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
@@ -143,16 +143,20 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
                 tacletInfo.ifDirectFormulaList = tacletInfo.ifDirectFormulaList.append(str);
             }
             case KeY_USER -> { // UserLog
-                if (proof.userLog == null) {
-                    proof.userLog = new ArrayList<>();
+                if(proof != null) {
+                    if (proof.userLog == null) {
+                        proof.userLog = new ArrayList<>();
+                    }
+                    proof.userLog.add(str);
                 }
-                proof.userLog.add(str);
             }
             case KeY_VERSION -> { // Version log
-                if (proof.keyVersionLog == null) {
-                    proof.keyVersionLog = new ArrayList<>();
+                if(proof != null) {
+                    if (proof.keyVersionLog == null) {
+                        proof.keyVersionLog = new ArrayList<>();
+                    }
+                    proof.keyVersionLog.add(str);
                 }
-                proof.keyVersionLog.add(str);
             }
             case KeY_SETTINGS -> // ProofSettings
                 loadPreferences(str);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediatePresentationProofFileParser.java
@@ -143,7 +143,7 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
                 tacletInfo.ifDirectFormulaList = tacletInfo.ifDirectFormulaList.append(str);
             }
             case KeY_USER -> { // UserLog
-                if(proof != null) {
+                if (proof != null) {
                     if (proof.userLog == null) {
                         proof.userLog = new ArrayList<>();
                     }
@@ -151,7 +151,7 @@ public class IntermediatePresentationProofFileParser implements IProofFileParser
                 }
             }
             case KeY_VERSION -> { // Version log
-                if(proof != null) {
+                if (proof != null) {
                     if (proof.keyVersionLog == null) {
                         proof.keyVersionLog = new ArrayList<>();
                     }

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -249,7 +249,7 @@ public class IntermediateProofReplayer {
                             .getIntermediateRuleApp() instanceof TacletAppIntermediate appInterm) {
 
                         try {
-                            currGoal.apply(constructTacletApp(appInterm, currGoal));
+                            currGoal.apply(constructTacletApp(proof, appInterm, currGoal));
 
                             final Iterator<Node> children = currNode.childrenIterator();
                             final LinkedList<NodeIntermediate> intermChildren =
@@ -439,12 +439,13 @@ public class IntermediateProofReplayer {
     /**
      * Constructs a taclet application from an intermediate one.
      *
+     * @param proof the current proof to operate on
      * @param currInterm The intermediate taclet application to create a "real" application for.
-     * @param currGoal The goal on which to apply the taclet app.
+     * @param currGoal   The goal on which to apply the taclet app.
      * @return The taclet application corresponding to the supplied intermediate representation.
      * @throws TacletAppConstructionException In case of an error during construction.
      */
-    private TacletApp constructTacletApp(TacletAppIntermediate currInterm, Goal currGoal)
+    public static TacletApp constructTacletApp(Proof proof, TacletAppIntermediate currInterm, Goal currGoal)
             throws TacletAppConstructionException {
 
         final String tacletName = currInterm.getRuleName();

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -441,11 +441,12 @@ public class IntermediateProofReplayer {
      *
      * @param proof the current proof to operate on
      * @param currInterm The intermediate taclet application to create a "real" application for.
-     * @param currGoal   The goal on which to apply the taclet app.
+     * @param currGoal The goal on which to apply the taclet app.
      * @return The taclet application corresponding to the supplied intermediate representation.
      * @throws TacletAppConstructionException In case of an error during construction.
      */
-    public static TacletApp constructTacletApp(Proof proof, TacletAppIntermediate currInterm, Goal currGoal)
+    public static TacletApp constructTacletApp(Proof proof, TacletAppIntermediate currInterm,
+            Goal currGoal)
             throws TacletAppConstructionException {
 
         final String tacletName = currInterm.getRuleName();

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationExtension.java
@@ -1,0 +1,32 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.proofreplay;
+
+import de.uka.ilkd.key.core.KeYMediator;
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
+import de.uka.ilkd.key.gui.extension.api.TabPanel;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+@KeYGuiExtension.Info(name = "Proof Replayer", experimental = false, optional = true,
+        description = """
+                UI to help replaying stored proofs on new KeY versions. 
+                """
+)
+@NullMarked
+public class ProofReapplicationExtension implements KeYGuiExtension, KeYGuiExtension.LeftPanel {
+    private @Nullable ProofReapplicationView view;
+
+    @Override
+    public Collection<TabPanel> getPanels(MainWindow window, KeYMediator mediator) {
+        if (view == null) {
+            view = new ProofReapplicationView(window, mediator);
+        }
+        return List.of(view);
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationExtension.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationExtension.java
@@ -3,21 +3,21 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.proofreplay;
 
+import java.util.Collection;
+import java.util.List;
+
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.extension.api.KeYGuiExtension;
 import de.uka.ilkd.key.gui.extension.api.TabPanel;
+
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.List;
-
 @KeYGuiExtension.Info(name = "Proof Replayer", experimental = false, optional = true,
-        description = """
-                UI to help replaying stored proofs on new KeY versions. 
-                """
-)
+    description = """
+            UI to help replaying stored proofs on new KeY versions.
+            """)
 @NullMarked
 public class ProofReapplicationExtension implements KeYGuiExtension, KeYGuiExtension.LeftPanel {
     private @Nullable ProofReapplicationView view;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
@@ -7,15 +7,31 @@ import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.KeyAction;
 import de.uka.ilkd.key.gui.extension.api.TabPanel;
+import de.uka.ilkd.key.java.Services;
+import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.TacletIndex;
 import de.uka.ilkd.key.proof.init.KeYUserProblemFile;
 import de.uka.ilkd.key.proof.io.IntermediatePresentationProofFileParser;
-import de.uka.ilkd.key.proof.io.intermediate.AppNodeIntermediate;
-import de.uka.ilkd.key.proof.io.intermediate.BranchNodeIntermediate;
-import de.uka.ilkd.key.proof.io.intermediate.NodeIntermediate;
+import de.uka.ilkd.key.proof.io.IntermediateProofReplayer;
+import de.uka.ilkd.key.proof.io.intermediate.*;
+import de.uka.ilkd.key.rule.*;
+import de.uka.ilkd.key.settings.DefaultSMTSettings;
+import de.uka.ilkd.key.settings.ProofIndependentSMTSettings;
+import de.uka.ilkd.key.settings.ProofIndependentSettings;
+import de.uka.ilkd.key.smt.*;
+import de.uka.ilkd.key.speclang.Contract;
+import de.uka.ilkd.key.speclang.OperationContract;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.key_project.logic.PosInTerm;
+import org.key_project.prover.rules.RuleApp;
+import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.util.collection.DefaultImmutableSet;
+import org.key_project.util.collection.ImmutableList;
+import org.key_project.util.collection.ImmutableSet;
+import org.key_project.util.collection.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +48,8 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.List;
 import java.util.stream.StreamSupport;
+
+import static de.uka.ilkd.key.proof.io.IntermediateProofReplayer.constructTacletApp;
 
 /// A Swing-based UI component for viewing KeY proofs and allowing reapplication of subtrees
 /// and single rules.
@@ -54,7 +72,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     private final DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultMutableTreeNode("No proof loaded"));
 
     /// The JTree displaying the proof structure
-    private final JTree proofTree = new JTree(treeModel);
+    private final JTree intermProofTree = new JTree(treeModel);
 
     /// The mediator for proof operations
     private final KeYMediator mediator;
@@ -69,21 +87,21 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     /// Initializes the UI components.
     private void initComponents() {
         setLayout(new BorderLayout());
-        proofTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
-        proofTree.setCellRenderer(new ProofTreeNodeRenderer());
-        proofTree.addTreeSelectionListener(e -> onNodeSelected());
-        proofTree.addMouseListener(new MouseAdapter() {
+        intermProofTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+        intermProofTree.setCellRenderer(new ProofTreeNodeRenderer());
+        intermProofTree.addTreeSelectionListener(e -> onNodeSelected());
+        intermProofTree.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
                 if (SwingUtilities.isRightMouseButton(e)) {
-                    int row = proofTree.getClosestRowForLocation(e.getX(), e.getY());
-                    proofTree.setSelectionRow(row);
+                    int row = intermProofTree.getClosestRowForLocation(e.getX(), e.getY());
+                    intermProofTree.setSelectionRow(row);
                     showContextMenu(e.getComponent(), e.getX(), e.getY());
                 }
             }
         });
 
-        JScrollPane treeScrollPane = new JScrollPane(proofTree);
+        JScrollPane treeScrollPane = new JScrollPane(intermProofTree);
         add(treeScrollPane, BorderLayout.CENTER);
         add(new JButton(new LoadProofAction()), BorderLayout.NORTH);
     }
@@ -108,12 +126,15 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
     /// Action to replay subtree from selected node.
     private AbstractAction createReplaySubtreeAction() {
-        return new AbstractAction("Replay Subtree") {
+        AbstractAction replaySubtreeAction = new AbstractAction("Replay Subtree") {
             @Override
             public void actionPerformed(ActionEvent e) {
                 //replaySubtree();
             }
         };
+        // not implemented at the moment
+        replaySubtreeAction.setEnabled(false);
+        return replaySubtreeAction;
     }
 
     /// Action to replay single rule at selected node.
@@ -125,7 +146,12 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                //replaySingleRule();
+                try {
+                    replaySingleRule();
+                } catch (IntermediateProofReplayer.TacletAppConstructionException ex) {
+                    // TODO: error reporting
+                    throw new RuntimeException(ex);
+                }
             }
         };
     }
@@ -178,7 +204,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
         // Expand the first few levels
         for (int i = 0; i < 3; i++) {
-            proofTree.expandRow(i);
+            intermProofTree.expandRow(i);
         }
     }
 
@@ -216,7 +242,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
     /// Handles node selection in the tree.
     private void onNodeSelected() {
-        TreePath path = proofTree.getSelectionPath();
+        TreePath path = intermProofTree.getSelectionPath();
     }
 
     /// Shows the context menu at the specified location.
@@ -284,7 +310,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     "Replay Error", JOptionPane.ERROR_MESSAGE);
             statusLabel.setText("Subtree replay failed");
         }
-    }
+    }*/
 
     /// Collects all rule applications from a node and its descendants.
     private List<RuleApp> collectRuleApps(Node node) {
@@ -300,15 +326,106 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     }
 
     /// Replays a single rule at the selected node.
-    private void replaySingleRule(ProofTreeIntermediateNode node) {
+    private void replaySingleRule()
+        throws IntermediateProofReplayer.TacletAppConstructionException {
+
+        proof = mediator.getSelectedProof();
         if (proof == null) {
             JOptionPane.showMessageDialog(this,
-                    "No proof loaded.",
-                    "No Proof", JOptionPane.WARNING_MESSAGE);
+                "No proof loaded.",
+                "No Proof", JOptionPane.WARNING_MESSAGE);
             return;
         }
 
-        RuleApp originalApp = selectedNode.getAppliedRuleApp();
+        Node currNode = mediator.getSelectedNode();
+        Goal currGoal = mediator.getSelectedGoal();
+
+        // obtain selected node from intermProofTree
+        TreeNodeIntermediate<?> selectedNode =
+            (TreeNodeIntermediate<?>)intermProofTree.getLastSelectedPathComponent();
+        NodeIntermediate currNodeInterm = selectedNode.data;
+
+        /*
+        if (n instanceof AppNodeIntermediate nApp) {
+            app = nApp.getIntermediateRuleApp();
+        } else if (n instanceof BranchNodeIntermediate nBranch) {
+
+        }
+        } else {
+            // not a replayable rule
+            return;
+        }*/
+
+        if (currNodeInterm instanceof BranchNodeIntermediate) {
+            // not a replayable rule
+            return;
+        } else if (currNodeInterm instanceof AppNodeIntermediate currInterm) {
+
+            currNode.getNodeInfo().setNotes(currInterm.getNotes());
+
+            // Register name proposals
+            proof.getServices().getNameRecorder()
+                .setProposals(currInterm.getIntermediateRuleApp().getNewNames());
+
+            if (currInterm.getIntermediateRuleApp() instanceof TacletAppIntermediate appInterm) {
+
+                //try {
+                TacletApp tacletApp = constructTacletApp(proof, appInterm, currGoal);
+                currGoal.apply(tacletApp);
+
+                /*
+                final Iterator<Node> children = currNode.childrenIterator();
+                final LinkedList<NodeIntermediate> intermChildren =
+                    currInterm.getChildren();
+
+                addChildren(children, intermChildren);*/
+
+                // set information about SUCCESSFUL rule application
+                currNode.getNodeInfo().setInteractiveRuleApplication(
+                    currInterm.isInteractiveRuleApplication());
+                currNode.getNodeInfo()
+                    .setScriptRuleApplication(currInterm.isScriptRuleApplication());
+
+                /*
+                } catch (Exception | AssertionError e) {
+                    reportError("Error loading proof.\n Line " + appInterm.getLineNr()
+                        + ", goal " + currGoal.node().serialNr() + ", rule "
+                        + appInterm.getRuleName() + NOT_APPLICABLE, e);
+                }*/
+                selectedNode.applied = true;
+
+            } else if (currInterm.getIntermediateRuleApp() instanceof BuiltInAppIntermediate appInterm) {
+
+                try {
+                    IBuiltInRuleApp app = constructBuiltinApp(proof, appInterm, currGoal);
+                    if (!app.complete()) {
+                        app = app.tryToInstantiate(currGoal);
+                    }
+                    currGoal.apply(app);
+
+                    /*
+                    final Iterator<Node> children = currNode.childrenIterator();
+                    LinkedList<NodeIntermediate> intermChildren =
+                        currInterm.getChildren();
+
+                    addChildren(children, intermChildren);*/
+                //} catch (IntermediateProofReplayer.SkipSMTRuleException e) {
+                    // silently continue; status will be reported via polling
+                } catch (IntermediateProofReplayer.BuiltInConstructionException | AssertionError
+                         | RuntimeException e) {
+                    // TODO: error reporting
+                    selectedNode.errored = true;
+                    throw new RuntimeException("Error loading proof: Line " + appInterm.getLineNr()
+                        + ", goal " + currGoal.node().serialNr() + ", rule "
+                        + appInterm.getRuleName() + " not applicable.", e);
+                    /*reportError(ERROR_LOADING_PROOF_LINE + "Line "
+                        + appInterm.getLineNr() + ", goal " + currGoal.node().serialNr()
+                        + ", rule " + appInterm.getRuleName() + NOT_APPLICABLE, e);*/
+                }
+                selectedNode.applied = true;
+            }
+
+        /*RuleApp originalApp = selectedNode.getAppliedRuleApp();
         if (originalApp == null) {
             JOptionPane.showMessageDialog(this,
                     "Selected node has no applied rule.",
@@ -336,7 +453,208 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     "Error replaying rule: " + e.getMessage(),
                     "Replay Error", JOptionPane.ERROR_MESSAGE);
             statusLabel.setText("Rule replay failed");
+        }*/
         }
+    }
+
+    // TODO: taken and adapted from IntermediateProofReplayer. Should be refactored instead there!
+    private static IBuiltInRuleApp constructBuiltinApp(Proof proof, BuiltInAppIntermediate currInterm, Goal currGoal)
+        throws //IntermediateProofReplayer.SkipSMTRuleException,
+        IntermediateProofReplayer.BuiltInConstructionException {
+
+        final String ruleName = currInterm.getRuleName();
+        final int currFormula = currInterm.getPosInfo().first;
+        final PosInTerm currPosInTerm = currInterm.getPosInfo().second;
+
+        Contract currContract = null;
+        ImmutableList<PosInOccurrence> builtinIfInsts = null;
+
+        // Load contracts, if applicable
+        if (currInterm.getContract() != null) {
+            currContract = proof.getServices().getSpecificationRepository()
+                .getContractByName(currInterm.getContract());
+            if (currContract == null) {
+                throw new IntermediateProofReplayer.BuiltInConstructionException(
+                    "Could not reconstruct the rule application: the stored contract \""
+                        + currInterm.getContract() + "\" could not be found in the current specification repository.");
+                /*final ProblemLoaderException e =
+                    new ProblemLoaderException(loader, "Error loading proof: contract \""
+                        + currInterm.getContract() + "\" not found.");
+                reportError(ERROR_LOADING_PROOF_LINE + ", goal " + currGoal.node().serialNr()
+                    + ", rule " + ruleName + NOT_APPLICABLE, e);*/
+            }
+        }
+
+        // Load ifInsts, if applicable
+        if (currInterm.getBuiltInIfInsts() != null) {
+            builtinIfInsts = ImmutableList.nil();
+            for (final Pair<Integer, PosInTerm> ifInstP : currInterm.getBuiltInIfInsts()) {
+                final int currIfInstFormula = ifInstP.first;
+                final PosInTerm currIfInstPosInTerm = ifInstP.second;
+
+                try {
+                    final PosInOccurrence ifInst =
+                        PosInOccurrence.findInSequent(
+                            currGoal.sequent(),
+                            currIfInstFormula, currIfInstPosInTerm);
+                    builtinIfInsts = builtinIfInsts.append(ifInst);
+                } catch (RuntimeException | AssertionError e) {
+                    // TODO: error reporting
+                    throw new RuntimeException("Error loading proof: Line " + currInterm.getLineNr()
+                        + ", goal " + currGoal.node().serialNr() + ", rule " + ruleName
+                        + " not applicable.", e);
+                    /*
+                    reportError(
+                        ERROR_LOADING_PROOF_LINE + "Line " + currInterm.getLineNr() + ", goal "
+                            + currGoal.node().serialNr() + ", rule " + ruleName + NOT_APPLICABLE,
+                        e);*/
+                }
+            }
+        }
+
+        final SMTRule smtRule = SMTRule.INSTANCE; // proof.getServices().getProfile().findInstanceFor(SMTRule.class);
+
+        if (smtRule.name().toString().equals(ruleName)) {
+            if (!ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings().isEnableOnLoad()) {
+                // TODO
+                //status = SMT_NOT_RUN;
+                throw new RuntimeException();
+            }
+            boolean error = false;
+            final SMTProblem smtProblem = new SMTProblem(currGoal);
+            try {
+                DefaultSMTSettings settings = new DefaultSMTSettings(
+                    proof.getSettings().getSMTSettings(),
+                    ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings(),
+                    proof.getSettings().getNewSMTSettings(),
+                    proof);
+
+                ProofIndependentSMTSettings smtSettings = ProofIndependentSettings.DEFAULT_INSTANCE
+                    .getSMTSettings();
+                SolverTypeCollection active = smtSettings.computeActiveSolverUnion();
+                SMTAppIntermediate smtAppIntermediate = (SMTAppIntermediate) currInterm;
+                String smtSolver = smtAppIntermediate.getSolver();
+                if (smtSolver == null || smtSolver.isEmpty()) {
+                    // default to Z3 because this one most likely was used when saving the proof
+                    smtSolver = "Z3";
+                }
+                // try to find the solver that closed the proof
+                for (SolverTypeCollection su : smtSettings.getSolverUnions(true)) {
+                    if (su.name().equals(smtSolver)) {
+                        active = su;
+                        break;
+                    }
+                }
+                ArrayList<SMTProblem> problems = new ArrayList<>();
+                problems.add(smtProblem);
+
+                SolverLauncher launcher = new SolverLauncher(settings);
+                launcher.launch(active.getTypes(), problems,
+                    proof.getServices());
+            } catch (Exception e) {
+                error = true;
+            }
+            if (error || smtProblem.getFinalResult().isValid() != SMTSolverResult.ThreeValuedTruth.VALID) {
+                // TODO
+                //status = SMT_NOT_RUN;
+                throw new RuntimeException();
+            } else {
+                String name = smtProblem.getSuccessfulSolver().name();
+                ImmutableList<PosInOccurrence> unsatCore =
+                    SMTFocusResults.getUnsatCore(smtProblem);
+                if (unsatCore != null) {
+                    return smtRule.createApp(name, unsatCore);
+                } else {
+                    return smtRule.createApp(name);
+                }
+            }
+        }
+
+        IBuiltInRuleApp ourApp;
+        PosInOccurrence pos = null;
+
+        if (currFormula != 0) { // otherwise we have no pos
+            try {
+                pos = PosInOccurrence
+                    .findInSequent(currGoal.sequent(), currFormula, currPosInTerm);
+            } catch (RuntimeException e) {
+                throw new IntermediateProofReplayer.BuiltInConstructionException(
+                    "Could not reconstruct the rule application: the stored position (formula "
+                        + currFormula + ", term " + currPosInTerm
+                        + ") could not be located in the current sequent.",
+                    e);
+            }
+        }
+
+        if (currContract != null) {
+            AbstractContractRuleApp<?> contractApp;
+
+            if (currContract instanceof OperationContract) {
+                var rule = proof.getServices().getProfile().getUseOperationContractRule();
+                contractApp = rule.createApp(pos).setContract(currContract);
+            } else {
+                var rule = proof.getServices().getProfile().getUseDependencyContractRule();
+                contractApp = rule.createApp(pos).setContract(currContract);
+                // restore "step" if needed
+                var depContractApp = ((UseDependencyContractApp<?>) contractApp);
+                if (depContractApp.step() == null) {
+                    contractApp = depContractApp.setStep(builtinIfInsts.head());
+                }
+            }
+
+            if (contractApp.check(currGoal.proof().getServices()) == null) {
+                throw new IntermediateProofReplayer.BuiltInConstructionException("Cannot apply contract: " + currContract);
+            } else {
+                ourApp = contractApp;
+            }
+
+            if (builtinIfInsts != null) {
+                ourApp = ourApp.setAssumesInsts(builtinIfInsts);
+            }
+            return ourApp;
+        }
+
+        final ImmutableSet<IBuiltInRuleApp> ruleApps = collectAppsForRule(ruleName, currGoal, pos);
+        if (ruleApps.size() != 1) {
+            if (ruleApps.size() < 1) {
+                throw new IntermediateProofReplayer.BuiltInConstructionException(
+                    ruleName + " is missing. Most probably the binary "
+                        + "for this built-in rule is not in your path or "
+                        + "you do not have the permission to execute it.");
+            } else {
+                throw new IntermediateProofReplayer.BuiltInConstructionException(ruleName + ": found " + ruleApps.size()
+                    + " applications. Don't know what to do !\n" + "@ " + pos);
+            }
+        }
+        ourApp = ruleApps.iterator().next();
+        if (ourApp instanceof OneStepSimplifierRuleApp) {
+            ((OneStepSimplifierRuleApp) ourApp).restrictAssumeInsts(builtinIfInsts);
+        }
+        builtinIfInsts = null;
+        return ourApp;
+    }
+
+    /**
+     * Retrieves all registered applications at the given goal and position for the rule
+     * corresponding to the given ruleName.
+     *
+     * @param ruleName Name of the rule to find applications for.
+     * @param g Goal to search.
+     * @param pos Position of interest in the given goal.
+     * @return All matching rule applications at pos in g.
+     */
+    public static ImmutableSet<IBuiltInRuleApp> collectAppsForRule(String ruleName, Goal g,
+                                                                   PosInOccurrence pos) {
+
+        ImmutableSet<IBuiltInRuleApp> result = DefaultImmutableSet.nil();
+
+        for (final IBuiltInRuleApp app : g.ruleAppIndex().getBuiltInRules(g, pos)) {
+            if (app.rule().name().toString().equals(ruleName)) {
+                result = result.add(app);
+            }
+        }
+
+        return result;
     }
 
     /// Attempts to replay a rule at the given goal.
@@ -406,7 +724,6 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     + originalApp.getClass().getName());
         }
     }
-    */
 }
 
 abstract class TreeNodeIntermediate<T extends NodeIntermediate> implements TreeNode {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
@@ -1,0 +1,541 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.proofreplay;
+
+import de.uka.ilkd.key.core.KeYMediator;
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.gui.actions.KeyAction;
+import de.uka.ilkd.key.gui.extension.api.TabPanel;
+import de.uka.ilkd.key.proof.Node;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.init.KeYUserProblemFile;
+import de.uka.ilkd.key.proof.io.IntermediatePresentationProofFileParser;
+import de.uka.ilkd.key.proof.io.intermediate.AppNodeIntermediate;
+import de.uka.ilkd.key.proof.io.intermediate.BranchNodeIntermediate;
+import de.uka.ilkd.key.proof.io.intermediate.NodeIntermediate;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.tree.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/// A Swing-based UI component for viewing KeY proofs and allowing reapplication of subtrees
+/// and single rules.
+///
+/// This view displays the proof tree in a JTree and provides context menus for:
+///
+///   - Reapplying a single rule at a selected node
+///   - Reapplying an entire subtree from a selected node
+///   - Pruning the proof to a selected node
+///
+/// @author Cline
+public class ProofReapplicationView extends JPanel implements TabPanel {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProofReapplicationView.class);
+
+    private final MainWindow mainWindow;
+    /// The proof currently loaded
+    private Proof proof;
+
+    /// The tree model for the proof tree
+    private final DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultMutableTreeNode("No proof loaded"));
+
+    /// The JTree displaying the proof structure
+    private final JTree proofTree = new JTree(treeModel);
+
+    /// The mediator for proof operations
+    private final KeYMediator mediator;
+
+    /// Creates a new ProofReapplicationView.
+    public ProofReapplicationView(MainWindow window, KeYMediator mediator) {
+        this.mainWindow = window;
+        this.mediator = mediator;
+        initComponents();
+    }
+
+    /// Initializes the UI components.
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        proofTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+        proofTree.setCellRenderer(new ProofTreeNodeRenderer());
+        proofTree.addTreeSelectionListener(e -> onNodeSelected());
+        proofTree.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (SwingUtilities.isRightMouseButton(e)) {
+                    int row = proofTree.getClosestRowForLocation(e.getX(), e.getY());
+                    proofTree.setSelectionRow(row);
+                    showContextMenu(e.getComponent(), e.getX(), e.getY());
+                }
+            }
+        });
+
+        JScrollPane treeScrollPane = new JScrollPane(proofTree);
+        add(treeScrollPane, BorderLayout.CENTER);
+        add(new JButton(new LoadProofAction()), BorderLayout.NORTH);
+    }
+
+    /// Action to load a proof file.
+
+    class LoadProofAction extends KeyAction {
+        {
+            setName(("Load Proof"));
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            JFileChooser fileChooser = new JFileChooser();
+            fileChooser.setFileFilter(new FileNameExtensionFilter("Proof files (*.proof)", "proof"));
+            int result = fileChooser.showOpenDialog(ProofReapplicationView.this);
+            if (result == JFileChooser.APPROVE_OPTION) {
+                loadProof(fileChooser.getSelectedFile());
+            }
+        }
+    }
+
+    /// Action to replay subtree from selected node.
+    private AbstractAction createReplaySubtreeAction() {
+        return new AbstractAction("Replay Subtree") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //replaySubtree();
+            }
+        };
+    }
+
+    /// Action to replay single rule at selected node.
+    private KeyAction createReplayRuleAction() {
+        return new KeyAction() {
+            {
+                setName("Replay Rule");
+            }
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //replaySingleRule();
+            }
+        };
+    }
+
+    public void loadProof(File file) {
+        try {
+            Path filePath = file.toPath();
+            KeYUserProblemFile problemFile = new KeYUserProblemFile(file.getName(), filePath, null, null);
+            IntermediatePresentationProofFileParser fileParser = new IntermediatePresentationProofFileParser(mediator.getSelectedProof());
+            problemFile.readProof(fileParser);
+            var r = fileParser.getResult();
+
+            if (!r.errors().isEmpty()) {
+                JOptionPane.showMessageDialog(this,
+                        "Errors during parsing:\n" + String.join("\n",
+                                r.errors().stream().map(Throwable::getMessage).toArray(String[]::new)),
+                        "Parse Errors", JOptionPane.ERROR_MESSAGE);
+            }
+
+            System.out.println(r.status());
+
+            // Build the tree representation
+            rebuildProofTree(r.parsedResult());
+
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this,
+                    "Error loading proof: " + ex.getMessage(),
+                    "Load Error", JOptionPane.ERROR_MESSAGE);
+            LOGGER.warn("", ex);
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this,
+                    "Unexpected error: " + ex.getMessage(),
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            LOGGER.warn("", ex);
+        }
+    }
+
+    /// Counts the number of nodes in the proof tree.
+    private int countNodes(Node node) {
+        int count = 1;
+        for (Node child : node.children()) {
+            count += countNodes(child);
+        }
+        return count;
+    }
+
+    /// Rebuilds the proof tree visualization.
+    private void rebuildProofTree(BranchNodeIntermediate branchNodeIntermediate) {
+        treeModel.setRoot(new ProofTreeIntermediateNode(branchNodeIntermediate));
+
+        // Expand the first few levels
+        for (int i = 0; i < 3; i++) {
+            proofTree.expandRow(i);
+        }
+    }
+
+    @Override
+    public @NonNull String getTitle() {
+        return "Proof Applier";
+    }
+
+    @Override
+    public @NonNull JComponent getComponent() {
+        return this;
+    }
+
+    /// Custom cell renderer for the proof tree.
+    private class ProofTreeNodeRenderer extends DefaultTreeCellRenderer {
+        @Override
+        public Component getTreeCellRendererComponent(JTree tree, Object value,
+                                                      boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {
+            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+
+            if (value instanceof TreeNodeIntermediate<?> ptn) {
+                var data = ptn.data;
+                if (data instanceof AppNodeIntermediate app) {
+                    setToolTipText(app.getIntermediateRuleApp().getRuleName());
+                }
+                // Color based on node type
+                if (ptn.errored) setForeground(Color.RED.darker());
+                else if (ptn.applied) {
+                    setForeground(Color.GREEN.darker());
+                }
+            }
+            return this;
+        }
+    }
+
+    /// Handles node selection in the tree.
+    private void onNodeSelected() {
+        TreePath path = proofTree.getSelectionPath();
+    }
+
+    /// Shows the context menu at the specified location.
+    private void showContextMenu(Component invoker, int x, int y) {
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem replaySubtreeItem = new JMenuItem(createReplaySubtreeAction());
+        JMenuItem replayRuleItem = new JMenuItem(createReplayRuleAction());
+
+        popup.add(replaySubtreeItem);
+        popup.add(replayRuleItem);
+        popup.addSeparator();
+
+        // Add separator and rule-specific items
+        /*RuleApp app = selectedNode.getAppliedRuleApp();
+        if (app != null) {
+            popup.addSeparator();
+            popup.add("Rule: " + app.rule().name());
+        }*/
+        popup.show(invoker, x, y);
+    }
+
+    /*
+    /// Replays the subtree starting from the selected node.
+    private void replaySubtree(TreeNode node) {
+        if (proof == null) {
+            JOptionPane.showMessageDialog(this,
+                    "No proof loaded.",
+                    "No Proof", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        try {
+            // Collect all rule applications from the subtree
+            List<RuleApp> ruleApps = collectRuleApps(selectedNode);
+
+            // Prune the proof to the parent of the selected node
+            Node parent = selectedNode.parent();
+            if (parent != null) {
+                proof.pruneProof(parent);
+
+                // Reapply all rules from the collected subtree
+                Goal currentGoal = proof.getOpenGoal(parent);
+                if (currentGoal != null && !ruleApps.isEmpty()) {
+                    // Skip the first rule (it was at the pruned position) and apply the rest
+                    for (int i = 1; i < ruleApps.size(); i++) {
+                        RuleApp app = ruleApps.get(i);
+                        tryReplayRuleAtGoal(currentGoal, app);
+                        // Move to next goal after application
+                        if (!currentGoal.node().isClosed()) {
+                            var nextGoal = proof.getOpenGoal(currentGoal.node());
+                            if (nextGoal != null) {
+                                currentGoal = nextGoal;
+                            }
+                        }
+                    }
+                }
+
+                // Refresh the tree
+                rebuildProofTree(r.parsedResult());
+                statusLabel.setText("Subtree replayed from node " + selectedNode.serialNr());
+            }
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(this,
+                    "Error replaying subtree: " + e.getMessage(),
+                    "Replay Error", JOptionPane.ERROR_MESSAGE);
+            statusLabel.setText("Subtree replay failed");
+        }
+    }
+
+    /// Collects all rule applications from a node and its descendants.
+    private List<RuleApp> collectRuleApps(Node node) {
+        List<RuleApp> result = new ArrayList<>();
+        RuleApp app = node.getAppliedRuleApp();
+        if (app != null) {
+            result.add(app);
+        }
+        for (Node child : node.children()) {
+            result.addAll(collectRuleApps(child));
+        }
+        return result;
+    }
+
+    /// Replays a single rule at the selected node.
+    private void replaySingleRule(ProofTreeIntermediateNode node) {
+        if (proof == null) {
+            JOptionPane.showMessageDialog(this,
+                    "No proof loaded.",
+                    "No Proof", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        RuleApp originalApp = selectedNode.getAppliedRuleApp();
+        if (originalApp == null) {
+            JOptionPane.showMessageDialog(this,
+                    "Selected node has no applied rule.",
+                    "No Rule", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        try {
+            // Prune to the selected node's parent
+            Node parent = selectedNode.parent();
+            if (parent != null) {
+                proof.pruneProof(parent);
+                Goal goal = proof.getOpenGoal(parent);
+
+                if (goal != null) {
+                    tryReplayRuleAtGoal(goal, originalApp);
+                }
+
+                rebuildProofTree(r.parsedResult());
+                statusLabel.setText("Rule '" + originalApp.rule().name()
+                        + "' replayed at node " + parent.serialNr());
+            }
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(this,
+                    "Error replaying rule: " + e.getMessage(),
+                    "Replay Error", JOptionPane.ERROR_MESSAGE);
+            statusLabel.setText("Rule replay failed");
+        }
+    }
+
+    /// Attempts to replay a rule at the given goal.
+    private void tryReplayRuleAtGoal(Goal goal, RuleApp originalApp) {
+        Services services = goal.proof().getServices();
+
+        if (originalApp instanceof TacletApp tacletApp) {
+            // Find matching taclet applications using the TacletIndex
+            TacletIndex tacletIndex = goal.indexOfTaclets();
+
+            // Get all applicable taclets and find matching one
+            var allApps = tacletIndex.allNoPosTacletApps();
+            NoPosTacletApp matchingApp = null;
+
+            for (NoPosTacletApp candidate : allApps) {
+                if (candidate.rule().name().equals(tacletApp.rule().name())) {
+                    matchingApp = candidate;
+                    break;
+                }
+            }
+
+            if (matchingApp != null) {
+                // Try to match the position if needed
+                PosInOccurrence pos = tacletApp.posInOccurrence();
+                if (pos != null) {
+                    // Find the matching app with position
+                    ImmutableList<TacletApp> appsWithPos =
+                            ImmutableList.nil();
+                    for (TacletApp app : appsWithPos) {
+                        if (app.rule().name().equals(tacletApp.rule().name())) {
+                            goal.apply(app);
+                            return;
+                        }
+                    }
+                } else {
+                    goal.apply(matchingApp);
+                    return;
+                }
+            }
+
+            throw new RuntimeException("Could not find matching taclet: "
+                    + tacletApp.rule().name());
+        } else if (originalApp instanceof IBuiltInRuleApp builtinApp) {
+            // Find matching built-in rule applications
+            PosInOccurrence pos = builtinApp.posInOccurrence();
+
+            // Collect all built-in rule apps at the position
+            ImmutableList<IBuiltInRuleApp> apps =
+                    goal.ruleAppIndex().getBuiltInRules(goal, pos);
+
+            IBuiltInRuleApp matchingApp = null;
+            for (IBuiltInRuleApp app : apps) {
+                if (app.rule().name().equals(builtinApp.rule().name())) {
+                    matchingApp = app;
+                    break;
+                }
+            }
+
+            if (matchingApp != null) {
+                goal.apply(matchingApp);
+            } else {
+                throw new RuntimeException("Could not find matching built-in rule: "
+                        + builtinApp.rule().name());
+            }
+        } else {
+            throw new RuntimeException("Unsupported rule type: "
+                    + originalApp.getClass().getName());
+        }
+    }
+    */
+}
+
+abstract class TreeNodeIntermediate<T extends NodeIntermediate> implements TreeNode {
+    private @Nullable List<TreeNodeIntermediate<?>> children = null;
+    private final TreeNodeIntermediate<?> parent;
+    final T data;
+    boolean applied = false;
+    boolean errored = false;
+
+    TreeNodeIntermediate(@Nullable TreeNodeIntermediate<?> parent, T data) {
+        this.parent = parent;
+        this.data = data;
+    }
+
+    public List<TreeNodeIntermediate<?>> getChildren() {
+        if (children == null) {
+            if(data.getChildren().size()>1) {
+                 children = data.getChildren().stream().map(it ->
+                                it instanceof AppNodeIntermediate app ? new AppIntermediateNode(this, app) :
+                                        new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
+                        .toList();
+            }else {
+                class DepthWalker implements Iterator<NodeIntermediate> {
+                    NodeIntermediate current = data;
+
+                    @Override
+                    public boolean hasNext() {
+                        return current != null && current.getChildren().size() == 1;
+                    }
+
+                    @Override
+                    public NodeIntermediate next() {
+                        return current = current.getChildren().getFirst();
+                    }
+                }
+
+                final var walker = new DepthWalker();
+                var stream =
+                        StreamSupport.stream(Spliterators.spliteratorUnknownSize(walker, 0), false);
+
+                var flat = stream.map(it ->
+                                it instanceof AppNodeIntermediate app ? new AppIntermediateNode(this, app) :
+                                        new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
+                        .toList();
+
+                children = new ArrayList<>(flat.size() + 1);
+                children.addAll(flat);
+                if (walker.current instanceof AppNodeIntermediate branch) {
+                    children.add(new AppIntermediateNode(this, branch));
+                }
+            }
+        }
+        return children;
+    }
+
+    @Override
+    public TreeNode getChildAt(int childIndex) {
+        return getChildren().get(childIndex);
+    }
+
+    @Override
+    public int getChildCount() {
+        return getChildren().size();
+    }
+
+    @Override
+    public TreeNode getParent() {
+        return parent;
+    }
+
+    @Override
+    public int getIndex(TreeNode node) {
+        return getChildren().indexOf(node);
+    }
+
+    @Override
+    public boolean getAllowsChildren() {
+        return switch (data) {
+            case AppNodeIntermediate ignored -> false;
+            case BranchNodeIntermediate ignored -> true;
+            case null, default -> false;
+        };
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return !getAllowsChildren();
+    }
+
+    @Override
+    public Enumeration<? extends TreeNode> children() {
+        return Collections.enumeration(getChildren());
+    }
+}
+
+
+class ProofTreeIntermediateNode extends TreeNodeIntermediate<BranchNodeIntermediate> {
+    public ProofTreeIntermediateNode(TreeNodeIntermediate<?> parent, BranchNodeIntermediate node) {
+        super(parent, node);
+    }
+
+    public ProofTreeIntermediateNode(BranchNodeIntermediate node) {
+        this(null, node);
+    }
+
+    @Override
+    public String toString() {
+        return "BR: " + data.getBranchTitle();
+    }
+}
+
+class AppIntermediateNode extends TreeNodeIntermediate<AppNodeIntermediate> {
+    public AppIntermediateNode(TreeNodeIntermediate<?> parent, AppNodeIntermediate node) {
+        super(parent, node);
+    }
+
+    @Override
+    public String toString() {
+        return "APP: " + data.getIntermediateRuleApp().getRuleName();
+    }
+
+    @Override
+    public List<TreeNodeIntermediate<?>> getChildren() {
+        if(data.getChildren().size() <= 1) return Collections.emptyList();
+        return super.getChildren();
+    }
+
+    @Override
+    public boolean getAllowsChildren() {
+        return getChildren().size() > 1;
+    }
+}

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/proofreplay/ProofReapplicationView.java
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.proofreplay;
 
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.tree.*;
+
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.actions.KeyAction;
@@ -23,8 +37,7 @@ import de.uka.ilkd.key.settings.ProofIndependentSettings;
 import de.uka.ilkd.key.smt.*;
 import de.uka.ilkd.key.speclang.Contract;
 import de.uka.ilkd.key.speclang.OperationContract;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
+
 import org.key_project.logic.PosInTerm;
 import org.key_project.prover.rules.RuleApp;
 import org.key_project.prover.sequent.PosInOccurrence;
@@ -32,22 +45,11 @@ import org.key_project.util.collection.DefaultImmutableSet;
 import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.collection.ImmutableSet;
 import org.key_project.util.collection.Pair;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
-import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.swing.tree.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.List;
-import java.util.stream.StreamSupport;
 
 import static de.uka.ilkd.key.proof.io.IntermediateProofReplayer.constructTacletApp;
 
@@ -56,9 +58,9 @@ import static de.uka.ilkd.key.proof.io.IntermediateProofReplayer.constructTaclet
 ///
 /// This view displays the proof tree in a JTree and provides context menus for:
 ///
-///   - Reapplying a single rule at a selected node
-///   - Reapplying an entire subtree from a selected node
-///   - Pruning the proof to a selected node
+/// - Reapplying a single rule at a selected node
+/// - Reapplying an entire subtree from a selected node
+/// - Pruning the proof to a selected node
 ///
 /// @author Cline
 public class ProofReapplicationView extends JPanel implements TabPanel {
@@ -69,7 +71,8 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     private Proof proof;
 
     /// The tree model for the proof tree
-    private final DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultMutableTreeNode("No proof loaded"));
+    private final DefaultTreeModel treeModel =
+        new DefaultTreeModel(new DefaultMutableTreeNode("No proof loaded"));
 
     /// The JTree displaying the proof structure
     private final JTree intermProofTree = new JTree(treeModel);
@@ -87,7 +90,8 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     /// Initializes the UI components.
     private void initComponents() {
         setLayout(new BorderLayout());
-        intermProofTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+        intermProofTree.getSelectionModel()
+                .setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
         intermProofTree.setCellRenderer(new ProofTreeNodeRenderer());
         intermProofTree.addTreeSelectionListener(e -> onNodeSelected());
         intermProofTree.addMouseListener(new MouseAdapter() {
@@ -116,7 +120,8 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         @Override
         public void actionPerformed(ActionEvent e) {
             JFileChooser fileChooser = new JFileChooser();
-            fileChooser.setFileFilter(new FileNameExtensionFilter("Proof files (*.proof)", "proof"));
+            fileChooser
+                    .setFileFilter(new FileNameExtensionFilter("Proof files (*.proof)", "proof"));
             int result = fileChooser.showOpenDialog(ProofReapplicationView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 loadProof(fileChooser.getSelectedFile());
@@ -129,7 +134,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         AbstractAction replaySubtreeAction = new AbstractAction("Replay Subtree") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                //replaySubtree();
+                // replaySubtree();
             }
         };
         // not implemented at the moment
@@ -159,16 +164,18 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     public void loadProof(File file) {
         try {
             Path filePath = file.toPath();
-            KeYUserProblemFile problemFile = new KeYUserProblemFile(file.getName(), filePath, null, null);
-            IntermediatePresentationProofFileParser fileParser = new IntermediatePresentationProofFileParser(mediator.getSelectedProof());
+            KeYUserProblemFile problemFile =
+                new KeYUserProblemFile(file.getName(), filePath, null, null);
+            IntermediatePresentationProofFileParser fileParser =
+                new IntermediatePresentationProofFileParser(mediator.getSelectedProof());
             problemFile.readProof(fileParser);
             var r = fileParser.getResult();
 
             if (!r.errors().isEmpty()) {
                 JOptionPane.showMessageDialog(this,
-                        "Errors during parsing:\n" + String.join("\n",
-                                r.errors().stream().map(Throwable::getMessage).toArray(String[]::new)),
-                        "Parse Errors", JOptionPane.ERROR_MESSAGE);
+                    "Errors during parsing:\n" + String.join("\n",
+                        r.errors().stream().map(Throwable::getMessage).toArray(String[]::new)),
+                    "Parse Errors", JOptionPane.ERROR_MESSAGE);
             }
 
             System.out.println(r.status());
@@ -178,13 +185,13 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
         } catch (IOException ex) {
             JOptionPane.showMessageDialog(this,
-                    "Error loading proof: " + ex.getMessage(),
-                    "Load Error", JOptionPane.ERROR_MESSAGE);
+                "Error loading proof: " + ex.getMessage(),
+                "Load Error", JOptionPane.ERROR_MESSAGE);
             LOGGER.warn("", ex);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this,
-                    "Unexpected error: " + ex.getMessage(),
-                    "Error", JOptionPane.ERROR_MESSAGE);
+                "Unexpected error: " + ex.getMessage(),
+                "Error", JOptionPane.ERROR_MESSAGE);
             LOGGER.warn("", ex);
         }
     }
@@ -222,7 +229,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
     private class ProofTreeNodeRenderer extends DefaultTreeCellRenderer {
         @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value,
-                                                      boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {
+                boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {
             super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
 
             if (value instanceof TreeNodeIntermediate<?> ptn) {
@@ -231,7 +238,8 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     setToolTipText(app.getIntermediateRuleApp().getRuleName());
                 }
                 // Color based on node type
-                if (ptn.errored) setForeground(Color.RED.darker());
+                if (ptn.errored)
+                    setForeground(Color.RED.darker());
                 else if (ptn.applied) {
                     setForeground(Color.GREEN.darker());
                 }
@@ -256,61 +264,64 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         popup.addSeparator();
 
         // Add separator and rule-specific items
-        /*RuleApp app = selectedNode.getAppliedRuleApp();
-        if (app != null) {
-            popup.addSeparator();
-            popup.add("Rule: " + app.rule().name());
-        }*/
+        /*
+         * RuleApp app = selectedNode.getAppliedRuleApp();
+         * if (app != null) {
+         * popup.addSeparator();
+         * popup.add("Rule: " + app.rule().name());
+         * }
+         */
         popup.show(invoker, x, y);
     }
 
     /*
-    /// Replays the subtree starting from the selected node.
-    private void replaySubtree(TreeNode node) {
-        if (proof == null) {
-            JOptionPane.showMessageDialog(this,
-                    "No proof loaded.",
-                    "No Proof", JOptionPane.WARNING_MESSAGE);
-            return;
-        }
-
-        try {
-            // Collect all rule applications from the subtree
-            List<RuleApp> ruleApps = collectRuleApps(selectedNode);
-
-            // Prune the proof to the parent of the selected node
-            Node parent = selectedNode.parent();
-            if (parent != null) {
-                proof.pruneProof(parent);
-
-                // Reapply all rules from the collected subtree
-                Goal currentGoal = proof.getOpenGoal(parent);
-                if (currentGoal != null && !ruleApps.isEmpty()) {
-                    // Skip the first rule (it was at the pruned position) and apply the rest
-                    for (int i = 1; i < ruleApps.size(); i++) {
-                        RuleApp app = ruleApps.get(i);
-                        tryReplayRuleAtGoal(currentGoal, app);
-                        // Move to next goal after application
-                        if (!currentGoal.node().isClosed()) {
-                            var nextGoal = proof.getOpenGoal(currentGoal.node());
-                            if (nextGoal != null) {
-                                currentGoal = nextGoal;
-                            }
-                        }
-                    }
-                }
-
-                // Refresh the tree
-                rebuildProofTree(r.parsedResult());
-                statusLabel.setText("Subtree replayed from node " + selectedNode.serialNr());
-            }
-        } catch (Exception e) {
-            JOptionPane.showMessageDialog(this,
-                    "Error replaying subtree: " + e.getMessage(),
-                    "Replay Error", JOptionPane.ERROR_MESSAGE);
-            statusLabel.setText("Subtree replay failed");
-        }
-    }*/
+     * /// Replays the subtree starting from the selected node.
+     * private void replaySubtree(TreeNode node) {
+     * if (proof == null) {
+     * JOptionPane.showMessageDialog(this,
+     * "No proof loaded.",
+     * "No Proof", JOptionPane.WARNING_MESSAGE);
+     * return;
+     * }
+     *
+     * try {
+     * // Collect all rule applications from the subtree
+     * List<RuleApp> ruleApps = collectRuleApps(selectedNode);
+     *
+     * // Prune the proof to the parent of the selected node
+     * Node parent = selectedNode.parent();
+     * if (parent != null) {
+     * proof.pruneProof(parent);
+     *
+     * // Reapply all rules from the collected subtree
+     * Goal currentGoal = proof.getOpenGoal(parent);
+     * if (currentGoal != null && !ruleApps.isEmpty()) {
+     * // Skip the first rule (it was at the pruned position) and apply the rest
+     * for (int i = 1; i < ruleApps.size(); i++) {
+     * RuleApp app = ruleApps.get(i);
+     * tryReplayRuleAtGoal(currentGoal, app);
+     * // Move to next goal after application
+     * if (!currentGoal.node().isClosed()) {
+     * var nextGoal = proof.getOpenGoal(currentGoal.node());
+     * if (nextGoal != null) {
+     * currentGoal = nextGoal;
+     * }
+     * }
+     * }
+     * }
+     *
+     * // Refresh the tree
+     * rebuildProofTree(r.parsedResult());
+     * statusLabel.setText("Subtree replayed from node " + selectedNode.serialNr());
+     * }
+     * } catch (Exception e) {
+     * JOptionPane.showMessageDialog(this,
+     * "Error replaying subtree: " + e.getMessage(),
+     * "Replay Error", JOptionPane.ERROR_MESSAGE);
+     * statusLabel.setText("Subtree replay failed");
+     * }
+     * }
+     */
 
     /// Collects all rule applications from a node and its descendants.
     private List<RuleApp> collectRuleApps(Node node) {
@@ -327,7 +338,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
     /// Replays a single rule at the selected node.
     private void replaySingleRule()
-        throws IntermediateProofReplayer.TacletAppConstructionException {
+            throws IntermediateProofReplayer.TacletAppConstructionException {
 
         proof = mediator.getSelectedProof();
         if (proof == null) {
@@ -342,19 +353,20 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
         // obtain selected node from intermProofTree
         TreeNodeIntermediate<?> selectedNode =
-            (TreeNodeIntermediate<?>)intermProofTree.getLastSelectedPathComponent();
+            (TreeNodeIntermediate<?>) intermProofTree.getLastSelectedPathComponent();
         NodeIntermediate currNodeInterm = selectedNode.data;
 
         /*
-        if (n instanceof AppNodeIntermediate nApp) {
-            app = nApp.getIntermediateRuleApp();
-        } else if (n instanceof BranchNodeIntermediate nBranch) {
-
-        }
-        } else {
-            // not a replayable rule
-            return;
-        }*/
+         * if (n instanceof AppNodeIntermediate nApp) {
+         * app = nApp.getIntermediateRuleApp();
+         * } else if (n instanceof BranchNodeIntermediate nBranch) {
+         *
+         * }
+         * } else {
+         * // not a replayable rule
+         * return;
+         * }
+         */
 
         if (currNodeInterm instanceof BranchNodeIntermediate) {
             // not a replayable rule
@@ -365,36 +377,39 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
 
             // Register name proposals
             proof.getServices().getNameRecorder()
-                .setProposals(currInterm.getIntermediateRuleApp().getNewNames());
+                    .setProposals(currInterm.getIntermediateRuleApp().getNewNames());
 
             if (currInterm.getIntermediateRuleApp() instanceof TacletAppIntermediate appInterm) {
 
-                //try {
+                // try {
                 TacletApp tacletApp = constructTacletApp(proof, appInterm, currGoal);
                 currGoal.apply(tacletApp);
 
                 /*
-                final Iterator<Node> children = currNode.childrenIterator();
-                final LinkedList<NodeIntermediate> intermChildren =
-                    currInterm.getChildren();
-
-                addChildren(children, intermChildren);*/
+                 * final Iterator<Node> children = currNode.childrenIterator();
+                 * final LinkedList<NodeIntermediate> intermChildren =
+                 * currInterm.getChildren();
+                 *
+                 * addChildren(children, intermChildren);
+                 */
 
                 // set information about SUCCESSFUL rule application
                 currNode.getNodeInfo().setInteractiveRuleApplication(
                     currInterm.isInteractiveRuleApplication());
                 currNode.getNodeInfo()
-                    .setScriptRuleApplication(currInterm.isScriptRuleApplication());
+                        .setScriptRuleApplication(currInterm.isScriptRuleApplication());
 
                 /*
-                } catch (Exception | AssertionError e) {
-                    reportError("Error loading proof.\n Line " + appInterm.getLineNr()
-                        + ", goal " + currGoal.node().serialNr() + ", rule "
-                        + appInterm.getRuleName() + NOT_APPLICABLE, e);
-                }*/
+                 * } catch (Exception | AssertionError e) {
+                 * reportError("Error loading proof.\n Line " + appInterm.getLineNr()
+                 * + ", goal " + currGoal.node().serialNr() + ", rule "
+                 * + appInterm.getRuleName() + NOT_APPLICABLE, e);
+                 * }
+                 */
                 selectedNode.applied = true;
 
-            } else if (currInterm.getIntermediateRuleApp() instanceof BuiltInAppIntermediate appInterm) {
+            } else if (currInterm
+                    .getIntermediateRuleApp() instanceof BuiltInAppIntermediate appInterm) {
 
                 try {
                     IBuiltInRuleApp app = constructBuiltinApp(proof, appInterm, currGoal);
@@ -404,63 +419,69 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     currGoal.apply(app);
 
                     /*
-                    final Iterator<Node> children = currNode.childrenIterator();
-                    LinkedList<NodeIntermediate> intermChildren =
-                        currInterm.getChildren();
-
-                    addChildren(children, intermChildren);*/
-                //} catch (IntermediateProofReplayer.SkipSMTRuleException e) {
+                     * final Iterator<Node> children = currNode.childrenIterator();
+                     * LinkedList<NodeIntermediate> intermChildren =
+                     * currInterm.getChildren();
+                     *
+                     * addChildren(children, intermChildren);
+                     */
+                    // } catch (IntermediateProofReplayer.SkipSMTRuleException e) {
                     // silently continue; status will be reported via polling
                 } catch (IntermediateProofReplayer.BuiltInConstructionException | AssertionError
-                         | RuntimeException e) {
+                        | RuntimeException e) {
                     // TODO: error reporting
                     selectedNode.errored = true;
                     throw new RuntimeException("Error loading proof: Line " + appInterm.getLineNr()
                         + ", goal " + currGoal.node().serialNr() + ", rule "
                         + appInterm.getRuleName() + " not applicable.", e);
-                    /*reportError(ERROR_LOADING_PROOF_LINE + "Line "
-                        + appInterm.getLineNr() + ", goal " + currGoal.node().serialNr()
-                        + ", rule " + appInterm.getRuleName() + NOT_APPLICABLE, e);*/
+                    /*
+                     * reportError(ERROR_LOADING_PROOF_LINE + "Line "
+                     * + appInterm.getLineNr() + ", goal " + currGoal.node().serialNr()
+                     * + ", rule " + appInterm.getRuleName() + NOT_APPLICABLE, e);
+                     */
                 }
                 selectedNode.applied = true;
             }
 
-        /*RuleApp originalApp = selectedNode.getAppliedRuleApp();
-        if (originalApp == null) {
-            JOptionPane.showMessageDialog(this,
-                    "Selected node has no applied rule.",
-                    "No Rule", JOptionPane.WARNING_MESSAGE);
-            return;
-        }
-
-        try {
-            // Prune to the selected node's parent
-            Node parent = selectedNode.parent();
-            if (parent != null) {
-                proof.pruneProof(parent);
-                Goal goal = proof.getOpenGoal(parent);
-
-                if (goal != null) {
-                    tryReplayRuleAtGoal(goal, originalApp);
-                }
-
-                rebuildProofTree(r.parsedResult());
-                statusLabel.setText("Rule '" + originalApp.rule().name()
-                        + "' replayed at node " + parent.serialNr());
-            }
-        } catch (Exception e) {
-            JOptionPane.showMessageDialog(this,
-                    "Error replaying rule: " + e.getMessage(),
-                    "Replay Error", JOptionPane.ERROR_MESSAGE);
-            statusLabel.setText("Rule replay failed");
-        }*/
+            /*
+             * RuleApp originalApp = selectedNode.getAppliedRuleApp();
+             * if (originalApp == null) {
+             * JOptionPane.showMessageDialog(this,
+             * "Selected node has no applied rule.",
+             * "No Rule", JOptionPane.WARNING_MESSAGE);
+             * return;
+             * }
+             *
+             * try {
+             * // Prune to the selected node's parent
+             * Node parent = selectedNode.parent();
+             * if (parent != null) {
+             * proof.pruneProof(parent);
+             * Goal goal = proof.getOpenGoal(parent);
+             *
+             * if (goal != null) {
+             * tryReplayRuleAtGoal(goal, originalApp);
+             * }
+             *
+             * rebuildProofTree(r.parsedResult());
+             * statusLabel.setText("Rule '" + originalApp.rule().name()
+             * + "' replayed at node " + parent.serialNr());
+             * }
+             * } catch (Exception e) {
+             * JOptionPane.showMessageDialog(this,
+             * "Error replaying rule: " + e.getMessage(),
+             * "Replay Error", JOptionPane.ERROR_MESSAGE);
+             * statusLabel.setText("Rule replay failed");
+             * }
+             */
         }
     }
 
     // TODO: taken and adapted from IntermediateProofReplayer. Should be refactored instead there!
-    private static IBuiltInRuleApp constructBuiltinApp(Proof proof, BuiltInAppIntermediate currInterm, Goal currGoal)
-        throws //IntermediateProofReplayer.SkipSMTRuleException,
-        IntermediateProofReplayer.BuiltInConstructionException {
+    private static IBuiltInRuleApp constructBuiltinApp(Proof proof,
+            BuiltInAppIntermediate currInterm, Goal currGoal)
+            throws // IntermediateProofReplayer.SkipSMTRuleException,
+            IntermediateProofReplayer.BuiltInConstructionException {
 
         final String ruleName = currInterm.getRuleName();
         final int currFormula = currInterm.getPosInfo().first;
@@ -472,16 +493,19 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         // Load contracts, if applicable
         if (currInterm.getContract() != null) {
             currContract = proof.getServices().getSpecificationRepository()
-                .getContractByName(currInterm.getContract());
+                    .getContractByName(currInterm.getContract());
             if (currContract == null) {
                 throw new IntermediateProofReplayer.BuiltInConstructionException(
                     "Could not reconstruct the rule application: the stored contract \""
-                        + currInterm.getContract() + "\" could not be found in the current specification repository.");
-                /*final ProblemLoaderException e =
-                    new ProblemLoaderException(loader, "Error loading proof: contract \""
-                        + currInterm.getContract() + "\" not found.");
-                reportError(ERROR_LOADING_PROOF_LINE + ", goal " + currGoal.node().serialNr()
-                    + ", rule " + ruleName + NOT_APPLICABLE, e);*/
+                        + currInterm.getContract()
+                        + "\" could not be found in the current specification repository.");
+                /*
+                 * final ProblemLoaderException e =
+                 * new ProblemLoaderException(loader, "Error loading proof: contract \""
+                 * + currInterm.getContract() + "\" not found.");
+                 * reportError(ERROR_LOADING_PROOF_LINE + ", goal " + currGoal.node().serialNr()
+                 * + ", rule " + ruleName + NOT_APPLICABLE, e);
+                 */
             }
         }
 
@@ -504,10 +528,11 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                         + ", goal " + currGoal.node().serialNr() + ", rule " + ruleName
                         + " not applicable.", e);
                     /*
-                    reportError(
-                        ERROR_LOADING_PROOF_LINE + "Line " + currInterm.getLineNr() + ", goal "
-                            + currGoal.node().serialNr() + ", rule " + ruleName + NOT_APPLICABLE,
-                        e);*/
+                     * reportError(
+                     * ERROR_LOADING_PROOF_LINE + "Line " + currInterm.getLineNr() + ", goal "
+                     * + currGoal.node().serialNr() + ", rule " + ruleName + NOT_APPLICABLE,
+                     * e);
+                     */
                 }
             }
         }
@@ -517,7 +542,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         if (smtRule.name().toString().equals(ruleName)) {
             if (!ProofIndependentSettings.DEFAULT_INSTANCE.getSMTSettings().isEnableOnLoad()) {
                 // TODO
-                //status = SMT_NOT_RUN;
+                // status = SMT_NOT_RUN;
                 throw new RuntimeException();
             }
             boolean error = false;
@@ -530,7 +555,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                     proof);
 
                 ProofIndependentSMTSettings smtSettings = ProofIndependentSettings.DEFAULT_INSTANCE
-                    .getSMTSettings();
+                        .getSMTSettings();
                 SolverTypeCollection active = smtSettings.computeActiveSolverUnion();
                 SMTAppIntermediate smtAppIntermediate = (SMTAppIntermediate) currInterm;
                 String smtSolver = smtAppIntermediate.getSolver();
@@ -554,9 +579,10 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
             } catch (Exception e) {
                 error = true;
             }
-            if (error || smtProblem.getFinalResult().isValid() != SMTSolverResult.ThreeValuedTruth.VALID) {
+            if (error || smtProblem.getFinalResult()
+                    .isValid() != SMTSolverResult.ThreeValuedTruth.VALID) {
                 // TODO
-                //status = SMT_NOT_RUN;
+                // status = SMT_NOT_RUN;
                 throw new RuntimeException();
             } else {
                 String name = smtProblem.getSuccessfulSolver().name();
@@ -576,7 +602,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
         if (currFormula != 0) { // otherwise we have no pos
             try {
                 pos = PosInOccurrence
-                    .findInSequent(currGoal.sequent(), currFormula, currPosInTerm);
+                        .findInSequent(currGoal.sequent(), currFormula, currPosInTerm);
             } catch (RuntimeException e) {
                 throw new IntermediateProofReplayer.BuiltInConstructionException(
                     "Could not reconstruct the rule application: the stored position (formula "
@@ -603,7 +629,8 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
             }
 
             if (contractApp.check(currGoal.proof().getServices()) == null) {
-                throw new IntermediateProofReplayer.BuiltInConstructionException("Cannot apply contract: " + currContract);
+                throw new IntermediateProofReplayer.BuiltInConstructionException(
+                    "Cannot apply contract: " + currContract);
             } else {
                 ourApp = contractApp;
             }
@@ -622,8 +649,9 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                         + "for this built-in rule is not in your path or "
                         + "you do not have the permission to execute it.");
             } else {
-                throw new IntermediateProofReplayer.BuiltInConstructionException(ruleName + ": found " + ruleApps.size()
-                    + " applications. Don't know what to do !\n" + "@ " + pos);
+                throw new IntermediateProofReplayer.BuiltInConstructionException(
+                    ruleName + ": found " + ruleApps.size()
+                        + " applications. Don't know what to do !\n" + "@ " + pos);
             }
         }
         ourApp = ruleApps.iterator().next();
@@ -644,7 +672,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
      * @return All matching rule applications at pos in g.
      */
     public static ImmutableSet<IBuiltInRuleApp> collectAppsForRule(String ruleName, Goal g,
-                                                                   PosInOccurrence pos) {
+            PosInOccurrence pos) {
 
         ImmutableSet<IBuiltInRuleApp> result = DefaultImmutableSet.nil();
 
@@ -682,7 +710,7 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                 if (pos != null) {
                     // Find the matching app with position
                     ImmutableList<TacletApp> appsWithPos =
-                            ImmutableList.nil();
+                        ImmutableList.nil();
                     for (TacletApp app : appsWithPos) {
                         if (app.rule().name().equals(tacletApp.rule().name())) {
                             goal.apply(app);
@@ -696,14 +724,14 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
             }
 
             throw new RuntimeException("Could not find matching taclet: "
-                    + tacletApp.rule().name());
+                + tacletApp.rule().name());
         } else if (originalApp instanceof IBuiltInRuleApp builtinApp) {
             // Find matching built-in rule applications
             PosInOccurrence pos = builtinApp.posInOccurrence();
 
             // Collect all built-in rule apps at the position
             ImmutableList<IBuiltInRuleApp> apps =
-                    goal.ruleAppIndex().getBuiltInRules(goal, pos);
+                goal.ruleAppIndex().getBuiltInRules(goal, pos);
 
             IBuiltInRuleApp matchingApp = null;
             for (IBuiltInRuleApp app : apps) {
@@ -717,14 +745,15 @@ public class ProofReapplicationView extends JPanel implements TabPanel {
                 goal.apply(matchingApp);
             } else {
                 throw new RuntimeException("Could not find matching built-in rule: "
-                        + builtinApp.rule().name());
+                    + builtinApp.rule().name());
             }
         } else {
             throw new RuntimeException("Unsupported rule type: "
-                    + originalApp.getClass().getName());
+                + originalApp.getClass().getName());
         }
     }
 }
+
 
 abstract class TreeNodeIntermediate<T extends NodeIntermediate> implements TreeNode {
     private @Nullable List<TreeNodeIntermediate<?>> children = null;
@@ -740,12 +769,13 @@ abstract class TreeNodeIntermediate<T extends NodeIntermediate> implements TreeN
 
     public List<TreeNodeIntermediate<?>> getChildren() {
         if (children == null) {
-            if(data.getChildren().size()>1) {
-                 children = data.getChildren().stream().map(it ->
-                                it instanceof AppNodeIntermediate app ? new AppIntermediateNode(this, app) :
-                                        new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
+            if (data.getChildren().size() > 1) {
+                children = data.getChildren().stream()
+                        .map(it -> it instanceof AppNodeIntermediate app
+                                ? new AppIntermediateNode(this, app)
+                                : new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
                         .toList();
-            }else {
+            } else {
                 class DepthWalker implements Iterator<NodeIntermediate> {
                     NodeIntermediate current = data;
 
@@ -762,11 +792,12 @@ abstract class TreeNodeIntermediate<T extends NodeIntermediate> implements TreeN
 
                 final var walker = new DepthWalker();
                 var stream =
-                        StreamSupport.stream(Spliterators.spliteratorUnknownSize(walker, 0), false);
+                    StreamSupport.stream(Spliterators.spliteratorUnknownSize(walker, 0), false);
 
-                var flat = stream.map(it ->
-                                it instanceof AppNodeIntermediate app ? new AppIntermediateNode(this, app) :
-                                        new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
+                var flat = stream
+                        .map(it -> it instanceof AppNodeIntermediate app
+                                ? new AppIntermediateNode(this, app)
+                                : new ProofTreeIntermediateNode(this, (BranchNodeIntermediate) it))
                         .toList();
 
                 children = new ArrayList<>(flat.size() + 1);
@@ -835,6 +866,7 @@ class ProofTreeIntermediateNode extends TreeNodeIntermediate<BranchNodeIntermedi
     }
 }
 
+
 class AppIntermediateNode extends TreeNodeIntermediate<AppNodeIntermediate> {
     public AppIntermediateNode(TreeNodeIntermediate<?> parent, AppNodeIntermediate node) {
         super(parent, node);
@@ -847,7 +879,8 @@ class AppIntermediateNode extends TreeNodeIntermediate<AppNodeIntermediate> {
 
     @Override
     public List<TreeNodeIntermediate<?>> getChildren() {
-        if(data.getChildren().size() <= 1) return Collections.emptyList();
+        if (data.getChildren().size() <= 1)
+            return Collections.emptyList();
         return super.getChildren();
     }
 

--- a/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
+++ b/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
@@ -10,3 +10,4 @@ de.uka.ilkd.key.gui.utilities.HeapStatusExt
 de.uka.ilkd.key.gui.JmlEnabledKeysIndicator
 de.uka.ilkd.key.gui.extension.impl.ProfileNameInStatusBar
 de.uka.ilkd.key.gui.profileloading.WDLoadDialogOptionPanel
+de.uka.ilkd.key.gui.proofreplay.ProofReapplicationExtension

--- a/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
+++ b/key.ui/src/main/resources/META-INF/services/de.uka.ilkd.key.gui.extension.api.KeYGuiExtension
@@ -11,4 +11,5 @@ de.uka.ilkd.key.gui.JmlEnabledKeysIndicator
 de.uka.ilkd.key.gui.extension.impl.ProfileNameInStatusBar
 de.uka.ilkd.key.gui.extension.impl.ParallelProverStatusIndicator
 de.uka.ilkd.key.gui.profileloading.WDLoadDialogOptionPanel
+de.uka.ilkd.key.gui.proofreplay.ProofReapplicationExtension
 de.uka.ilkd.key.gui.extension.impl.SoundinessExtension


### PR DESCRIPTION
## Intended Change

A user interface that allows you to replay stored proofs interactively. 

The idea is to (a) allow restoring stored proofs partially, (b) on error try to message your current state into a replayable state (e.g. hide formulas etc.), and (c) restart the proof replay.  

<img height="568" alt="image" src="https://github.com/user-attachments/assets/6a9cb48b-efce-431e-9e7c-98a780b714bf" />


## Feature

* [x] Load Proofs from file and store them into a data structure
* [x] Nice beautiful proof tree, similar to the "Proof Tree".
* [ ] Clicking on a tree node allows you to 
  * [x] Apply selected rules on the current proof node
  * [ ] Apply a sub-tree to a proof node
  * [ ] If applied, jump to the (last) corresponding proof node.
* [x] Applied with success => "green" marked tree node
* [x] Applied with error => "red" marked tree node
* [ ] Shows stored information of rule application 
* [ ] Shows why rule application was not applicable

## Type of pull request

- New feature (non-breaking change which adds functionality)

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: ...
- I have checked that runtime performance has not deteriorated.
- For new Gradle modules: I added the Gradle module to the test matrix in
  `.github/workflows/tests.yml`

