### PR TITLE
Forgotten commit from 3.0 release

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1472,7 +1472,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 setBorder(BorderFactory.createLineBorder(style.border));
             } else {
                 // set default
-                setBorder(BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
+                setBorder(null);
             }
 
             setFont(getFont().deriveFont(Font.PLAIN));


### PR DESCRIPTION
In #3941, the commit c7e163d31e was forgotten, so the borders in the proof tree reappeared (see #3928).