### PR TITLE
Cache subtype computations in KeYProgModelInfo

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
@@ -56,6 +56,21 @@ public class KeYProgModelInfo {
     private final JP2KeYTypeConverter typeConverter;
     private final Map<KeYJavaType, Map<String, IProgramMethod>> implicits = new LinkedHashMap<>();
 
+    /**
+     * Caches subtype lookup. First it is a general win, but second JavaParser pretty prints AST
+     * nodes
+     * on every as part of checking assignability, which causes a lot of String creations.
+     * The cache is invalidated if the backing Java models number of types changes
+     * {@code subtypeCachedSize}.
+     */
+    private final Map<KeYJavaType, List<ResolvedReferenceTypeDeclaration>> subtypeCache =
+        new HashMap<>();
+
+    /** Size of the type model {@link #subtypeCache} was computed from. */
+    private int subtypeCachedSize = -1;
+
+
+
     public KeYProgModelInfo(JavaService service) {
         this.typeConverter = service.getTypeConverter();
         this.mapping = service.getMapping();
@@ -507,8 +522,38 @@ public class KeYProgModelInfo {
 
     /**
      * returns all proper subtypes of class <code>ct</code> (i.e. without <code>ct</code> itself)
+     *
+     * @return an unmodifiable list of all proper subtypes
      */
     private List<ResolvedReferenceTypeDeclaration> getAllRecoderSubtypes(KeYJavaType ct) {
+        final int size = rec2key().elemsRec().size();
+        synchronized (subtypeCache) {
+            if (size != subtypeCachedSize) {
+                subtypeCache.clear();
+                subtypeCachedSize = size;
+            }
+            List<ResolvedReferenceTypeDeclaration> hit = subtypeCache.get(ct);
+            if (hit != null) {
+                return hit;
+            }
+        }
+        // Computed outside the lock: this is the expensive part and it only reads the model.
+        final List<ResolvedReferenceTypeDeclaration> res =
+            Collections.unmodifiableList(computeAllRecoderSubtypes(ct));
+        synchronized (subtypeCache) {
+            // check if the number of known types has changed and invalidate cache if so
+            // assumes: no changes to existing types happen
+            if (rec2key().elemsRec().size() == subtypeCachedSize) {
+                subtypeCache.put(ct, res);
+            }
+        }
+        return res;
+    }
+
+    /**
+     * computes all proper subtypes of class <code>ct</code> (i.e. without <code>ct</code> itself)
+     */
+    private List<ResolvedReferenceTypeDeclaration> computeAllRecoderSubtypes(KeYJavaType ct) {
         final ResolvedType rt = getJavaParserType(ct);
         final ResolvedReferenceTypeDeclaration rtAsTypeDecl =
             rt.asReferenceType().getTypeDeclaration().get();


### PR DESCRIPTION
## Intended Change

Cache subtype relations of the Java model. Speeds up lookup in loading and proof search.
In general, but in particular because at each lookup JavaParser generates and uses pretty printed Strings
to decide assignability between types.

## Type of pull request

- There are changes to the (Java) code

## Ensuring quality
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.

Part of going through the remnants of different performance fixes.

Partially gnerated/identified with AI support. 

