### PR TITLE
Set version to 3.1.0

### DIFF
--- a/.github/workflows/nightlydeploy.yml
+++ b/.github/workflows/nightlydeploy.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create --generate-notes --title "Nightly Release" \
-             --prerelease --notes-start-tag KEY-2.12.3 \
+             --prerelease --notes-start-tag KEY-3.0.0-rc \
              nightly key.ui/build/libs/key-*-exe.jar key-javadoc.tar.xz
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Tests](https://github.com/KeYProject/key/actions/workflows/tests.yml/badge.svg)](https://github.com/KeYProject/key/actions/workflows/tests.yml) [![CodeQuality](https://github.com/KeYProject/key/actions/workflows/code_quality.yml/badge.svg)](https://github.com/KeYProject/key/actions/workflows/code_quality.yml)
 
-![Maven metadata URL](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fkey-project%2Fkey.core%2Fmaven-metadata.xml&label=maven%20snapshots)
 ![Maven metadata URL](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Forg%2Fkey-project%2Fkey.core%2Fmaven-metadata.xml&label=maven%20central)
 
 
@@ -18,7 +17,7 @@ For more information, refer to
   * [Verification of `java.util.IdentityHashMap`](https://doi.org/10.1007/978-3-031-07727-2_4),
   * [Google Award for analysing a bug in `LinkedList`](https://www.key-project.org/2023/07/23/cwi-researchers-win-google-award-for-finding-a-bug-in-javas-linkedlist-using-key/)
 
-The current version of KeY is 2.12.2, licensed under GPL v2.
+The current version of KeY is 3.1.0-dev, licensed under GPL v2.
 
 
 Feel free to use the project templates to get started using KeY:
@@ -30,7 +29,7 @@ Feel free to use the project templates to get started using KeY:
 
 * Hardware: >=2 GB RAM
 * Operating System: Linux/Unix, MacOSX, Windows
-* Java 17 or newer
+* Java 21 or newer
 * Optionally, KeY can make use of the following binaries:
   * SMT Solvers:
     * [Z3](https://github.com/Z3Prover/z3#z3)

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ static def getDate() {
 def build = System.env.BUILD_NUMBER == null ? "-dev" : "-${System.env.BUILD_NUMBER}"
 
 group = "org.key-project"
-version = "3.0.0$build"
+version = "3.1.0$build"
 
 subprojects {
     apply plugin: "java"


### PR DESCRIPTION
## Intended Change

After forking the release branch to `prerelease/KeY-3.0.0`, the main branch is set to the next version `3.1.0` to avoid confusion between the two branches. 

Also small updates on `README.md`.

After this PR, `main` is re-opened for new features. 

## Type of pull request
- There are **no** changes to the (Java) code
- There are **no** changes to the taclet rule base
- There are **no** changes to the deployment/CI infrastructure
- **But there is a change to Gradle**


## Ensuring quality

- No tests required. It is just the version. 