### PR TITLE
Fix for ImmutableList.take(int) 

### DIFF
--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableSLList.java
@@ -101,7 +101,7 @@ abstract class ImmutableSLList<T extends @Nullable Object> implements ImmutableL
         ImmutableList<T> list = this;
         for (int i = 0; i < elems; i++) {
             seq.add(list.head());
-            list = tail();
+            list = list.tail();
         }
         return ImmutableList.fromList(seq);
     }

--- a/key.util/src/test/java/org/key_project/util/testcase/collection/TestSLListOfString.java
+++ b/key.util/src/test/java/org/key_project/util/testcase/collection/TestSLListOfString.java
@@ -217,6 +217,20 @@ public class TestSLListOfString {
         assertEquals("[Dies,ist,ein,Test]", newList.toString());
     }
 
+    @Test
+    public void testTake() {
+        ImmutableList<String> newList = ImmutableList.nil();
+
+        for (int i = str.length - 1; i >= 0; i--) {
+            newList = newList.prepend(str[i]);
+        }
+
+        ImmutableList<String> expected = ImmutableList.of(str[0], str[1], str[2]);
+        ImmutableList<String> actual = newList.take(3);
+        assertEquals(3, actual.size());
+        assertEquals(expected, actual);
+    }
+
 
     public static void performanceTest(int n) {
         LOGGER.info("Performance Test for " + n + " elements");


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Fixes method ImmutableList#take(n) for n > 2

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code
## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I added new test case(s) for new functionality.
## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
