### PR TITLE
introduce the "script-aware script" button in the auto selection

### DIFF
--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/MainWindow.java
@@ -820,10 +820,10 @@ public final class MainWindow extends JFrame {
                 IconFactory.automationWithOverlay(TOOLBAR_ICON_SIZE, "S")),
             new MacroAutomationAction(this,
                 new de.uka.ilkd.key.macros.AutoPilotPrepareProofMacro(),
-                IconFactory.automationWithOverlay(TOOLBAR_ICON_SIZE, "P"))
-        // when it is finished ... new MacroAutomationAction(this ... ScriptMacro ... "J" (*J*ML
-        // scripts)
-        );
+                IconFactory.automationWithOverlay(TOOLBAR_ICON_SIZE, "P")),
+            new MacroAutomationAction(this,
+                new de.uka.ilkd.key.macros.ScriptAwareMacro(),
+                IconFactory.automationWithOverlay(TOOLBAR_ICON_SIZE, "J")));
     }
 
     /**

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/fonticons/IconFactory.java
@@ -4,6 +4,8 @@
 package de.uka.ilkd.key.gui.fonticons;
 
 import java.awt.*;
+import java.awt.font.GlyphVector;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.ArrayList;
@@ -189,7 +191,7 @@ public final class IconFactory {
      * Additional horizontal space in pixels reserved for the overlay letter in
      * toolbar automation icons created by {@link #automationWithOverlay(int, String)}.
      */
-    public static final int TOOLBAR_INDICATOR_EXTRA_SPACE = 5;
+    public static final int TOOLBAR_INDICATOR_EXTRA_SPACE = 7;
     /**
      * Additional horizontal space in pixels for wider auto buttons.
      */
@@ -414,19 +416,21 @@ public final class IconFactory {
 
         // Draw letter overlay
         g2d.setColor(Color.BLACK);
-        Font font = new Font(Font.SANS_SERIF, Font.BOLD | Font.ITALIC,
+        Font font = new Font(Font.MONOSPACED, Font.BOLD | Font.ITALIC,
             (int) (baseIcon.getIconHeight() * 0.9f));
         g2d.setFont(font);
 
-        FontMetrics fm = g2d.getFontMetrics();
-        int textWidth = fm.stringWidth(letter);
-        int textHeight = fm.getAscent() - fm.getDescent();
+        GlyphVector glyphVector = font.createGlyphVector(g2d.getFontRenderContext(), letter);
+        Rectangle2D tightBounds = glyphVector.getVisualBounds();
 
-        // Position letter in bottom-right corner
-        int x = baseIcon.getIconWidth() - textWidth;
+        int overlayRight = TOOLBAR_EXTRA_WIDTH + TOOLBAR_INDICATOR_EXTRA_SPACE
+                + baseIcon.getIconWidth() - 1;
+        int overlayBottom = baseIcon.getIconHeight() - 1;
 
-        g2d.drawString(letter, x + TOOLBAR_INDICATOR_EXTRA_SPACE + TOOLBAR_EXTRA_WIDTH,
-            baseIcon.getIconHeight());
+        int baselineX = overlayRight - (int) Math.ceil(tightBounds.getMaxX());
+        int baselineY = overlayBottom - (int) Math.ceil(tightBounds.getMaxY());
+
+        g2d.drawString(letter, baselineX, baselineY);
         g2d.dispose();
 
         return new ImageIcon(image);


### PR DESCRIPTION
## Intended Change

As planned: Add the script-aware auto macro as one of the options in the dropdown menu

## Plan

This has been commented out in the sources. But now with scripts available in 3.0, this button should also be available in 3.0.

I suggest this be backported to 3.0.1 as well.

Done:
* Added a "J" version of the button for the script aware macro
* Fixed the outline computation in the icon factory, and added 2 px more space

## Type of pull request

- New *micro* feature (non-breaking change which adds functionality)

## Ensuring quality

- I checked the macro behaved as intended.

## Additional information and contact(s)

Should go to 3.0.1!

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
