### PR TITLE
Fix model fields resolution when multiple heaps present

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLAttributeResolver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/translation/SLAttributeResolver.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.speclang.translation;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import de.uka.ilkd.key.java.JavaInfo;
@@ -138,10 +137,8 @@ public final class SLAttributeResolver extends SLExpressionResolver {
                         heapLDT.getFieldSymbolForPV((LocationVariable) attribute, services);
                     JTerm attributeTerm;
                     if (attribute.isModel()) {
-                        List<LocationVariable> heaps = new ArrayList<>();
-                        for (LocationVariable h : HeapContext.getModifiableHeaps(services, false)) {
-                            heaps.add(h);
-                        }
+                        List<LocationVariable> heaps =
+                            HeapContext.getModifiableHeaps(services, false);
                         JTerm[] subs = new JTerm[fieldSymbol.arity()];
                         for (int j = 0; j < heaps.size(); j++) {
                             subs[j] = services.getTermBuilder().var(heaps.get(j));


### PR DESCRIPTION

## Intended Change

Model fields without a represents or accessible clause could not be used in JavaRedux
as permissions could not build the term (wrong arity).

Found out when trying to specify addSuppressed in Throwable of PR #3918.

This PR should fix it.

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

## Type of pull request

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

- I have tested the feature as follows: CI test suite, MErged on local branch with PR 3918 and activated model fields in Throwable

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
