### PR TITLE
Ensure default option for pruning/disposing of cache sources is set properly

### DIFF
--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/settings/CachingSettingsProvider.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/settings/CachingSettingsProvider.java
@@ -80,7 +80,7 @@ public class CachingSettingsProvider extends SettingsPanel implements SettingsPr
                 When a referenced proof is pruned, this is what happens to
                  all cached branches that reference it.""",
             0, x -> {
-            }, PRUNE_REOPEN, PRUNE_COPY);
+            }, PRUNE_COPY, PRUNE_REOPEN);
     }
 
     @Override

--- a/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/settings/ProofCachingSettings.java
+++ b/keyext.caching/src/main/java/de/uka/ilkd/key/gui/plugins/caching/settings/ProofCachingSettings.java
@@ -39,12 +39,12 @@ public class ProofCachingSettings extends AbstractPropertiesSettings {
      * Behaviour when disposing a proof that is referenced elsewhere.
      */
     private final AbstractPropertiesSettings.PropertyEntry<String> dispose =
-        createStringProperty(DISPOSE_KEY, "");
+        createStringProperty(DISPOSE_KEY, DISPOSE_COPY);
     /**
      * Behaviour when pruning a proof that is referenced elsewhere.
      */
     private final AbstractPropertiesSettings.PropertyEntry<String> prune =
-        createStringProperty(PRUNE_KEY, "");
+        createStringProperty(PRUNE_KEY, PRUNE_COPY);
 
     public ProofCachingSettings() {
         super("ProofCaching");


### PR DESCRIPTION
This is a small bugfix that sets the default values for two settings of the caching extension:
1. Pruning a branch used as cache source automatically copies the steps to the target node where the cache hit occurred.
2. Disposing a proof that was used as cache source automatically copies the steps to the target proof.

Both have two options: "Copy" or "Reopen" (compare to the screenshot in #3469), where the former transfers the steps, and the latter silently reopens the affected branches.

Since the default was not set properly (empty string returned), the first option in the combo box was selected, which happened to be the unsafe option ("Reopen") when pruning. For disposing, the default was correct (although not properly set), because the combo box had "Copy" as first entry.

This PR sets both options to the safe variant "Copy" to avoid silently reopening any branches the user might have thought of as closed.

## Related Issue

Partially fixes #3469, even if it still remains a valid feature request.

## Type of pull request


- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: manually checked in the GUI that indeed the set defaults are applied, and also persisting a set option across KeY runs still works (settings are correctly written to `~/.key/proofIndependentSettings.json`)

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
