### PR TITLE
Fix compact constructor in Records

### DIFF
--- a/key.core/pipelineTests/records/expected/03_RecordClassBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/03_RecordClassBuilder/CompactConstructor.java
@@ -63,10 +63,4 @@ final class Mapping extends Record {
     public final non_null String toString() {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
-
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
 }

--- a/key.core/pipelineTests/records/expected/04_JMLTransformer/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/04_JMLTransformer/CompactConstructor.java
@@ -63,10 +63,4 @@ final class Mapping extends Record {
     public final non_null String toString() {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
-
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
 }

--- a/key.core/pipelineTests/records/expected/05_JmlDocRemoval/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/05_JmlDocRemoval/CompactConstructor.java
@@ -63,10 +63,4 @@ final class Mapping extends Record {
     public final non_null String toString() {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
-
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
 }

--- a/key.core/pipelineTests/records/expected/06_ImplicitFieldAdder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/06_ImplicitFieldAdder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/07_InstanceAllocationMethodBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/07_InstanceAllocationMethodBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/08_ConstructorNormalformBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/08_ConstructorNormalformBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/09_ClassPreparationMethodBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/09_ClassPreparationMethodBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/10_ClassInitializeMethodBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/10_ClassInitializeMethodBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/11_PrepareObjectBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/11_PrepareObjectBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/12_CreateBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/12_CreateBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/13_CreateObjectBuilder/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/13_CreateObjectBuilder/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/14_LocalClassTransformation/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/14_LocalClassTransformation/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/pipelineTests/records/expected/15_ConstantStringExpressionEvaluator/CompactConstructor.java
+++ b/key.core/pipelineTests/records/expected/15_ConstantStringExpressionEvaluator/CompactConstructor.java
@@ -64,12 +64,6 @@ final class Mapping extends Record {
         return "Mapping[" + "from=" + from + "," + "to=" + to + "]";
     }
 
-    Mapping {
-        // compact constructor!
-        from = "abc";
-        to = "def";
-    }
-
     @javax.annotation.processing.Generated()
     static private boolean $classInitializationInProgress;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/RecordClassBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/transformations/pipeline/RecordClassBuilder.java
@@ -136,6 +136,10 @@ public class RecordClassBuilder extends JavaTransformerAbstract {
             fullConstructor.getBody().get().getStatements().add(0, compactConstructor.getBody());
         }
 
+        for (var compactConstructor : recordDeclaration.getCompactConstructors()) {
+            compactConstructor.remove();
+        }
+
         var type = recordDeclaration.getNameAsString();
         // var marker = new KeYMarkerStatement(MarkerStatementHelper.KIND_ASSUME);
         var fieldParamEqual = recordDeclaration.getParameters()

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/KeyAst.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -400,12 +401,14 @@ public abstract class KeyAst<T extends ParserRuleContext> {
             super(ctx);
         }
 
-        public java.io.@Nullable File getJavaSourceLocation() {
+        public Path getJavaSourceLocation() {
             try {
                 JavaKeYParser.String_valueContext value =
                     ctx.programSource(0).oneProgramSource().string_value(0);
                 String v = ParsingFacade.getValueDocumentation(value);
-                return new java.io.File(v);
+                var location = Location.fromToken(ctx.start);
+                var keyFile = Paths.get(location.fileUri());
+                return keyFile.getParent().resolve(v);
             } catch (NullPointerException | IndexOutOfBoundsException e) {
                 {
                     return null;

--- a/key.ui/examples/Java/Records+CompactConstructor/Constructor.key
+++ b/key.ui/examples/Java/Records+CompactConstructor/Constructor.key
@@ -74,4 +74,9 @@
 
 
 \javaSource "src";
-\chooseContract
+
+\proofObligation {
+    "class" : "de.uka.ilkd.key.proof.init.FunctionalOperationContractPO",
+    "contract" : "Point3d[Point3d::Point3d(int,int,int)].JML normal_behavior operation contract.0",
+    "name" : "Point3d[Point3d::Point3d(int,int,int)].JML normal_behavior operation contract.0"
+}

--- a/key.ui/examples/Java/Records+CompactConstructor/README.txt
+++ b/key.ui/examples/Java/Records+CompactConstructor/README.txt
@@ -1,0 +1,8 @@
+example.path = Java 25
+example.name = Records+CC
+example.file = Use.key
+example.additionalFile.1 = src/Point2dU.java
+
+Example for the use of Java Records with a Compact Constructor in KeY
+
+KeY supports Records by an internal transformation into regular Java classes. Combined with the treatment of final fields, you get a simple construct for verification.

--- a/key.ui/examples/Java/Records+CompactConstructor/Use.key
+++ b/key.ui/examples/Java/Records+CompactConstructor/Use.key
@@ -74,4 +74,10 @@
 
 
 \javaSource "src";
-\chooseContract
+
+\proofObligation {
+    "class" : "de.uka.ilkd.key.proof.init.FunctionalOperationContractPO",
+    "contract" : "Use[Use::m()].JML normal_behavior operation contract.0",
+    "name" : "Use[Use::m()].JML normal_behavior operation contract.0"
+}
+

--- a/key.ui/examples/Java/Records+CompactConstructor/project.key
+++ b/key.ui/examples/Java/Records+CompactConstructor/project.key
@@ -1,0 +1,3 @@
+\javaSource "src";
+
+\chooseContract

--- a/key.ui/examples/Java/Records+CompactConstructor/src/Point2dU.java
+++ b/key.ui/examples/Java/Records+CompactConstructor/src/Point2dU.java
@@ -1,0 +1,14 @@
+public record Point2dU(int x, int y) {
+    Point2dU {
+        if(x<0) x *= -1;
+        if(y<0) y *= -1;
+    }
+}
+
+class Use {
+    /*@ normal_behavior ensures true; requires true; */
+    public void m() {
+        var p = new Point2dU(1, -2);
+        //@assert p.x()>0 && p.y()>0;
+    }
+}

--- a/key.ui/examples/Java/Records/README.txt
+++ b/key.ui/examples/Java/Records/README.txt
@@ -1,7 +1,7 @@
 example.path = Java 25
 example.name = Records
 example.file = Use.key
-example.additionalFile.1 = src/Point.java
+example.additionalFile.1 = src/Point3d.java
 
 Example for the use of Java Records in KeY
 

--- a/key.ui/examples/Java/Records/Use.key
+++ b/key.ui/examples/Java/Records/Use.key
@@ -74,4 +74,9 @@
 
 
 \javaSource "src";
-\chooseContract
+\proofObligation {
+    "class" : "de.uka.ilkd.key.proof.init.FunctionalOperationContractPO",
+    "contract" : "Use[Use::m()].JML normal_behavior operation contract.0",
+    "name" : "Use[Use::m()].JML normal_behavior operation contract.0"
+}
+

--- a/key.ui/examples/Java/Records/src/Point3d.java
+++ b/key.ui/examples/Java/Records/src/Point3d.java
@@ -1,4 +1,24 @@
-record Point3d(int x, int y, int z) {
+public record Point3d(int x, int y, int z) {
+    /*@ normal_behavior ensures true; requires true; */
+    public static void test() {
+        Point3d p = new Point3d(1, 2, 3);
+
+        //boolean b= p.equals(p);
+        // @assert b;
+
+        //@ assert p.x() == 1;
+        //@ assert p.y() == 2;
+        //@ assert p.z() == 3;
+
+        //@assert p.equals(p);
+
+        Point3d q = new Point3d(p.x, p.y, p.z);
+        //@assert p.equals(q);
+        //@assert q.equals(p);
+    }
+}
+
+class Use {
     /*@ normal_behavior ensures true; requires true; */
     public static void m() {
         Point3d p = new Point3d(1, 2, 3);
@@ -13,10 +33,7 @@ record Point3d(int x, int y, int z) {
         //@assert p.equals(p);
 
         Point3d q = new Point3d(p.x, p.y, p.z);
-
         //@assert p.equals(q);
-
         //@assert q.equals(p);
-
     }
 }

--- a/key.ui/examples/Java/Records/src/Point3d.java
+++ b/key.ui/examples/Java/Records/src/Point3d.java
@@ -1,8 +1,6 @@
-record Point3d(int x, int y, int z) {}
-
-public class Use {
+record Point3d(int x, int y, int z) {
     /*@ normal_behavior ensures true; requires true; */
-    public void m() {
+    public static void m() {
         Point3d p = new Point3d(1, 2, 3);
 
         //boolean b= p.equals(p);

--- a/key.ui/examples/index/samplesIndex.txt
+++ b/key.ui/examples/index/samplesIndex.txt
@@ -22,6 +22,7 @@ firstTouch/11-StateMerging/README.txt
 
 # Java Features
 Java/Records/README.txt
+Java/Records+CompactConstructor/README.txt
 Java/TextBlockLiterals/README.txt
 
 

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
@@ -25,6 +25,8 @@ import de.uka.ilkd.key.util.KeYConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.swing.*;
+
 /**
  * This action allows the creation of Github issues with more ease.
  * <p>
@@ -76,10 +78,9 @@ public class CreateGithubIssueAction extends MainWindowAction {
         String java = "";
         Proof proof = MainWindow.getInstance().getMediator().getSelectedProof();
         if (proof != null) {
-            File javaSourceLocation = SendFeedbackAction.getJavaSourceLocation(proof);
+            var javaSourceLocation = SendFeedbackAction.getJavaSourceLocation(proof);
             if (javaSourceLocation != null) {
-                Path path = javaSourceLocation.toPath();
-                try (final var walker = Files.walk(path)) {
+                try (final var walker = Files.walk(javaSourceLocation)) {
                     java = walker.map(it -> {
                         try {
                             if (it.getFileName().toString().endsWith(".java")) {
@@ -105,8 +106,53 @@ public class CreateGithubIssueAction extends MainWindowAction {
         try {
             Desktop.getDesktop().browse(uri);
         } catch (IOException e) {
-            LOGGER.error("Could not open browser for URI {}.", uri, e);
+            LOGGER.error("Could not open browser for URI", e);
+            showGeneratedTextDialog(body);
         }
 
+    }
+
+    /**
+     * Shows a dialog with the generated text that can be copied by the user.
+     *
+     * @param text the text to display
+     */
+    private void showGeneratedTextDialog(String text) {
+        JTextArea textArea = new JTextArea(20, 60);
+        textArea.setText(text);
+        textArea.setLineWrap(true);
+        textArea.setWrapStyleWord(true);
+        textArea.setEditable(false);
+        
+        JScrollPane scrollPane = new JScrollPane(textArea);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        
+        JButton copyButton = new JButton("Copy to Clipboard & Open Github");
+        copyButton.addActionListener(e -> {
+            textArea.selectAll();
+            textArea.copy();
+            textArea.setSelectionStart(0);
+            textArea.setSelectionEnd(0);
+
+            try {
+                Desktop.getDesktop().browse(URI.create(URL));
+            } catch (IOException ignore) {
+            }
+        });
+        
+        JButton closeButton = new JButton("Close");
+        closeButton.addActionListener(e -> SwingUtilities.getWindowAncestor(closeButton).dispose());
+        
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        buttonPanel.add(copyButton);
+        buttonPanel.add(closeButton);
+        
+        JPanel contentPanel = new JPanel(new BorderLayout());
+        contentPanel.add(scrollPane, BorderLayout.CENTER);
+        contentPanel.add(buttonPanel, BorderLayout.SOUTH);
+        
+        JOptionPane pane = new JOptionPane(contentPanel, JOptionPane.PLAIN_MESSAGE, JOptionPane.NO_OPTION);
+        JDialog dialog = pane.createDialog(mainWindow, "Generated GitHub Issue Text");
+        dialog.setVisible(true);
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/CreateGithubIssueAction.java
@@ -5,15 +5,14 @@ package de.uka.ilkd.key.gui.actions;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.swing.*;
 
 import de.uka.ilkd.key.gui.MainWindow;
 import de.uka.ilkd.key.gui.fonticons.FontAwesomeBrands;
@@ -24,8 +23,6 @@ import de.uka.ilkd.key.util.KeYConstants;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
 
 /**
  * This action allows the creation of Github issues with more ease.
@@ -123,10 +120,10 @@ public class CreateGithubIssueAction extends MainWindowAction {
         textArea.setLineWrap(true);
         textArea.setWrapStyleWord(true);
         textArea.setEditable(false);
-        
+
         JScrollPane scrollPane = new JScrollPane(textArea);
         scrollPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        
+
         JButton copyButton = new JButton("Copy to Clipboard & Open Github");
         copyButton.addActionListener(e -> {
             textArea.selectAll();
@@ -139,19 +136,20 @@ public class CreateGithubIssueAction extends MainWindowAction {
             } catch (IOException ignore) {
             }
         });
-        
+
         JButton closeButton = new JButton("Close");
         closeButton.addActionListener(e -> SwingUtilities.getWindowAncestor(closeButton).dispose());
-        
+
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         buttonPanel.add(copyButton);
         buttonPanel.add(closeButton);
-        
+
         JPanel contentPanel = new JPanel(new BorderLayout());
         contentPanel.add(scrollPane, BorderLayout.CENTER);
         contentPanel.add(buttonPanel, BorderLayout.SOUTH);
-        
-        JOptionPane pane = new JOptionPane(contentPanel, JOptionPane.PLAIN_MESSAGE, JOptionPane.NO_OPTION);
+
+        JOptionPane pane =
+            new JOptionPane(contentPanel, JOptionPane.PLAIN_MESSAGE, JOptionPane.NO_OPTION);
         JDialog dialog = pane.createDialog(mainWindow, "Generated GitHub Issue Text");
         dialog.setVisible(true);
     }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
@@ -3,24 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions;
 
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.*;
-import java.net.*;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-import javax.swing.*;
-import javax.swing.border.TitledBorder;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.text.html.HTMLEditorKit;
-
 import de.uka.ilkd.key.core.KeYMediator;
 import de.uka.ilkd.key.gui.IssueDialog;
 import de.uka.ilkd.key.gui.MainWindow;
@@ -32,19 +14,38 @@ import de.uka.ilkd.key.settings.ProofSettings;
 import de.uka.ilkd.key.util.ExceptionTools;
 import de.uka.ilkd.key.util.KeYConstants;
 import de.uka.ilkd.key.util.KeYResourceManager;
-
+import org.jspecify.annotations.Nullable;
 import org.key_project.util.Streams;
 import org.key_project.util.java.IOUtil;
 import org.key_project.util.parsing.Location;
-
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Action that executes if "Send Feedback..." was pressed. There are currently two locations: In
  * {@link IssueDialog} and in the main menu {@link MenuSendFeedackAction}.
- *
+ * <p>
  * For a documentation of the backend of the auto-send mechanism, refer to the file key-report.php
  * in the same directory as this file.
  *
@@ -53,8 +54,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SendFeedbackAction extends AbstractAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(SendFeedbackAction.class);
-
-    private static final long serialVersionUID = 8146108238901822515L;
 
     /*
      * This is the email address to which feedback will be sent.
@@ -78,7 +77,7 @@ public class SendFeedbackAction extends AbstractAction {
      * @param proof the Proof
      * @return the location of the java source code or null if no such exists
      */
-    public static @Nullable File getJavaSourceLocation(Proof proof) {
+    public static @Nullable Path getJavaSourceLocation(Proof proof) {
         KeyAst.@Nullable Declarations header = proof.header();
         if (header == null)
             return null;
@@ -133,7 +132,7 @@ public class SendFeedbackAction extends AbstractAction {
             } catch (Exception e) {
                 zipEntryFileName += ".exception";
                 data = (e.getClass().getSimpleName() + " occured while trying to read data.\n"
-                    + e.getMessage() + "\n" + serializeStackTrace(e))
+                        + e.getMessage() + "\n" + serializeStackTrace(e))
                         .getBytes(StandardCharsets.UTF_8);
             }
             stream.putNextEntry(new ZipEntry(zipEntryFileName));
@@ -151,7 +150,7 @@ public class SendFeedbackAction extends AbstractAction {
         @Override
         byte[] retrieveFileData() throws Exception {
             File mostRecentFile = new File(
-                MainWindow.getInstance().getRecentFiles().getMostRecent());
+                    MainWindow.getInstance().getRecentFiles().getMostRecent());
             return Files.readAllBytes(mostRecentFile.toPath());
         }
 
@@ -159,7 +158,7 @@ public class SendFeedbackAction extends AbstractAction {
         boolean isEnabled() {
             try {
                 String file =
-                    MainWindow.getInstance().getRecentFiles().getMostRecent();
+                        MainWindow.getInstance().getRecentFiles().getMostRecent();
                 return file != null && file.length() != 0;
             } catch (Exception e) {
                 return false;
@@ -318,33 +317,33 @@ public class SendFeedbackAction extends AbstractAction {
         boolean isEnabled() {
             try {
                 Proof proof = MainWindow.getInstance().getMediator().getSelectedProof();
-                File javaSourceLocation = getJavaSourceLocation(proof);
+                File javaSourceLocation = getJavaSourceLocation(proof).toFile();
                 return javaSourceLocation != null;
             } catch (Exception e) {
                 return false;
             }
         }
 
-        private void getJavaFilesRecursively(File directory, List<File> list) {
-            for (File f : directory.listFiles()) {
-                if (f.isDirectory()) {
-                    getJavaFilesRecursively(f, list);
-                } else if (f.getName().endsWith(".java")) {
-                    list.add(f);
-                }
+        private List<Path> getJavaFilesRecursively(Path directory) {
+            try (var stream = Files.walk(directory)) {
+                return stream
+                        .filter(it -> it.toString().endsWith(".java")
+                                || it.toString().endsWith(".jml"))
+                        .toList();
+            } catch (IOException e) {
+                return List.of();
             }
         }
 
         @Override
         void appendDataToZipOutputStream(ZipOutputStream stream) throws IOException {
             Proof proof = MainWindow.getInstance().getMediator().getSelectedProof();
-            File javaSourceLocation = getJavaSourceLocation(proof);
-            List<File> javaFiles = new LinkedList<>();
-            getJavaFilesRecursively(javaSourceLocation, javaFiles);
-            for (File f : javaFiles) {
+            Path javaSourceLocation = getJavaSourceLocation(proof);
+            List<Path> javaFiles = getJavaFilesRecursively(javaSourceLocation);
+            for (Path f : javaFiles) {
                 stream.putNextEntry(
-                    new ZipEntry("javaSource/" + javaSourceLocation.toURI().relativize(f.toURI())));
-                stream.write(Files.readAllBytes(f.toPath()));
+                        new ZipEntry("javaSource/" + javaSourceLocation.relativize(f)));
+                stream.write(Files.readAllBytes(f));
                 stream.closeEntry();
             }
         }
@@ -369,9 +368,9 @@ public class SendFeedbackAction extends AbstractAction {
             if (answer == JFileChooser.APPROVE_OPTION) {
                 saveMetaDataToFile(jfc.getSelectedFile(), message);
                 JOptionPane.showMessageDialog(parent,
-                    String.format("Your message has been saved to the file %s.\n"
-                        + "If you want to report a bug, you can enclose this file in an\n"
-                        + "e-mail to " + FEEDBACK_RECIPIENT + ".", jfc.getSelectedFile()));
+                        String.format("Your message has been saved to the file %s.\n"
+                                + "If you want to report a bug, you can enclose this file in an\n"
+                                + "e-mail to " + FEEDBACK_RECIPIENT + ".", jfc.getSelectedFile()));
             }
         } catch (Exception e) {
             LOGGER.error("", e);
@@ -382,15 +381,15 @@ public class SendFeedbackAction extends AbstractAction {
     private void sendReport(String message) {
 
         String[] msgs = {
-            // tp.setEditable(false);
-            // tp.setBackground(UIManager.getColor("label.background"));
-            // tp.setEditorKit(new HTMLEditorKit());
-            // tp.setText("<html>" +
-            "The data you have collected and the description text will now be sent via",
-            "https to the server formal.kastel.kit.edu, stored on the server and forwarded",
-            "to the KeY mailing list.", "", "Click OK if you want to send the report now." };
+                // tp.setEditable(false);
+                // tp.setBackground(UIManager.getColor("label.background"));
+                // tp.setEditorKit(new HTMLEditorKit());
+                // tp.setText("<html>" +
+                "The data you have collected and the description text will now be sent via",
+                "https to the server formal.kastel.kit.edu, stored on the server and forwarded",
+                "to the KeY mailing list.", "", "Click OK if you want to send the report now."};
         int answer = JOptionPane.showConfirmDialog(parent, msgs, "Ready to send?",
-            JOptionPane.YES_NO_OPTION);
+                JOptionPane.YES_NO_OPTION);
         if (answer != JOptionPane.YES_OPTION) {
             return;
         }
@@ -402,7 +401,7 @@ public class SendFeedbackAction extends AbstractAction {
             connection.setDoOutput(true);
             connection.setRequestProperty("Content-Type", "application/zip");
             connection.setRequestProperty("KeY-Version",
-                "KeY " + KeYResourceManager.getManager().getVersion());
+                    "KeY " + KeYResourceManager.getManager().getVersion());
             try (OutputStream os = connection.getOutputStream()) {
                 os.write(buffer.toByteArray());
             }
@@ -414,7 +413,7 @@ public class SendFeedbackAction extends AbstractAction {
             } else {
                 String msg = Streams.toString(((HttpURLConnection) connection).getErrorStream());
                 throw new IOException(
-                    "The server responded with an error message (" + responseCode + "): " + msg);
+                        "The server responded with an error message (" + responseCode + "): " + msg);
             }
 
         } catch (Exception e) {
@@ -445,9 +444,9 @@ public class SendFeedbackAction extends AbstractAction {
         }
     }
 
-    private final SendFeedbackItem[] items = { new StacktraceItem(), new FaultyFileItem(),
-        new LastLoadedProblemItem(), new VersionItem(), new SystemPropertiesItem(),
-        new OpenGoalItem(), new OpenProofItem(), new SettingsItem(), new JavaSourceItem() };
+    private final SendFeedbackItem[] items = {new StacktraceItem(), new FaultyFileItem(),
+            new LastLoadedProblemItem(), new VersionItem(), new SystemPropertiesItem(),
+            new OpenGoalItem(), new OpenProofItem(), new SettingsItem(), new JavaSourceItem()};
 
     private final Throwable throwable;
     private final Window parent;
@@ -465,7 +464,7 @@ public class SendFeedbackAction extends AbstractAction {
     private JDialog makeDialog() {
 
         final JDialog dialog = new JDialog(parent, "Report an error to KeY developers",
-            Dialog.ModalityType.DOCUMENT_MODAL);
+                Dialog.ModalityType.DOCUMENT_MODAL);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 
         JPanel right = new JPanel();
@@ -499,8 +498,8 @@ public class SendFeedbackAction extends AbstractAction {
 
         JButton saveFeedbackReportButton = new JButton("Save Feedback...");
         saveFeedbackReportButton.setToolTipText(
-            "<html>Information about current proof state are saved to a file.<br>"
-                + "This file can be also used when reporting a bug via e-mail.");
+                "<html>Information about current proof state are saved to a file.<br>"
+                        + "This file can be also used when reporting a bug via e-mail.");
         saveFeedbackReportButton.addActionListener(e -> {
             saveZIP(bugDescription.getText());
             dialog.dispose();
@@ -509,8 +508,8 @@ public class SendFeedbackAction extends AbstractAction {
         JButton sendFeedbackReportButton = new JButton("Send Feedback...");
         sendFeedbackReportButton
                 .setToolTipText("<html>Information about current proof state are sent via a "
-                    + "secure https connection to the developers.<br>"
-                    + "The receiving server is located at KIT (formal.kastel.kit.edu).");
+                        + "secure https connection to the developers.<br>"
+                        + "The receiving server is located at KIT (formal.kastel.kit.edu).");
         sendFeedbackReportButton.addActionListener(e -> {
             sendReport(bugDescription.getText());
             dialog.dispose();
@@ -529,12 +528,12 @@ public class SendFeedbackAction extends AbstractAction {
         labels.setBackground(UIManager.getColor("Label.background"));
         labels.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         labels.setText(
-            "<html>The report feature can be used to send information about your current state of KeY to report a bug or to ask for advice from the KeY team.<br>"
-                + "You can either store the information in a zip locally (and then e.g. send that via e-mail to "
-                + FEEDBACK_RECIPIENT + ") or send directly to our server.<br>"
-                + "Please select the information that you want to include from the list on the right.<br>"
-                + "If you send the information directly, <b>please make sure to indicate your e-mail address</b> "
-                + "in the message below such that the team can respond.");
+                "<html>The report feature can be used to send information about your current state of KeY to report a bug or to ask for advice from the KeY team.<br>"
+                        + "You can either store the information in a zip locally (and then e.g. send that via e-mail to "
+                        + FEEDBACK_RECIPIENT + ") or send directly to our server.<br>"
+                        + "Please select the information that you want to include from the list on the right.<br>"
+                        + "If you send the information directly, <b>please make sure to indicate your e-mail address</b> "
+                        + "in the message below such that the team can respond.");
         Container container = dialog.getContentPane();
         container.setLayout(new BorderLayout());
         container.add(labels, BorderLayout.NORTH);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/SendFeedbackAction.java
@@ -3,28 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.gui.actions;
 
-import de.uka.ilkd.key.core.KeYMediator;
-import de.uka.ilkd.key.gui.IssueDialog;
-import de.uka.ilkd.key.gui.MainWindow;
-import de.uka.ilkd.key.nparser.KeyAst;
-import de.uka.ilkd.key.proof.Goal;
-import de.uka.ilkd.key.proof.Proof;
-import de.uka.ilkd.key.proof.io.OutputStreamProofSaver;
-import de.uka.ilkd.key.settings.ProofSettings;
-import de.uka.ilkd.key.util.ExceptionTools;
-import de.uka.ilkd.key.util.KeYConstants;
-import de.uka.ilkd.key.util.KeYResourceManager;
-import org.jspecify.annotations.Nullable;
-import org.key_project.util.Streams;
-import org.key_project.util.java.IOUtil;
-import org.key_project.util.parsing.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
-import javax.swing.border.TitledBorder;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.text.html.HTMLEditorKit;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -41,6 +19,30 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.text.html.HTMLEditorKit;
+
+import de.uka.ilkd.key.core.KeYMediator;
+import de.uka.ilkd.key.gui.IssueDialog;
+import de.uka.ilkd.key.gui.MainWindow;
+import de.uka.ilkd.key.nparser.KeyAst;
+import de.uka.ilkd.key.proof.Goal;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.io.OutputStreamProofSaver;
+import de.uka.ilkd.key.settings.ProofSettings;
+import de.uka.ilkd.key.util.ExceptionTools;
+import de.uka.ilkd.key.util.KeYConstants;
+import de.uka.ilkd.key.util.KeYResourceManager;
+
+import org.key_project.util.Streams;
+import org.key_project.util.java.IOUtil;
+import org.key_project.util.parsing.Location;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Action that executes if "Send Feedback..." was pressed. There are currently two locations: In
@@ -132,7 +134,7 @@ public class SendFeedbackAction extends AbstractAction {
             } catch (Exception e) {
                 zipEntryFileName += ".exception";
                 data = (e.getClass().getSimpleName() + " occured while trying to read data.\n"
-                        + e.getMessage() + "\n" + serializeStackTrace(e))
+                    + e.getMessage() + "\n" + serializeStackTrace(e))
                         .getBytes(StandardCharsets.UTF_8);
             }
             stream.putNextEntry(new ZipEntry(zipEntryFileName));
@@ -150,7 +152,7 @@ public class SendFeedbackAction extends AbstractAction {
         @Override
         byte[] retrieveFileData() throws Exception {
             File mostRecentFile = new File(
-                    MainWindow.getInstance().getRecentFiles().getMostRecent());
+                MainWindow.getInstance().getRecentFiles().getMostRecent());
             return Files.readAllBytes(mostRecentFile.toPath());
         }
 
@@ -158,7 +160,7 @@ public class SendFeedbackAction extends AbstractAction {
         boolean isEnabled() {
             try {
                 String file =
-                        MainWindow.getInstance().getRecentFiles().getMostRecent();
+                    MainWindow.getInstance().getRecentFiles().getMostRecent();
                 return file != null && file.length() != 0;
             } catch (Exception e) {
                 return false;
@@ -342,7 +344,7 @@ public class SendFeedbackAction extends AbstractAction {
             List<Path> javaFiles = getJavaFilesRecursively(javaSourceLocation);
             for (Path f : javaFiles) {
                 stream.putNextEntry(
-                        new ZipEntry("javaSource/" + javaSourceLocation.relativize(f)));
+                    new ZipEntry("javaSource/" + javaSourceLocation.relativize(f)));
                 stream.write(Files.readAllBytes(f));
                 stream.closeEntry();
             }
@@ -368,9 +370,9 @@ public class SendFeedbackAction extends AbstractAction {
             if (answer == JFileChooser.APPROVE_OPTION) {
                 saveMetaDataToFile(jfc.getSelectedFile(), message);
                 JOptionPane.showMessageDialog(parent,
-                        String.format("Your message has been saved to the file %s.\n"
-                                + "If you want to report a bug, you can enclose this file in an\n"
-                                + "e-mail to " + FEEDBACK_RECIPIENT + ".", jfc.getSelectedFile()));
+                    String.format("Your message has been saved to the file %s.\n"
+                        + "If you want to report a bug, you can enclose this file in an\n"
+                        + "e-mail to " + FEEDBACK_RECIPIENT + ".", jfc.getSelectedFile()));
             }
         } catch (Exception e) {
             LOGGER.error("", e);
@@ -381,15 +383,15 @@ public class SendFeedbackAction extends AbstractAction {
     private void sendReport(String message) {
 
         String[] msgs = {
-                // tp.setEditable(false);
-                // tp.setBackground(UIManager.getColor("label.background"));
-                // tp.setEditorKit(new HTMLEditorKit());
-                // tp.setText("<html>" +
-                "The data you have collected and the description text will now be sent via",
-                "https to the server formal.kastel.kit.edu, stored on the server and forwarded",
-                "to the KeY mailing list.", "", "Click OK if you want to send the report now."};
+            // tp.setEditable(false);
+            // tp.setBackground(UIManager.getColor("label.background"));
+            // tp.setEditorKit(new HTMLEditorKit());
+            // tp.setText("<html>" +
+            "The data you have collected and the description text will now be sent via",
+            "https to the server formal.kastel.kit.edu, stored on the server and forwarded",
+            "to the KeY mailing list.", "", "Click OK if you want to send the report now." };
         int answer = JOptionPane.showConfirmDialog(parent, msgs, "Ready to send?",
-                JOptionPane.YES_NO_OPTION);
+            JOptionPane.YES_NO_OPTION);
         if (answer != JOptionPane.YES_OPTION) {
             return;
         }
@@ -401,7 +403,7 @@ public class SendFeedbackAction extends AbstractAction {
             connection.setDoOutput(true);
             connection.setRequestProperty("Content-Type", "application/zip");
             connection.setRequestProperty("KeY-Version",
-                    "KeY " + KeYResourceManager.getManager().getVersion());
+                "KeY " + KeYResourceManager.getManager().getVersion());
             try (OutputStream os = connection.getOutputStream()) {
                 os.write(buffer.toByteArray());
             }
@@ -413,7 +415,7 @@ public class SendFeedbackAction extends AbstractAction {
             } else {
                 String msg = Streams.toString(((HttpURLConnection) connection).getErrorStream());
                 throw new IOException(
-                        "The server responded with an error message (" + responseCode + "): " + msg);
+                    "The server responded with an error message (" + responseCode + "): " + msg);
             }
 
         } catch (Exception e) {
@@ -444,9 +446,9 @@ public class SendFeedbackAction extends AbstractAction {
         }
     }
 
-    private final SendFeedbackItem[] items = {new StacktraceItem(), new FaultyFileItem(),
-            new LastLoadedProblemItem(), new VersionItem(), new SystemPropertiesItem(),
-            new OpenGoalItem(), new OpenProofItem(), new SettingsItem(), new JavaSourceItem()};
+    private final SendFeedbackItem[] items = { new StacktraceItem(), new FaultyFileItem(),
+        new LastLoadedProblemItem(), new VersionItem(), new SystemPropertiesItem(),
+        new OpenGoalItem(), new OpenProofItem(), new SettingsItem(), new JavaSourceItem() };
 
     private final Throwable throwable;
     private final Window parent;
@@ -464,7 +466,7 @@ public class SendFeedbackAction extends AbstractAction {
     private JDialog makeDialog() {
 
         final JDialog dialog = new JDialog(parent, "Report an error to KeY developers",
-                Dialog.ModalityType.DOCUMENT_MODAL);
+            Dialog.ModalityType.DOCUMENT_MODAL);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 
         JPanel right = new JPanel();
@@ -498,8 +500,8 @@ public class SendFeedbackAction extends AbstractAction {
 
         JButton saveFeedbackReportButton = new JButton("Save Feedback...");
         saveFeedbackReportButton.setToolTipText(
-                "<html>Information about current proof state are saved to a file.<br>"
-                        + "This file can be also used when reporting a bug via e-mail.");
+            "<html>Information about current proof state are saved to a file.<br>"
+                + "This file can be also used when reporting a bug via e-mail.");
         saveFeedbackReportButton.addActionListener(e -> {
             saveZIP(bugDescription.getText());
             dialog.dispose();
@@ -508,8 +510,8 @@ public class SendFeedbackAction extends AbstractAction {
         JButton sendFeedbackReportButton = new JButton("Send Feedback...");
         sendFeedbackReportButton
                 .setToolTipText("<html>Information about current proof state are sent via a "
-                        + "secure https connection to the developers.<br>"
-                        + "The receiving server is located at KIT (formal.kastel.kit.edu).");
+                    + "secure https connection to the developers.<br>"
+                    + "The receiving server is located at KIT (formal.kastel.kit.edu).");
         sendFeedbackReportButton.addActionListener(e -> {
             sendReport(bugDescription.getText());
             dialog.dispose();
@@ -528,12 +530,12 @@ public class SendFeedbackAction extends AbstractAction {
         labels.setBackground(UIManager.getColor("Label.background"));
         labels.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         labels.setText(
-                "<html>The report feature can be used to send information about your current state of KeY to report a bug or to ask for advice from the KeY team.<br>"
-                        + "You can either store the information in a zip locally (and then e.g. send that via e-mail to "
-                        + FEEDBACK_RECIPIENT + ") or send directly to our server.<br>"
-                        + "Please select the information that you want to include from the list on the right.<br>"
-                        + "If you send the information directly, <b>please make sure to indicate your e-mail address</b> "
-                        + "in the message below such that the team can respond.");
+            "<html>The report feature can be used to send information about your current state of KeY to report a bug or to ask for advice from the KeY team.<br>"
+                + "You can either store the information in a zip locally (and then e.g. send that via e-mail to "
+                + FEEDBACK_RECIPIENT + ") or send directly to our server.<br>"
+                + "Please select the information that you want to include from the list on the right.<br>"
+                + "If you send the information directly, <b>please make sure to indicate your e-mail address</b> "
+                + "in the message below such that the team can respond.");
         Container container = dialog.getContentPane();
         container.setLayout(new BorderLayout());
         container.add(labels, BorderLayout.NORTH);


### PR DESCRIPTION
## Related Issue

Records with compact constructors were not loadable. Only the removal of the AST nodes was missing. 

The remaining issue is a definition/specification problem of the half-user-coded/half-synthetic constructor. It remains unclear where to specify the behavior. Issue at [JmlRef](https://github.com/JavaModelingLanguage/RefMan/issues/62) was opened. 

## Intended Change

Make compact constructors work as far as possible.

### Side Quests

`CreateGithubIssueAction` and `SendFeedbackAction` were not performing correctly, as `KeYFile` has not returned the Java absolutely. This is fixed.

## Plan

* [x] Fix it
* [x] Add a new example
* [x] Resolve Java compiler error from existing example.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality
    
- I added new test case(s) for new functionality.

