### PR TITLE
Only recreate Isabelle session files if path has actually changed

### DIFF
--- a/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/IsabelleTranslationSettings.java
+++ b/keyext.isabelletranslation/src/main/java/org/key_project/isabelletranslation/IsabelleTranslationSettings.java
@@ -156,7 +156,7 @@ public class IsabelleTranslationSettings extends AbstractSettings {
     public void readSettings(Properties props) {
         isabellePath = Path.of(props.getProperty(isabellePathKey));
         Path newTranslationPath = Path.of(props.getProperty(translationPathKey));
-        if (newTranslationPath != translationPath) {
+        if (!newTranslationPath.equals(translationPath)) {
             translationPath = newTranslationPath;
             createSessionFiles();
         }
@@ -180,7 +180,7 @@ public class IsabelleTranslationSettings extends AbstractSettings {
 
         Path newTranslationPath =
             Path.of(props.getString(translationPathKey, translationPath.toString()));
-        if (newTranslationPath != translationPath) {
+        if (!newTranslationPath.equals(translationPath)) {
             translationPath = newTranslationPath;
             createSessionFiles();
         }


### PR DESCRIPTION
## Intended Change

Only recreate Isabelle session files if the Isabelle settings path has actually changed. The paths must be compared using `equals` instead of `==`



The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
