### PR TITLE
Relax restrictions for two taclets

### DIFF
--- a/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/booleanRules.key
+++ b/key.core/src/main/resources/de/uka/ilkd/key/proof/rules/booleanRules.key
@@ -97,6 +97,7 @@
         \schemaVar \term [rigid] boolean br;
         \assumes( ==> br = TRUE)
         \find(br)
+        \ignoreUpdateLevel // safe as only rigid terms are matched
         \replacewith(FALSE)
         \heuristics(apply_equations)
         \displayname "apply_eq_boolean"
@@ -106,6 +107,7 @@
         \schemaVar \term [rigid] boolean br;
         \assumes( ==> br = FALSE)
         \find(br)
+        \ignoreUpdateLevel // safe as only rigid terms are matched
         \replacewith(TRUE)
         \heuristics(apply_equations)
         \displayname "apply_eq_boolean"

--- a/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
@@ -1,5 +1,5 @@
 # This files contains representation of taclets, which are accepted and revised.
-# Date: Wed Jul 22 17:10:12 CEST 2026
+# Date: Sat Jul 25 10:22:38 CEST 2026
 
 == abortJavaCardTransactionAPI (abortJavaCardTransactionAPI) =========================================
 abortJavaCardTransactionAPI {
@@ -1006,7 +1006,7 @@ Choices: true}
 apply_eq_boolean_rigid {
 \assumes ([]==>[equals(br,TRUE)]) 
 \find(br)
-\sameUpdateLevel\replacewith(FALSE) 
+\replacewith(FALSE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -1014,7 +1014,7 @@ Choices: true}
 apply_eq_boolean_rigid_2 {
 \assumes ([]==>[equals(br,FALSE)]) 
 \find(br)
-\sameUpdateLevel\replacewith(TRUE) 
+\replacewith(TRUE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Relax application restriction for two taclets where it is save to use \ignoreUpdateLevel
Fixes reloadability of some proofs.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- There are changes to the taclet rule base

## Ensuring quality

    - I made sure that introduced/changed code is well documented (javadoc and inline comments).

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
