### PR TITLE
Respect the \profile declaration of loaded files again

### DIFF
--- a/key.core.infflow/src/test/java/de/uka/ilkd/key/informationflow/InfFlowProfileLoadingTest.java
+++ b/key.core.infflow/src/test/java/de/uka/ilkd/key/informationflow/InfFlowProfileLoadingTest.java
@@ -1,0 +1,99 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.informationflow;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import de.uka.ilkd.key.control.DefaultUserInterfaceControl;
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.nparser.KeyAst;
+import de.uka.ilkd.key.proof.Proof;
+import de.uka.ilkd.key.proof.init.AbstractProfile;
+import de.uka.ilkd.key.scripts.ProofScriptEngine;
+
+import org.key_project.util.helper.FindResources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the profile resolution of the problem loader.
+ * <p>
+ * Information flow problem files declare {@code \profile "java-infflow"}. When the loader was
+ * given a (default) profile with {@code forceNewProfileOfNewProofs = false}, that profile
+ * nevertheless overrode the file's declaration. Under the plain Java profile the auxiliary
+ * computation of the information flow macros uses the ordinary "Use Operation Contract" rule
+ * instead of "InfFlow Use Operation Contract", loses the RELATED_BY_* tracking and the proof can
+ * no longer be closed. This is how the GUI (examples dialog, recent files) and the command line
+ * loaded every file, so infflow proofs closed headlessly (e.g. in RunAllProofs) but not
+ * interactively.
+ */
+public class InfFlowProfileLoadingTest {
+    private static final String EXAMPLE = "InformationFlow/NewObjects/"
+        + "object.AmtoftBanerjee(object.AmtoftBanerjee__m_1()).Non-interference contract.0.m.key";
+
+    private static Path exampleFile() {
+        return Objects.requireNonNull(FindResources.getExampleDirectory()).resolve(EXAMPLE);
+    }
+
+    /**
+     * A default profile passed without force (as the GUI's problem loader does) must not override
+     * the file's {@code \profile} declaration.
+     */
+    @Test
+    void unforcedProfileDefersToFileDeclaration() throws Exception {
+        KeYEnvironment<DefaultUserInterfaceControl> env = KeYEnvironment.load(
+            AbstractProfile.getDefaultProfile(), exampleFile(), null, null, null, false);
+        try {
+            assertEquals(JavaInfFlowProfile.PROFILE_ID,
+                env.getLoadedProof().getServices().getProfile().ident(),
+                "the file's \\profile declaration must win over an unforced profile");
+        } finally {
+            env.dispose();
+        }
+    }
+
+    /**
+     * With {@code forceNewProfileOfNewProofs = true} the passed profile wins over the file's
+     * declaration (used e.g. when the user explicitly picks a profile in the file chooser).
+     */
+    @Test
+    void forcedProfileOverridesFileDeclaration() throws Exception {
+        KeYEnvironment<DefaultUserInterfaceControl> env = KeYEnvironment.load(
+            AbstractProfile.getDefaultProfile(), exampleFile(), null, null, null, true);
+        try {
+            assertEquals(AbstractProfile.getDefaultProfile().ident(),
+                env.getLoadedProof().getServices().getProfile().ident(),
+                "a forced profile must override the file's \\profile declaration");
+        } finally {
+            env.dispose();
+        }
+    }
+
+    /**
+     * End-to-end guard: loaded with the (previously broken) unforced default profile, the
+     * embedded infflow-autopilot script must close the proof. Before the fix this got stuck with
+     * an open goal after ~25 nodes because the auxiliary computation ran under the wrong profile.
+     */
+    @Test
+    void autopilotClosesProofWhenLoadedLikeTheGui() throws Exception {
+        KeYEnvironment<DefaultUserInterfaceControl> env = KeYEnvironment.load(
+            AbstractProfile.getDefaultProfile(), exampleFile(), null, null, null, false);
+        try {
+            Proof proof = env.getLoadedProof();
+            KeyAst.ProofScript script = env.getProofScript();
+            assertNotNull(script, "expected embedded \\proofScript in .m.key file");
+
+            new ProofScriptEngine(proof).execute(env.getUi(), script);
+
+            assertTrue(proof.closed(), "proof should close via the infflow-autopilot script");
+        } finally {
+            env.dispose();
+        }
+    }
+}

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/KeYUserProblemFile.java
@@ -237,6 +237,12 @@ public final class KeYUserProblemFile extends KeYFile implements ProofOblInput {
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * A {@link Profile} passed at construction time is <em>enforced</em>: the {@code \profile}
+     * declaration of the loaded file is not even read then. Pass {@code null} at construction to
+     * respect the file's declaration (with {@link #getDefaultProfile()} as fallback).
+     * </p>
      */
     @Override
     public Profile getProfile() {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
@@ -104,6 +104,13 @@ public abstract class AbstractProblemLoader {
     private @Nullable Profile profileOfNewProofs;
 
     /**
+     * {@code true} {@link #profileOfNewProofs} will be used as {@link Profile} of new proofs,
+     * {@code false} the {@link Profile} specified by the problem file will be used for new proofs
+     * (with the default profile as fallback if the file specifies none).
+     */
+    private final boolean forceNewProfileOfNewProofs;
+
+    /**
      * {@code true} to call {@link ProblemLoaderControl#selectProofObligation(InitConfig)} if no
      * {@link Proof} is defined by the loaded proof or {@code false} otherwise which still allows to
      * work with the loaded {@link InitConfig}.
@@ -193,6 +200,7 @@ public abstract class AbstractProblemLoader {
         this.bootClassPath = bootClassPath;
         this.control = control;
         setProfileOfNewProofs(profileOfNewProofs);
+        this.forceNewProfileOfNewProofs = forceNewProfileOfNewProofs;
         this.askUiToSelectAProofObligationIfNotDefinedByLoadedFile =
             askUiToSelectAProofObligationIfNotDefinedByLoadedFile;
         this.poPropertiesToForce = poPropertiesToForce;
@@ -487,11 +495,11 @@ public abstract class AbstractProblemLoader {
             Path unzippedProof = tmpDir.resolve(proofFilename);
 
             return new KeYUserProblemFile(unzippedProof.toString(), unzippedProof,
-                fileRepo, control, profileOfNewProofs, false);
+                fileRepo, control, enforcedProfile(), false);
         } else if (filename.endsWith(".key") || filename.endsWith(".proof")
                 || filename.endsWith(".proof.gz")) {
             // KeY problem specification or saved proof
-            return new KeYUserProblemFile(filename, file, fileRepo, control, profileOfNewProofs,
+            return new KeYUserProblemFile(filename, file, fileRepo, control, enforcedProfile(),
                 filename.endsWith(".proof.gz"));
         } else if (Files.isDirectory(file)) {
             // directory containing java sources, probably enriched
@@ -511,13 +519,25 @@ public abstract class AbstractProblemLoader {
     }
 
     /**
+     * Returns the {@link Profile} that overrides any profile declaration of the loaded file, or
+     * {@code null} if the file's own {@code \profile} declaration should be respected (see #3713:
+     * unconditionally passing {@link #profileOfNewProofs} made the GUI ignore the
+     * {@code \profile "java-infflow"} declaration of information flow problem files).
+     *
+     * @return the enforced {@link Profile} or {@code null}
+     */
+    private @Nullable Profile enforcedProfile() {
+        return forceNewProfileOfNewProofs ? profileOfNewProofs : null;
+    }
+
+    /**
      * Instantiates the {@link ProblemInitializer} to use.
      *
      * @param fileRepo the FileRepo used to ensure consistency between proof and source code
      * @return The {@link ProblemInitializer} to use.
      */
     protected ProblemInitializer createProblemInitializer(FileRepo fileRepo) {
-        Profile profile = profileOfNewProofs != null ? profileOfNewProofs : envInput.getProfile();
+        Profile profile = enforcedProfile() != null ? profileOfNewProofs : envInput.getProfile();
         ProblemInitializer pi = new ProblemInitializer(control, new Services(profile), control);
         pi.setAdditionalProfileOptions(additionalProfileOptions);
         pi.setFileRepo(fileRepo);


### PR DESCRIPTION
## Related Issue

Related to #3713 (where this regression was discovered while verifying the proof tree fix) and
to the corresponding proof tree fix #3911. 

## Intended Change

The problem loader enforces the profile passed at construction unconditionally:

* the constructor parameter `forceNewProfileOfNewProofs` of `AbstractProblemLoader` is accepted
  but no longer stored or evaluated (dead parameter), and
* a non-null profile passed to `KeYUserProblemFile` short-circuits reading the file's `\profile`
  declaration.

The GUI (`AbstractMediatorUserInterfaceControl.getProblemLoader`) and the command line always
pass `AbstractProfile.getDefaultProfile()` with `force = false` intending "prefer the file's
profile". Since the flag is dead, the default profile always wins and **every `\profile`
declaration is silently ignored** when loading via the examples dialog, File→Open, recent files,
drag & drop, or the CLI. Headless loading (`KeYEnvironment.load(location, …)`, used e.g. by
RunAllProofs) passes a `null` profile and was unaffected, which is why CI never caught this.

**Most visible consequence:** information flow problem files declare `\profile "java-infflow"`.
Loaded interactively they ran under the plain Java profile.

This PR implements the documented semantics of `forceNewProfileOfNewProofs` in
`AbstractProblemLoader` — no signature changes:

* only a **forced** profile overrides the file's declaration (used e.g. when the user explicitly
  picks a profile in the file chooser's loading options);
* otherwise the file's `\profile` wins, with the default profile as fallback if the file
  declares none unifying behavior for all `force = false` callers
  (examples dialog, File→Open, recent files, CLI, proof slicing).

`KeYUserProblemFile.getProfile()` now documents the enforced-profile semantics.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: new regression tests in `InfFlowProfileLoadingTest`:
  * an unforced default profile defers to the file's `\profile` (failed before this fix),
  * a forced profile still overrides the declaration,
  * end-to-end: loaded exactly like the GUI does, the infflow-autopilot script closes
    `object.AmtoftBanerjee::m_1` again (stuck at an open goal after ~25 nodes before this fix).

  Additionally verified interactively together with the proof tree fix for #3713.

## Additional information and contact(s)

Created with AI tooling support

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
