### PR TITLE
Fix file dependency for runAntlr4KeY

### DIFF
--- a/key.core/build.gradle
+++ b/key.core/build.gradle
@@ -191,6 +191,7 @@ def antlr4OutputKey = "$projectDir/build/generated-src/antlr4/main/de/uka/ilkd/k
 tasks.register('runAntlr4Key', JavaExec) {
     //see incremental task api, prevents rerun if nothing has changed.
     inputs.files "src/main/antlr4/JavaKeYLexer.g4", "src/main/antlr4/JavaKeYParser.g4"
+    inputs.files fileTree("../key.ncore/src/main/antlr") { include "*.g4" }
     outputs.dir antlr4OutputKey
     classpath = configurations.antlr4
     mainClass.set("org.antlr.v4.Tool")


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->
This pull request resolves #3915.

## Intended Change

This PR adds the ANTLR files explicitly as input files for `key.core`'s ANTLR task. It's not pretty but it works.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: Tested the steps in #3915 (and comments therein)

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
