### PR TITLE
Fixes "No Proof" in status line when a proof was closed.

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/ProofMacroFinishedInfo.java
@@ -72,7 +72,9 @@ public class ProofMacroFinishedInfo extends DefaultTaskFinishedInfo {
 
     public ProofMacroFinishedInfo(ProofMacro macro, ImmutableList<Goal> goals,
             List<Node> statisticNodes) {
-        this(macro, goals, goals.isEmpty() ? null : goals.head().proof(),
+        this(macro, goals,
+            !goals.isEmpty() ? goals.head().proof()
+                    : (statisticNodes.isEmpty() ? null : statisticNodes.get(0).proof()),
             statisticNodes.isEmpty() ? null : new Statistics(statisticNodes));
     }
 


### PR DESCRIPTION
## Intended Change

When closing a proof the status line reports no proof. This PR fixes that issue.


## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

    
- I have tested the feature as follows: manual test

## Additional information and contact(s)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
