### PR TITLE
Remove proof-tree node border

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1472,7 +1472,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 setBorder(BorderFactory.createLineBorder(style.border));
             } else {
                 // set default
-                setBorder(BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
+                setBorder(null);
             }
 
             setFont(getFont().deriveFont(Font.PLAIN));


### PR DESCRIPTION
## Intended Change

Removes the ugly border around proof-tree nodes that was introduces during the GUI rework last year in #3599

Before:

<img width="630" height="701" alt="Screenshot_2026-07-14_18-41-32" src="https://github.com/user-attachments/assets/1bf5bcfc-aeb3-428f-b602-83be7cbc35f5" />

After:

<img width="613" height="656" alt="Screenshot_2026-07-14_18-39-52" src="https://github.com/user-attachments/assets/ee785b05-adb1-495e-b970-09f124f4c1b3" />


## Type of pull request

- Non-breaking GUI change


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
