### PR TITLE
Add test for Java parsing coverage

### DIFF
--- a/key.core/src/test/java/de/uka/ilkd/key/java/JavaFeatureCoverageTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/java/JavaFeatureCoverageTest.java
@@ -1,0 +1,143 @@
+/* This file is part of KeY - https://key-project.org
+ * KeY is licensed under the GNU General Public License Version 2
+ * SPDX-License-Identifier: GPL-2.0-only */
+package de.uka.ilkd.key.java;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import de.uka.ilkd.key.control.KeYEnvironment;
+import de.uka.ilkd.key.speclang.PositionedString;
+import de.uka.ilkd.key.util.ExceptionTools;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Pins down which Java language features KeY's front-end
+ * ({@link de.uka.ilkd.key.java.loader.JP2KeYConverter} and the transformation pipeline) currently
+ * accepts. This backs the "Java Coverage" support table in the user documentation.
+ * <p>
+ * The examples live under {@code src/test/resources/de/uka/ilkd/key/java/coverage} in two folders:
+ * <ul>
+ * <li>{@code supported/} — one directory per feature that KeY <em>parses</em> today. Each is loaded
+ * and must keep loading; a failure here is a parser regression.</li>
+ * <li>{@code rejected/} — one directory per feature that KeY does <em>not</em> parse today (it
+ * throws at load time, usually "Unsupported element detected given by Java Parser"). Each must keep
+ * being rejected; if one starts loading, the feature has become supported and the test (plus the
+ * documentation table) must be updated.</li>
+ * </ul>
+ * Every example also compiles with {@code javac} 21, so a load failure reflects KeY's front-end and
+ * not malformed Java. Note this checks <em>parseability</em>, not sound reasoning: a few
+ * {@code supported/} features (e.g. autoboxing, try-with-resources) load but are not soundly
+ * modelled, as noted in the documentation.
+ *
+ * @see de.uka.ilkd.key.java.loader.JP2KeYConverter
+ */
+public class JavaFeatureCoverageTest {
+
+    /** Each directory here must keep parsing; a throw is a front-end regression. */
+    @TestFactory
+    public Stream<DynamicTest> supportedFeaturesStayParseable() throws Exception {
+        return featureDirs("supported")
+                .map(dir -> DynamicTest.dynamicTest(dir.getFileName().toString(),
+                    () -> {
+                        Throwable error = tryLoad(dir);
+                        if (error != null) {
+                            fail("Regression: the Java feature '" + dir.getFileName()
+                                + "' no longer parses, although it is listed as supported. "
+                                + "If dropping it is intended, move it to 'coverage/rejected/' and update "
+                                + "the Java Coverage documentation table. Load error: "
+                                + firstMessage(error));
+                        }
+                    }));
+    }
+
+    /**
+     * Each directory here must keep being rejected. If one starts to parse, the feature is now
+     * supported and both this test and the documentation must be updated.
+     */
+    @TestFactory
+    public Stream<DynamicTest> unsupportedFeaturesStayRejected() throws Exception {
+        return featureDirs("rejected")
+                .map(dir -> DynamicTest.dynamicTest(dir.getFileName().toString(),
+                    () -> {
+                        Throwable error = tryLoad(dir);
+                        if (error == null) {
+                            fail("'" + dir.getFileName()
+                                + "' is now supported and the test should be "
+                                + "modified to reflect the new addition: move it from 'coverage/rejected/' "
+                                + "to 'coverage/supported/' and update the Java Coverage documentation "
+                                + "table (mark the feature as supported).");
+                        }
+                    }));
+    }
+
+    // --- helpers -----------------------------------------------------------------------------
+
+    private static Stream<Path> featureDirs(String kind) throws IOException, URISyntaxException {
+        Path base = coverageRoot().resolve(kind);
+        Assumptions.assumeTrue(Files.isDirectory(base),
+            "coverage examples not found at " + base.toAbsolutePath());
+        try (Stream<Path> s = Files.list(base)) {
+            // Materialise so the directory stream is closed before the dynamic tests run.
+            List<Path> dirs = s.filter(Files::isDirectory).sorted().collect(Collectors.toList());
+            return dirs.stream();
+        }
+    }
+
+    private static Path coverageRoot() throws URISyntaxException {
+        // Prefer the copied test resources on the classpath (location-independent),
+        // fall back to the module-relative source path.
+        var url = JavaFeatureCoverageTest.class.getResource("/de/uka/ilkd/key/java/coverage");
+        if (url != null) {
+            return Paths.get(url.toURI());
+        }
+        return Paths.get("src/test/resources/de/uka/ilkd/key/java/coverage");
+    }
+
+    /** Loads the feature's {@code problem.key}; returns {@code null} on success, else the error. */
+    private static Throwable tryLoad(Path featureDir) {
+        Path problem = featureDir.resolve("problem.key");
+        KeYEnvironment<?> env = null;
+        try {
+            env = KeYEnvironment.load(problem);
+            return null;
+        } catch (Throwable t) {
+            return t;
+        } finally {
+            if (env != null) {
+                try {
+                    env.dispose();
+                } catch (Throwable ignore) {
+                }
+            }
+        }
+    }
+
+    private static String firstMessage(Throwable t) {
+        List<String> msgs = new ArrayList<>();
+        try {
+            for (PositionedString ps : ExceptionTools.getMessages(t)) {
+                msgs.add(ps.getText());
+            }
+        } catch (Throwable ignore) {
+        }
+        String joined = String.join(" | ", msgs);
+        if (joined.isBlank()) {
+            joined = t.getClass().getSimpleName()
+                    + (t.getMessage() != null ? ": " + t.getMessage() : "");
+        }
+        return joined.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/README.md
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/README.md
@@ -1,0 +1,65 @@
+# Java feature coverage examples
+
+Fixtures for `de.uka.ilkd.key.java.JavaFeatureCoverageTest`, which pins down
+which Java language features KeY's front-end currently parses. They also back
+the **Java Coverage** support table in the user documentation
+(*User Guide > Supported Language Features > Java Coverage*).
+
+Layout: one directory per feature, each with a small `.java` file plus a
+`problem.key` (`\javaSource "."; \problem { true }`) that makes KeY parse it:
+
+- `supported/`: features KeY **parses** today. The test loads each and fails
+  if one stops parsing (a front-end regression).
+- `rejected/`: features KeY does **not** parse today (loading throws, usually
+  *"Unsupported element detected given by Java Parser"*). The test fails if one
+  starts parsing, which means the feature became supported and both the test
+  and the documentation table must be updated.
+
+Every `.java` file also compiles with `javac` 21, and uses only types available
+in KeY's default classpath (`JavaRedux`) or types it declares itself, so a load
+failure reflects KeY's front-end and not malformed Java or a missing type.
+
+## Why each rejected example is rejected
+
+Each example isolates a single construct, so its rejection is attributable to
+the feature under test (verified by loading each and inspecting the error):
+
+| Example | Rejected because |
+|---|---|
+| `generics-*` (plain, bounded, wildcard, method, diamond) | converter aborts with *"Unexpected type to convert"* on the type parameter/argument |
+| `local-class` | `Unsupported element: LocalClassDeclarationStmt` |
+| `static-import` | `Unsupported element: ImportDeclaration` (the `static` import) |
+| `annotation-declaration` | `Unsupported element: AnnotationDeclaration` (the `@interface`) |
+| `multi-catch` | `Unsupported element: UnionType` |
+| `lambda` | `Unsupported element: LambdaExpr` |
+| `method-reference` | `Unsupported element: MethodReferenceExpr` |
+| `instanceof-pattern` | `Unsupported element: TypePatternExpr` (the bound pattern) |
+| `switch-expression` | parser rejects `yield` / arrow-switch (syntax error) |
+| `switch-pattern-type` | `Unsupported element: TypePatternExpr` (`case Integer i`) |
+| `switch-pattern-record` | `Unsupported element: TypePatternExpr` (record component of `case Point(...)`) |
+| `record-pattern` | `Unsupported element: TypePatternExpr` (record pattern via `instanceof`) |
+| `switch-enum-unqualified` | KeY cannot resolve the **unqualified** `case RED` label (the enum is declared in the file, so this is the label form, not a missing type) |
+| `module-declaration` | `module-info` currently triggers an internal error (`IndexOutOfBoundsException`) |
+| `var-reference-type` | a `var` with a `String` initializer currently triggers an internal `NullPointerException` |
+
+Because the host construct is otherwise supported (a `switch` statement,
+`instanceof`, a normal class), the failure lands on the tested feature, not on
+its surroundings.
+
+## Notes
+
+- `switch-enum-qualified` vs `switch-enum-unqualified` capture a real quirk: a
+  `switch` over an `enum` only loads with *qualified* case labels
+  (`case E.C:`); the standard unqualified `case C:` fails to resolve.
+- Pattern matching for `switch` is split by pattern kind:
+  `switch-pattern-type` and `switch-pattern-record` are rejected, but a bare
+  `case null` label (`switch-null-label`) actually parses, so it lives in
+  `supported/`. The examples use `switch` *statements*, not `switch`
+  *expressions*, so the failure is attributed to the pattern and not to the
+  (also unsupported) switch-expression form.
+- `var-primitive` / `var-in-for` load, but `var-reference-type` does not.
+- Generics come in five variants (`plain`, `bounded`, `wildcard`, `method`,
+  `diamond`), all rejected.
+- "Parses" is not "soundly reasoned about": `autoboxing` and
+  `try-with-resources` sit in `supported/` because they load, but KeY does not
+  model them soundly (see the documentation's *Comments* column).

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/annotation-declaration/AnnDecl.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/annotation-declaration/AnnDecl.java
@@ -1,0 +1,4 @@
+public class AnnDecl {
+    @interface Marker { int value() default 0; }
+    @Marker(3) int x;
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/annotation-declaration/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/annotation-declaration/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-bounded/GenBounded.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-bounded/GenBounded.java
@@ -1,0 +1,6 @@
+public class GenBounded {
+    interface S { }
+    static class Box<T extends S> { T v; }
+    static class Impl implements S { }
+    Box<Impl> b = new Box<Impl>();
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-bounded/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-bounded/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-diamond/GenDiamond.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-diamond/GenDiamond.java
@@ -1,0 +1,4 @@
+public class GenDiamond {
+    static class Box<T> { T v; }
+    Box<String> b = new Box<>();
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-diamond/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-diamond/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-method/GenMethod.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-method/GenMethod.java
@@ -1,0 +1,4 @@
+public class GenMethod {
+    <T> T id(T x) { return x; }
+    String f() { return id("hi"); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-method/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-method/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-plain/GenPlain.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-plain/GenPlain.java
@@ -1,0 +1,5 @@
+public class GenPlain<T> {
+    T value;
+    T get() { return value; }
+    void set(T v) { value = v; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-plain/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-plain/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-wildcard/GenWildcard.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-wildcard/GenWildcard.java
@@ -1,0 +1,5 @@
+public class GenWildcard {
+    static class Box<T> { T v; }
+    int size(Box<?> b) { return 0; }
+    int f(Box<? extends Object> b) { return 1; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-wildcard/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/generics-wildcard/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/instanceof-pattern/InstPattern.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/instanceof-pattern/InstPattern.java
@@ -1,0 +1,6 @@
+public class InstPattern {
+    int f(Object o) {
+        if (o instanceof String s) { return s.length(); }
+        return 0;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/instanceof-pattern/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/instanceof-pattern/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/lambda/Lambda.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/lambda/Lambda.java
@@ -1,0 +1,4 @@
+public class Lambda {
+    Runnable r = () -> { };
+    int f() { r.run(); return 1; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/lambda/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/lambda/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/local-class/LocalCls.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/local-class/LocalCls.java
@@ -1,0 +1,7 @@
+public class LocalCls {
+    int f() {
+        class Local { int g() { return 9; } }
+        Local l = new Local();
+        return l.g();
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/local-class/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/local-class/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/method-reference/MethodRef.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/method-reference/MethodRef.java
@@ -1,0 +1,5 @@
+public class MethodRef {
+    interface Fn { int apply(String s); }
+    int len(String s) { return s.length(); }
+    Fn f = this::len;
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/method-reference/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/method-reference/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/module-declaration/module-info.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/module-declaration/module-info.java
@@ -1,0 +1,1 @@
+module coverage.test { }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/module-declaration/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/module-declaration/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/multi-catch/MultiCatch.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/multi-catch/MultiCatch.java
@@ -1,0 +1,11 @@
+public class MultiCatch {
+    static class E1 extends Exception { }
+    static class E2 extends Exception { }
+    int f(int x) throws Exception {
+        try {
+            if (x == 1) throw new E1(); else throw new E2();
+        } catch (E1 | E2 e) {
+            return -1;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/multi-catch/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/multi-catch/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/record-pattern/RecordPattern.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/record-pattern/RecordPattern.java
@@ -1,0 +1,7 @@
+public class RecordPattern {
+    record Point(int x, int y) { }
+    int f(Object o) {
+        if (o instanceof Point(int a, int b)) { return a + b; }
+        return 0;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/record-pattern/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/record-pattern/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/p/Consts.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/p/Consts.java
@@ -1,0 +1,5 @@
+package p;
+public class Consts {
+    public static final int FOO = 7;
+    public static int twice(int x) { return 2 * x; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/p/UseStatic.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/p/UseStatic.java
@@ -1,0 +1,6 @@
+package p;
+import static p.Consts.FOO;
+import static p.Consts.twice;
+public class UseStatic {
+    int f() { return twice(FOO); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/static-import/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-enum-unqualified/SwitchEnum.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-enum-unqualified/SwitchEnum.java
@@ -1,0 +1,11 @@
+enum Color { RED, GREEN, BLUE }
+
+public class SwitchEnum {
+    int f(Color c) {
+        switch (c) {
+            case RED:   return 1;
+            case GREEN: return 2;
+            default:    return 3;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-enum-unqualified/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-enum-unqualified/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-expression/SwitchExpr.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-expression/SwitchExpr.java
@@ -1,0 +1,9 @@
+public class SwitchExpr {
+    int f(int x) {
+        return switch (x) {
+            case 1 -> 10;
+            case 2 -> { yield 20; }
+            default -> 0;
+        };
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-expression/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-expression/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-record/SwitchPatternRecord.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-record/SwitchPatternRecord.java
@@ -1,0 +1,11 @@
+public class SwitchPatternRecord {
+    record Point(int x, int y) { }
+    int f(Object o) {
+        int r;
+        switch (o) {
+            case Point(int x, int y): r = x + y; break;
+            default: r = 0;
+        }
+        return r;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-record/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-record/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-type/SwitchPatternType.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-type/SwitchPatternType.java
@@ -1,0 +1,10 @@
+public class SwitchPatternType {
+    int f(Object o) {
+        int r;
+        switch (o) {
+            case Integer i: r = i.intValue(); break;
+            default: r = 0;
+        }
+        return r;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-type/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/switch-pattern-type/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/var-reference-type/VarString.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/var-reference-type/VarString.java
@@ -1,0 +1,3 @@
+public class VarString {
+    int f() { var s = "hi"; return s.length(); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/var-reference-type/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/rejected/var-reference-type/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/annotation-marker/AnnOverride.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/annotation-marker/AnnOverride.java
@@ -1,0 +1,4 @@
+public class AnnOverride {
+    static class A { int f() { return 1; } }
+    static class B extends A { @Override int f() { return 2; } }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/annotation-marker/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/annotation-marker/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/anonymous-class/Anon.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/anonymous-class/Anon.java
@@ -1,0 +1,7 @@
+public class Anon {
+    interface Sup { int val(); }
+    int f() {
+        Sup s = new Sup() { public int val() { return 42; } };
+        return s.val();
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/anonymous-class/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/anonymous-class/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/arrays/Arr.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/arrays/Arr.java
@@ -1,0 +1,4 @@
+public class Arr {
+    int sum(int[] a) { int s = 0; for (int i = 0; i < a.length; i++) s += a[i]; return s; }
+    int grid() { int[][] m = new int[2][3]; m[1][2] = 7; return m[1][2]; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/arrays/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/arrays/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/autoboxing/AutoBox.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/autoboxing/AutoBox.java
@@ -1,0 +1,7 @@
+public class AutoBox {
+    int f() {
+        Integer boxed = 5;
+        int prim = boxed;
+        return prim;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/autoboxing/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/autoboxing/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/control-flow/ControlFlow.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/control-flow/ControlFlow.java
@@ -1,0 +1,13 @@
+public class ControlFlow {
+    int f(int n) {
+        int r = 0;
+        outer:
+        for (int i = 0; i < n; i++) {
+            int j = 0;
+            while (j < i) { if (j == 5) break outer; j++; }
+            do { r++; } while (r < 0);
+        }
+        if (r > 10) { r = 10; } else { r = r + 1; }
+        return r;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/control-flow/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/control-flow/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/core-classes/Classes.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/core-classes/Classes.java
@@ -1,0 +1,8 @@
+public class Classes {
+    interface Shape { int area(); }
+    static class Square implements Shape {
+        int s;
+        public int area() { return s * s; }
+    }
+    int use() { Square q = new Square(); q.s = 3; return q.area(); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/core-classes/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/core-classes/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/default-interface-method/DefaultMethod.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/default-interface-method/DefaultMethod.java
@@ -1,0 +1,8 @@
+public class DefaultMethod {
+    interface Greeter {
+        int base();
+        default int greet() { return base() + 1; }
+    }
+    static class G implements Greeter { public int base() { return 10; } }
+    int f() { return new G().greet(); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/default-interface-method/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/default-interface-method/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-array/ForArray.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-array/ForArray.java
@@ -1,0 +1,3 @@
+public class ForArray {
+    int sum(int[] a) { int s = 0; for (int x : a) s += x; return s; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-array/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-array/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-iterable/ForIterable.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-iterable/ForIterable.java
@@ -1,0 +1,4 @@
+import java.util.List;
+public class ForIterable {
+    int count(List l) { int s = 0; for (Object o : l) s++; return s; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-iterable/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enhanced-for-iterable/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-constant-body/EnumAnon.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-constant-body/EnumAnon.java
@@ -1,0 +1,7 @@
+public class EnumAnon {
+    enum Op {
+        ADD { int apply(int a, int b) { return a + b; } },
+        SUB { int apply(int a, int b) { return a - b; } };
+        abstract int apply(int a, int b);
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-constant-body/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-constant-body/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-simple/EnumSimple.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-simple/EnumSimple.java
@@ -1,0 +1,5 @@
+public class EnumSimple {
+    enum Dir { UP, DOWN }
+    Dir d = Dir.UP;
+    boolean up() { return d == Dir.UP; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-simple/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/enum-simple/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/exceptions/Exceptions.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/exceptions/Exceptions.java
@@ -1,0 +1,12 @@
+public class Exceptions {
+    int f(int x) {
+        try {
+            if (x < 0) throw new RuntimeException("neg");
+            return 1;
+        } catch (RuntimeException e) {
+            return -1;
+        } finally {
+            x = 0;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/exceptions/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/exceptions/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/float-double/Floats.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/float-double/Floats.java
@@ -1,0 +1,4 @@
+public class Floats {
+    double f(double a, float b) { return a + b * 2.0; }
+    strictfp double g(double x) { return x * x; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/float-double/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/float-double/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/inner-class/InnerCls.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/inner-class/InnerCls.java
@@ -1,0 +1,5 @@
+public class InnerCls {
+    int base = 5;
+    class Inner { int get() { return base; } }
+    int f() { Inner i = new InnerCls().new Inner(); return i.get(); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/inner-class/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/inner-class/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/instanceof/InstanceOf.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/instanceof/InstanceOf.java
@@ -1,0 +1,3 @@
+public class InstanceOf {
+    boolean f(Object o) { return o instanceof String; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/instanceof/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/instanceof/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/nested-static-class/NestedStatic.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/nested-static-class/NestedStatic.java
@@ -1,0 +1,4 @@
+public class NestedStatic {
+    static class Inner { int v; }
+    int f() { Inner i = new Inner(); i.v = 2; return i.v; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/nested-static-class/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/nested-static-class/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/numeric-literals/Literals.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/numeric-literals/Literals.java
@@ -1,0 +1,7 @@
+public class Literals {
+    int bin = 0b1010;
+    int us  = 1_000_000;
+    int hex = 0xFF;
+    int oct = 010;
+    long big = 9_000_000_000L;
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/numeric-literals/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/numeric-literals/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/private-interface-method/PrivateIface.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/private-interface-method/PrivateIface.java
@@ -1,0 +1,9 @@
+public class PrivateIface {
+    interface I {
+        int pub();
+        private int helper() { return 5; }
+        default int use() { return helper() + pub(); }
+    }
+    static class C implements I { public int pub() { return 1; } }
+    int f() { return new C().use(); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/private-interface-method/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/private-interface-method/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/record/Rec.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/record/Rec.java
@@ -1,0 +1,3 @@
+public record Rec(int x, int y) {
+    int sum() { return x + y; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/record/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/record/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/sealed/Sealed.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/sealed/Sealed.java
@@ -1,0 +1,2 @@
+public sealed class Sealed permits Sub { }
+final class Sub extends Sealed { }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/sealed/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/sealed/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-enum-qualified/SwitchEnumQ.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-enum-qualified/SwitchEnumQ.java
@@ -1,0 +1,11 @@
+enum ColorQ { RED, GREEN, BLUE }
+
+public class SwitchEnumQ {
+    int f(ColorQ c) {
+        switch (c) {
+            case ColorQ.RED:   return 1;
+            case ColorQ.GREEN: return 2;
+            default:           return 3;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-enum-qualified/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-enum-qualified/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-int/SwitchInt.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-int/SwitchInt.java
@@ -1,0 +1,9 @@
+public class SwitchInt {
+    int f(int x) {
+        switch (x) {
+            case 1: return 10;
+            case 2: return 20;
+            default: return 0;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-int/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-int/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-null-label/SwitchNullLabel.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-null-label/SwitchNullLabel.java
@@ -1,0 +1,11 @@
+public class SwitchNullLabel {
+    int f(String s) {
+        int r;
+        switch (s) {
+            case null: r = -1; break;
+            case "x":  r = 1;  break;
+            default:   r = 0;
+        }
+        return r;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-null-label/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-null-label/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-string/StringSwitch.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-string/StringSwitch.java
@@ -1,0 +1,9 @@
+public class StringSwitch {
+    int f(String s) {
+        switch (s) {
+            case "a": return 1;
+            case "b": return 2;
+            default:  return 0;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-string/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/switch-string/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/text-block/TextBlock.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/text-block/TextBlock.java
@@ -1,0 +1,5 @@
+public class TextBlock {
+    String s = """
+        hello
+        world""";
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/text-block/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/text-block/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/try-with-resources/TryRes.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/try-with-resources/TryRes.java
@@ -1,0 +1,10 @@
+public class TryRes {
+    static class Res implements java.io.Closeable {
+        public void close() throws java.io.IOException { }
+    }
+    int f() throws java.io.IOException {
+        try (Res r = new Res()) {
+            return 1;
+        }
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/try-with-resources/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/try-with-resources/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-in-for/VarInFor.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-in-for/VarInFor.java
@@ -1,0 +1,7 @@
+public class VarInFor {
+    int f() {
+        int r = 0;
+        for (var i = 0; i < 3; i++) { r = r + i; }
+        return r;
+    }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-in-for/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-in-for/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-primitive/VarInt.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-primitive/VarInt.java
@@ -1,0 +1,3 @@
+public class VarInt {
+    int f() { var x = 3; return x; }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-primitive/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/var-primitive/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/varargs/VarArgs.java
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/varargs/VarArgs.java
@@ -1,0 +1,4 @@
+public class VarArgs {
+    int sum(int... xs) { int s = 0; for (int x : xs) s += x; return s; }
+    int f() { return sum(1, 2, 3); }
+}

--- a/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/varargs/problem.key
+++ b/key.core/src/test/resources/de/uka/ilkd/key/java/coverage/supported/varargs/problem.key
@@ -1,0 +1,3 @@
+\javaSource ".";
+
+\problem { true }


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

This PR adds 48 test cases for Java constructs that are parser supported (it is not checked whether KeY can deal with them on a calculus level).

The tests record the current status quo, this means they fail when a supported construct can no longer be supported and they fail if a construct becomes supported (in the latter case the error message says to change the test case to refelct that a new feature is supported)

One thing that stands out is that we can parse ``var x = 0;``  if the right-hand side is a primtiive type but something with a reference type ``var x = "hi";`` fails.

The tests are an artifact  of determining the Java coverage for KeY 3.0 (see https://keyproject.github.io/key-docs/user/SupportedFeatures/JavaCoverage/)

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Other: Adds additional tests

## Ensuring quality
    
- I have tested the feature as follows: The added feature are tests

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

Created with AI tooling suuport

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
