### PR TITLE
Enforce profile when selected via file chooser

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/AbstractProblemLoader.java
@@ -108,7 +108,7 @@ public abstract class AbstractProblemLoader {
      * {@code false} the {@link Profile} specified by the problem file will be used for new proofs
      * (with the default profile as fallback if the file specifies none).
      */
-    private final boolean forceNewProfileOfNewProofs;
+    private boolean forceNewProfileOfNewProofs;
 
     /**
      * {@code true} to call {@link ProblemLoaderControl#selectProofObligation(InitConfig)} if no
@@ -836,6 +836,10 @@ public abstract class AbstractProblemLoader {
         this.proofFilename = proofFilename;
     }
 
+    public void forceNewProfileOfNewProofs(boolean forceNewProfileOfNewProofs) {
+        this.forceNewProfileOfNewProofs = forceNewProfileOfNewProofs;
+    }
+
     public boolean isLoadSingleJavaFile() {
         return loadSingleJavaFile;
     }
@@ -857,6 +861,7 @@ public abstract class AbstractProblemLoader {
     public Configuration getAdditionalProfileOptions() {
         return additionalProfileOptions;
     }
+
 
 
     public static class ReplayResult {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/OpenFileAction.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/actions/OpenFileAction.java
@@ -67,6 +67,7 @@ public class OpenFileAction extends MainWindowAction {
             var selectedProfile = options.getSelectedProfile();
             var additionalProfileOptions = options.getAdditionalProfileOptions();
             mainWindow.loadProblem(file, pl -> {
+                pl.forceNewProfileOfNewProofs(selectedProfile != null);
                 pl.setProfileOfNewProofs(selectedProfile);
                 pl.setAdditionalProfileOptions(additionalProfileOptions);
                 pl.setLoadSingleJavaFile(options.isOnlyLoadSingleJavaFile());


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

While settings in files were respected again, the file chooser needs also to enforce the chosen profile (if one was selected).

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality
- I have tested the feature as follows: tested that a selected profile is used and that a file with a given profile loads the in file specified profile 

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
