### PR TITLE
Use default key stroke settings when no settings file exists

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/KeyStrokeSettings.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/keyshortcuts/KeyStrokeSettings.java
@@ -163,6 +163,9 @@ public class KeyStrokeSettings extends AbstractPropertiesSettings {
                     LOGGER.error("Could not read {}", SETTINGS_FILE, e);
                     return INSTANCE = new KeyStrokeSettings(new Properties());
                 }
+            } else {
+                // if no settings file exists, initialise with default settings
+                return INSTANCE = new KeyStrokeSettings(new Properties());
             }
         }
         return INSTANCE;


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->
This pull request resolves #3908.

## Intended Change

If no settings file exists (KeY was installed for the first time, or it got deleted),
an NPE was thrown causing KeY to abort startup. The intended change is to 
allow KeY to startup and to use the default key stroke settings if no settings file can be found.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: manual testing

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
