### PR TITLE
Fix broken proof tree after information flow auto pilot

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1066,6 +1066,13 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 LOGGER.debug("delegateModel is null");
                 return;
             }
+            if (e.getSource() != proof) {
+                // Auto mode on a proof this view does not display, e.g. an auxiliary side proof
+                // of the information-flow macros (see #3713). Overwriting modifiedSubtrees with
+                // the foreign proof's goals would feed its nodes into the displayed proof's tree
+                // model in autoModeStopped.
+                return;
+            }
 
             // save goals on which the prover may work
             modifiedSubtrees = e.getSource().openGoals().map(Goal::node);
@@ -1088,7 +1095,10 @@ public class ProofTreeView extends JPanel implements TabPanel {
             setProof(mediator.getSelectedProof());
             if (modifiedSubtrees != null) {
                 for (final Node n : modifiedSubtrees) {
-                    if (proof.openGoals().filter(g -> g.node() == n).isEmpty()) {
+                    // skip nodes of other proofs: the displayed proof may have changed since the
+                    // subtrees were recorded in autoModeStarted (see #3713)
+                    if (n.proof() == proof
+                            && proof.openGoals().filter(g -> g.node() == n).isEmpty()) {
                         delegateModel.updateTree(n);
                     }
                 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/ui/AbstractMediatorUserInterfaceControl.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/ui/AbstractMediatorUserInterfaceControl.java
@@ -172,9 +172,10 @@ public abstract class AbstractMediatorUserInterfaceControl extends AbstractUserI
             });
             // stop interface again, because it is activated by the proof
             // change through startProver; the ProofMacroWorker will activate
-            // it again at the right time
+            // it again at the right time.
             ThreadUtilities.invokeAndWait(() -> {
-                getMediator().initiateAutoMode(info.getProof(), true, false);
+                getMediator().stopInterface(true);
+                getMediator().setInteractive(false);
             });
         }
     }

--- a/key.ui/src/test/java/de/uka/ilkd/key/gui/prooftree/DisposedProofTreeUpdateTest.java
+++ b/key.ui/src/test/java/de/uka/ilkd/key/gui/prooftree/DisposedProofTreeUpdateTest.java
@@ -1,0 +1,65 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.gui.prooftree;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import javax.swing.tree.TreeNode;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.proof.Node;
+import de.uka.ilkd.key.proof.Proof;
+
+import org.key_project.util.helper.FindResources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Documents the fail-fast contract of the proof tree model for the constellation behind issue
+ * #3713: nodes of a foreign (here: already disposed) proof must never be fed into another proof's
+ * {@link GUIProofTreeModel}. The information-flow auto pilot's side proof used to leak into
+ * {@code ProofTreeView.modifiedSubtrees} this way; the actual fix prevents the leak in
+ * {@code ProofTreeView} and {@code AbstractMediatorUserInterfaceControl#macroFinished}. The model
+ * itself deliberately keeps failing fast when the invariant is violated, so that bookkeeping bugs
+ * of this kind surface instead of being rendered silently.
+ */
+public class DisposedProofTreeUpdateTest {
+    private static final Path exampleDir =
+        Objects.requireNonNull(FindResources.getExampleDirectory());
+    private static final String EXAMPLE_PROOF =
+        "standard_key/BookExamples/10UsingKeY/andCommutes.proof";
+
+    @Test
+    void updatingWithNodeOfForeignDisposedProofFailsFast() throws Exception {
+        KeYEnvironment<DefaultUserInterfaceControl> env =
+            KeYEnvironment.load(exampleDir.resolve(EXAMPLE_PROOF));
+        Proof displayed = env.getLoadedProof();
+        KeYEnvironment<DefaultUserInterfaceControl> env2 =
+            KeYEnvironment.load(exampleDir.resolve(EXAMPLE_PROOF));
+        Proof foreign = env2.getLoadedProof();
+
+        GUIProofTreeModel model = new GUIProofTreeModel(displayed);
+        forceExpand((TreeNode) model.getRoot());
+
+        // keep a node of the foreign proof (Node keeps its proof reference), then dispose it
+        Node foreignRoot = foreign.root();
+        foreign.dispose();
+
+        assertThrows(IllegalStateException.class, () -> model.updateTree(foreignRoot),
+            "walking a foreign disposed proof's node must fail fast");
+
+        env.dispose();
+        env2.dispose();
+    }
+
+    private static void forceExpand(TreeNode node) {
+        int count = node.getChildCount();
+        for (int i = 0; i < count; i++) {
+            forceExpand(node.getChildAt(i));
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

This pull request resolves #3713.

## Intended Change

Applying the *Full Information Flow Auto Pilot* destroyed the proof tree view with

```
IllegalStateException: abstract tree node without parent: Proof Tree
    at GUIAbstractTreeNode.getParent(…) / getPath(…) / GUIProofTreeModel.updateTree(…)
```

The root problem was that two autoModeStarted events were fired, one for the main proof and 
one for the side proof. The side proof finished sent its autoModeStopped and the GUI tree
was informed about node changes of the tree it did not show and as the side proof was disposed
an NPE was triggered.

The actual fix is in ``AbstractMediatorUserInterfaceControl.macroFinished``. The ProofTreeView 
has a robustness fix discarding any information about a proof it does not display. The error is
not silenced as we still get an Exception from GUIAbstractTreeNode, but that is more fail fast and 
once, while the other exception from ProofTreeView would render the whole GUI unresponsive.

1. **`AbstractMediatorUserInterfaceControl.macroFinished`** only freezes the interface
   (`stopInterface` + `setInteractive(false)`) instead of broadcasting a spurious
   `autoModeStarted` for the side proof.
2. **`ProofTreeView`** ignores auto mode events for proofs it does not display, and skips foreign
   nodes when refreshing modified subtrees in `autoModeStopped`.

   
`DisposedProofTreeUpdateTest` reproduces the #3713 constellation headlessly (a foreign disposed
proof's node fed into a live proof's model) and pins the fail-fast contract.

Verified interactively: the auto pilot no longer breaks the proof tree.

**Note:** while verifying the fix another issue showed up, namely that information flow proofs additionally do not *close* interactively, an independent regression of the problem loader's profile handling, fixed in a separate follow-up PR.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: new regression test (`DisposedProofTreeUpdateTest`),
  manual GUI verification with the InformationFlow examples (the exact reproduction steps of
  #3713).

## Additional information and contact(s)

PR created with AI tooling

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
