### PR TITLE
Fix Taclet printing wrt \sameUpdateLevel

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/rule/RewriteTaclet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/RewriteTaclet.java
@@ -184,11 +184,21 @@ public class RewriteTaclet extends FindTaclet {
         return polarity;
     }
 
-
     @Override
     protected StringBuffer toStringFind(StringBuffer sb) {
         StringBuffer res = super.toStringFind(sb);
-        return res.append(applicationRestriction().toString());
+        return res.append(applicationRestriction().toString(needsSameUpdateLevel()));
+    }
+
+    private boolean needsSameUpdateLevel() {
+        if (!assumesSequent.isEmpty()) {
+            return true;
+        }
+        for (var tgt : goalTemplates) {
+            if (!tgt.sequent().isEmpty())
+                return true;
+        }
+        return false;
     }
 
     public SequentFormula getRewriteResult(Goal goal, TermLabelState termLabelState,

--- a/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/nparser/AdtTests.java
@@ -31,7 +31,7 @@ public class AdtTests {
             DT_Nat#Dec_pred#succ#EQ {
             \\assumes ([equals(succ(pred_sv),pred_x)]==>[])\s
             \\find(pred(pred_x))
-            \\sameUpdateLevel\\replacewith(pred_sv)\s
+            \\replacewith(pred_sv)\s
             \\heuristics(simplify)
             Choices: true}""";
 

--- a/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
+++ b/key.core/src/test/resources/de/uka/ilkd/key/nparser/taclets.old.txt
@@ -1,5 +1,5 @@
 # This files contains representation of taclets, which are accepted and revised.
-# Date: Fri Aug 07 13:53:49 CEST 2026
+# Date: Tue Aug 11 14:35:00 CEST 2026
 
 == abortJavaCardTransactionAPI (abortJavaCardTransactionAPI) =========================================
 abortJavaCardTransactionAPI {
@@ -41,14 +41,14 @@ Choices: reach:on}
 == acosIsNaN (acosIsNaN) =========================================
 acosIsNaN {
 \find(acosDouble(arg))
-\sameUpdateLevel\add [imp(or(or(doubleIsNaN(arg),ltDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(acosDouble(arg)))]==>[] 
+\add [imp(or(or(doubleIsNaN(arg),ltDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(acosDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == acosRange (acosRange) =========================================
 acosRange {
 \find(acosDouble(arg))
-\sameUpdateLevel\add [imp(and(geqDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),and(geqDouble(acosDouble(arg),DFP(0(#))),leqDouble(acosDouble(arg),DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(geqDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),and(geqDouble(acosDouble(arg),DFP(0(#))),leqDouble(acosDouble(arg),DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -568,7 +568,7 @@ Choices: programRules:Java}
 allFieldsSubsetOf {
 \assumes ([subset(allFields(o),s)]==>[]) 
 \find(elementOf(o,f,s))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -733,7 +733,7 @@ Choices: true}
 applyEq {
 \assumes ([equals(s,t1)]==>[]) 
 \find(s)
-\sameUpdateLevel\replacewith(t1) 
+\replacewith(t1) 
 \heuristics(apply_select_eq, apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -741,7 +741,7 @@ Choices: true}
 applyEqReverse {
 \assumes ([equals(s,t1)]==>[]) 
 \find(t1)
-\sameUpdateLevel\replacewith(s) 
+\replacewith(s) 
 \heuristics(apply_auxiliary_eq)
 Choices: true}
 -----------------------------------------------------
@@ -749,7 +749,7 @@ Choices: true}
 applyEqRigid {
 \assumes ([equals(sr,tr1)]==>[]) 
 \find(sr)
-\replacewith(tr1) 
+\ignoreUpdateLevel\replacewith(tr1) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -990,7 +990,7 @@ Choices: true}
 apply_eq_boolean {
 \assumes ([]==>[equals(bo,TRUE)]) 
 \find(bo)
-\sameUpdateLevel\replacewith(FALSE) 
+\replacewith(FALSE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -998,7 +998,7 @@ Choices: true}
 apply_eq_boolean_2 {
 \assumes ([]==>[equals(bo,FALSE)]) 
 \find(bo)
-\sameUpdateLevel\replacewith(TRUE) 
+\replacewith(TRUE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -1006,7 +1006,7 @@ Choices: true}
 apply_eq_boolean_rigid {
 \assumes ([]==>[equals(br,TRUE)]) 
 \find(br)
-\replacewith(FALSE) 
+\ignoreUpdateLevel\replacewith(FALSE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -1014,7 +1014,7 @@ Choices: true}
 apply_eq_boolean_rigid_2 {
 \assumes ([]==>[equals(br,FALSE)]) 
 \find(br)
-\replacewith(TRUE) 
+\ignoreUpdateLevel\replacewith(TRUE) 
 \heuristics(apply_equations)
 Choices: true}
 -----------------------------------------------------
@@ -1022,7 +1022,7 @@ Choices: true}
 apply_eq_monomials {
 \assumes ([equals(applyEqDivisor,i0)]==>[]) 
 \find(applyEqDividend)
-\sameUpdateLevel\replacewith(add(mul(#divideMonomials(applyEqDividend,applyEqDivisor),add(i0,mul(applyEqDivisor,Z(neglit(1(#)))))),applyEqDividend)) 
+\replacewith(add(mul(#divideMonomials(applyEqDividend,applyEqDivisor),add(i0,mul(applyEqDivisor,Z(neglit(1(#)))))),applyEqDividend)) 
 \heuristics(notHumanReadable, apply_equations, polySimp_applyEq)
 Choices: true}
 -----------------------------------------------------
@@ -1030,7 +1030,7 @@ Choices: true}
 apply_eq_monomials_rigid {
 \assumes ([equals(applyEqDivisorr,i0r)]==>[]) 
 \find(applyEqDividend)
-\replacewith(add(mul(#divideMonomials(applyEqDividend,applyEqDivisorr),add(i0r,mul(applyEqDivisorr,Z(neglit(1(#)))))),applyEqDividend)) 
+\ignoreUpdateLevel\replacewith(add(mul(#divideMonomials(applyEqDividend,applyEqDivisorr),add(i0r,mul(applyEqDivisorr,Z(neglit(1(#)))))),applyEqDividend)) 
 \heuristics(notHumanReadable, apply_equations, polySimp_applyEqRigid)
 Choices: true}
 -----------------------------------------------------
@@ -1038,7 +1038,7 @@ Choices: true}
 apply_eq_pseudo_eq {
 \assumes ([equals(mul(aePseudoLeft,aePseudoLeftCoeff),aePseudoRight)]==>[]) 
 \find(equals(aePseudoTargetLeft,aePseudoTargetRight))
-\sameUpdateLevel\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),not(equals(aePseudoLeftCoeff,Z(0(#))))),equals(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),equals(aePseudoTargetLeft,aePseudoTargetRight))) 
+\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),not(equals(aePseudoLeftCoeff,Z(0(#))))),equals(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),equals(aePseudoTargetLeft,aePseudoTargetRight))) 
 \heuristics(notHumanReadable, notHumanReadable, polySimp_applyEqPseudo, polySimp_leftNonUnit)
 Choices: true}
 -----------------------------------------------------
@@ -1046,7 +1046,7 @@ Choices: true}
 apply_eq_pseudo_geq {
 \assumes ([equals(mul(aePseudoLeft,aePseudoLeftCoeff),aePseudoRight)]==>[]) 
 \find(geq(aePseudoTargetLeft,aePseudoTargetRight))
-\sameUpdateLevel\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),gt(aePseudoLeftCoeff,Z(0(#)))),geq(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),geq(aePseudoTargetLeft,aePseudoTargetRight))) 
+\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),gt(aePseudoLeftCoeff,Z(0(#)))),geq(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),geq(aePseudoTargetLeft,aePseudoTargetRight))) 
 \heuristics(notHumanReadable, polySimp_applyEqPseudo, polySimp_leftNonUnit)
 Choices: true}
 -----------------------------------------------------
@@ -1054,7 +1054,7 @@ Choices: true}
 apply_eq_pseudo_leq {
 \assumes ([equals(mul(aePseudoLeft,aePseudoLeftCoeff),aePseudoRight)]==>[]) 
 \find(leq(aePseudoTargetLeft,aePseudoTargetRight))
-\sameUpdateLevel\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),gt(aePseudoLeftCoeff,Z(0(#)))),leq(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),leq(aePseudoTargetLeft,aePseudoTargetRight))) 
+\replacewith(if-then-else(and(equals(aePseudoTargetLeft,mul(aePseudoLeft,aePseudoTargetFactor)),gt(aePseudoLeftCoeff,Z(0(#)))),leq(mul(aePseudoRight,aePseudoTargetFactor),mul(aePseudoTargetRight,aePseudoLeftCoeff)),leq(aePseudoTargetLeft,aePseudoTargetRight))) 
 \heuristics(notHumanReadable, polySimp_applyEqPseudo, polySimp_leftNonUnit)
 Choices: true}
 -----------------------------------------------------
@@ -1121,14 +1121,14 @@ Choices: programRules:Java}
 == arrayLengthIsAShort (arrayLengthIsAShort) =========================================
 arrayLengthIsAShort {
 \find(length(o))
-\sameUpdateLevel\add [inShort(length(o))]==>[] 
+\add [inShort(length(o))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: (programRules:Java & JavaCard:on)}
 -----------------------------------------------------
 == arrayLengthNotNegative (arrayLengthNotNegative) =========================================
 arrayLengthNotNegative {
 \find(length(o))
-\sameUpdateLevel\add [geq(length(o),Z(0(#)))]==>[] 
+\add [geq(length(o),Z(0(#)))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -1147,7 +1147,7 @@ Choices: programRules:Java}
 array_self_reference {
 \assumes ([wellFormed(heapSV)]==>[equals(array,null)]) 
 \find(arrayStoreValid(array,select<[G]>(heapSV,array,arr(idx))))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(simplify_java)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -1155,7 +1155,7 @@ Choices: programRules:Java}
 array_self_reference_eq {
 \assumes ([wellFormed(heapSV),equals(select<[G]>(heapSV,array,arr(idx)),EQ)]==>[equals(array,null)]) 
 \find(arrayStoreValid(array,EQ))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(simplify_java)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -1163,7 +1163,7 @@ Choices: programRules:Java}
 array_store_known_dynamic_array_type {
 \assumes ([equals(exactInstance<[J]>(array),TRUE)]==>[]) 
 \find(arrayStoreValid(array,obj))
-\sameUpdateLevel\varcond(\isReference[non_null]( J ))
+\varcond(\isReference[non_null]( J ))
 \replacewith(or(equals(obj,null),equals(#arrayBaseInstanceOf(exactInstance<[J]>(array),obj),TRUE))) 
 \heuristics(simplify_java)
 Choices: programRules:Java}
@@ -1171,21 +1171,21 @@ Choices: programRules:Java}
 == asinIsNaN (asinIsNaN) =========================================
 asinIsNaN {
 \find(asinDouble(arg))
-\sameUpdateLevel\add [imp(or(or(doubleIsNaN(arg),ltDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(asinDouble(arg)))]==>[] 
+\add [imp(or(or(doubleIsNaN(arg),ltDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(asinDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == asineIsZero (asineIsZero) =========================================
 asineIsZero {
 \find(asinDouble(arg))
-\sameUpdateLevel\add [imp(equals(arg,DFP(0(#))),equals(asinDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(equals(arg,DFP(0(#))),equals(asinDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == asineRange (asineRange) =========================================
 asineRange {
 \find(asinDouble(arg))
-\sameUpdateLevel\add [imp(and(geqDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),and(geqDouble(asinDouble(arg),negDouble(DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))),leqDouble(asinDouble(arg),DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(geqDouble(arg,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),and(geqDouble(asinDouble(arg),negDouble(DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))),leqDouble(asinDouble(arg),DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -2050,35 +2050,35 @@ Choices: programRules:Java}
 == atan2IsNaN (atan2IsNaN) =========================================
 atan2IsNaN {
 \find(atan2Double(arg1,arg2))
-\sameUpdateLevel\add [imp(or(doubleIsNaN(arg1),doubleIsNaN(arg2)),doubleIsNaN(atan2Double(arg1,arg2)))]==>[] 
+\add [imp(or(doubleIsNaN(arg1),doubleIsNaN(arg2)),doubleIsNaN(atan2Double(arg1,arg2)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == atan2Range (atan2Range) =========================================
 atan2Range {
 \find(atan2Double(arg1,arg2))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg1)),not(doubleIsNaN(arg2))),and(geqDouble(atan2Double(arg1,arg2),negDouble(DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))),leqDouble(atan2Double(arg1,arg2),DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg1)),not(doubleIsNaN(arg2))),and(geqDouble(atan2Double(arg1,arg2),negDouble(DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))),leqDouble(atan2Double(arg1,arg2),DFP(8(4(8(5(4(0(2(5(5(6(5(6(6(5(2(4(1(6(4(#)))))))))))))))))))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == atanIsNaN (atanIsNaN) =========================================
 atanIsNaN {
 \find(atanDouble(arg))
-\sameUpdateLevel\add [imp(doubleIsNaN(arg),doubleIsNaN(atanDouble(arg)))]==>[] 
+\add [imp(doubleIsNaN(arg),doubleIsNaN(atanDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == atanIsZero (atanIsZero) =========================================
 atanIsZero {
 \find(atanDouble(arg))
-\sameUpdateLevel\add [imp(equals(arg,DFP(0(#))),equals(atanDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(equals(arg,DFP(0(#))),equals(atanDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == atanRange (atanRange) =========================================
 atanRange {
 \find(atanDouble(arg))
-\sameUpdateLevel\add [imp(not(doubleIsNaN(arg)),and(geqDouble(atanDouble(arg),negDouble(DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))),leqDouble(atanDouble(arg),DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(not(doubleIsNaN(arg)),and(geqDouble(atanDouble(arg),negDouble(DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))),leqDouble(atanDouble(arg),DFP(2(5(3(5(7(6(4(2(9(6(5(0(3(5(7(9(0(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -2403,14 +2403,14 @@ Choices: true}
 == binaryOrGte (binaryOrGte) =========================================
 binaryOrGte {
 \find(binaryOr(left,right))
-\sameUpdateLevel\add [imp(and(geq(left,Z(0(#))),geq(right,Z(0(#)))),and(and(geq(binaryOr(left,right),left),geq(binaryOr(left,right),right)),leq(binaryOr(left,right),mul(Z(2(#)),if-then-else(gt(left,right),left,right)))))]==>[] 
+\add [imp(and(geq(left,Z(0(#))),geq(right,Z(0(#)))),and(and(geq(binaryOr(left,right),left),geq(binaryOr(left,right),right)),leq(binaryOr(left,right),mul(Z(2(#)),if-then-else(gt(left,right),left,right)))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == binaryOrInInt (binaryOrInInt) =========================================
 binaryOrInInt {
 \find(binaryOr(left,right))
-\sameUpdateLevel\add [imp(and(inRangeInt(left),inRangeInt(right)),inRangeInt(binaryOr(left,right)))]==>[] 
+\add [imp(and(inRangeInt(left),inRangeInt(right)),inRangeInt(binaryOr(left,right)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -2431,7 +2431,7 @@ Choices: true}
 == binaryOrSign (binaryOrSign) =========================================
 binaryOrSign {
 \find(binaryOr(left,right))
-\sameUpdateLevel\add [geq(mul(if-then-else(and(geq(left,Z(0(#))),geq(right,Z(0(#)))),Z(1(#)),Z(neglit(1(#)))),binaryOr(left,right)),Z(0(#)))]==>[] 
+\add [geq(mul(if-then-else(and(geq(left,Z(0(#))),geq(right,Z(0(#)))),Z(1(#)),Z(neglit(1(#)))),binaryOr(left,right)),Z(0(#)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -2786,7 +2786,7 @@ Choices: programRules:Java}
 == bprod_all_positive (bprod_all_positive) =========================================
 bprod_all_positive {
 \find(bprod{uSub (variable)}(i0,i1,t1))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [imp(all{uSub (variable)}(imp(and(leq(i0,uSub),lt(uSub,i1)),geq(t1,Z(0(#))))),geq(bprod{uSub (variable)}(i0,i1,t1),Z(0(#))))]==>[] 
 
 Choices: (integerSimplificationRules:full & sequences:on)}
@@ -2802,7 +2802,7 @@ Choices: integerSimplificationRules:full}
 == bprod_empty (bprod_empty) =========================================
 bprod_empty {
 \find(bprod{uSub (variable)}(i0,i1,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \replacewith(Z(1(#))) ;
 \add []==>[leq(i1,i0)] 
 
@@ -2969,7 +2969,7 @@ Choices: integerSimplificationRules:full}
 == bsum_add_concrete (bsum_add_concrete) =========================================
 bsum_add_concrete {
 \find(add(bsum{uSub1 (variable)}(i0,i1,t1),bsum{uSub2 (variable)}(i1,i3,t2)))
-\sameUpdateLevel\varcond(\notFreeIn(uSub2 (variable), t1 (int term)), \notFreeIn(uSub2 (variable), i3 (int term)), \notFreeIn(uSub2 (variable), i1 (int term)), \notFreeIn(uSub2 (variable), i0 (int term)), \notFreeIn(uSub1 (variable), t2 (int term)), \notFreeIn(uSub1 (variable), i3 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub2 (variable), t1 (int term)), \notFreeIn(uSub2 (variable), i3 (int term)), \notFreeIn(uSub2 (variable), i1 (int term)), \notFreeIn(uSub2 (variable), i0 (int term)), \notFreeIn(uSub1 (variable), t2 (int term)), \notFreeIn(uSub1 (variable), i3 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), i0 (int term)))
 \replacewith(bsum{uSub1 (variable)}(i0,i3,subst{uSub2 (variable)}(uSub1,if-then-else(lt(uSub1,i1),t1,t2)))) ;
 \add []==>[and(leq(i0,i1),leq(i1,i3))] 
 
@@ -3002,7 +3002,7 @@ Choices: integerSimplificationRules:full}
 == bsum_empty (bsum_empty) =========================================
 bsum_empty {
 \find(bsum{uSub (variable)}(i0,i1,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \replacewith(Z(0(#))) ;
 \add []==>[leq(i1,i0)] 
 
@@ -3150,7 +3150,7 @@ Choices: integerSimplificationRules:full}
 == bsum_lower_bound (bsum_lower_bound) =========================================
 bsum_lower_bound {
 \find(bsum{uSub (variable)}(i0,i1,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), j (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), j (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [imp(all{uSub (variable)}(imp(and(geq(uSub,i0),lt(uSub,i1)),geq(t,j))),geq(bsum{uSub (variable)}(i0,i1,t),if-then-else(gt(sub(i1,i0),Z(0(#))),mul(sub(i1,i0),j),Z(0(#)))))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3166,7 +3166,7 @@ Choices: integerSimplificationRules:full}
 == bsum_num_of_bounds (bsum_num_of_bounds) =========================================
 bsum_num_of_bounds {
 \find(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(1(#)),Z(0(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [leq(Z(0(#)),bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(1(#)),Z(0(#))))),imp(leq(i0,i2),leq(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(1(#)),Z(0(#)))),sub(i2,i0)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3174,7 +3174,7 @@ Choices: integerSimplificationRules:full}
 == bsum_num_of_bounds2 (bsum_num_of_bounds2) =========================================
 bsum_num_of_bounds2 {
 \find(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(0(#)),Z(1(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [leq(Z(0(#)),bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(0(#)),Z(1(#))))),imp(leq(i0,i2),leq(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(0(#)),Z(1(#)))),sub(i2,i0)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3182,7 +3182,7 @@ Choices: integerSimplificationRules:full}
 == bsum_num_of_gt0 (bsum_num_of_gt0) =========================================
 bsum_num_of_gt0 {
 \find(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(1(#)),Z(0(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [imp(gt(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(1(#)),Z(0(#)))),Z(0(#))),exists{uSub (variable)}(and(and(leq(i0,uSub),lt(uSub,i2)),phi)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3190,7 +3190,7 @@ Choices: integerSimplificationRules:full}
 == bsum_num_of_gt0_alt (bsum_num_of_gt0_alt) =========================================
 bsum_num_of_gt0_alt {
 \find(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(0(#)),Z(1(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [imp(gt(bsum{uSub (variable)}(i0,i2,if-then-else(phi,Z(0(#)),Z(1(#)))),Z(0(#))),exists{uSub (variable)}(and(and(leq(i0,uSub),lt(uSub,i2)),not(phi))))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3300,7 +3300,7 @@ Choices: integerSimplificationRules:full}
 == bsum_positive1 (bsum_positive1) =========================================
 bsum_positive1 {
 \find(bsum{uSub (variable)}(i0,i1,if-then-else(b,Z(1(#)),Z(0(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [geq(bsum{uSub (variable)}(i0,i1,if-then-else(b,Z(1(#)),Z(0(#)))),Z(0(#)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3308,7 +3308,7 @@ Choices: integerSimplificationRules:full}
 == bsum_positive2 (bsum_positive2) =========================================
 bsum_positive2 {
 \find(bsum{uSub (variable)}(i0,i1,if-then-else(b,Z(0(#)),Z(1(#)))))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [geq(bsum{uSub (variable)}(i0,i1,if-then-else(b,Z(0(#)),Z(1(#)))),Z(0(#)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3316,7 +3316,7 @@ Choices: integerSimplificationRules:full}
 == bsum_positive_lower_bound_element (bsum_positive_lower_bound_element) =========================================
 bsum_positive_lower_bound_element {
 \find(bsum{uSub (variable)}(i0,i1,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), index (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), index (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [leq(subst{uSub (variable)}(index,t),bsum{uSub (variable)}(i0,i1,t))]==>[] ;
 \add []==>[and(and(all{uSub (variable)}(imp(and(and(geq(uSub,i0),lt(uSub,i1)),not(equals(uSub,index))),geq(t,Z(0(#))))),leq(i0,index)),lt(index,i1))] 
 
@@ -3350,7 +3350,7 @@ Choices: integerSimplificationRules:full
 == bsum_split_in_three (bsum_split_in_three) =========================================
 bsum_split_in_three {
 \find(bsum{uSub (variable)}(i0,i2,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub1 (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), t (int term)), \notFreeIn(uSub (variable), i1 (int term)))
+\varcond(\notFreeIn(uSub1 (variable), i2 (int term)), \notFreeIn(uSub (variable), i0 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), t (int term)), \notFreeIn(uSub (variable), i1 (int term)))
 \replacewith(add(add(bsum{uSub (variable)}(i0,i1,t),subst{uSub (variable)}(i1,t)),bsum{uSub1 (variable)}(add(i1,Z(1(#))),i2,subst{uSub (variable)}(uSub1,t)))) ;
 \add []==>[and(leq(i0,i1),lt(i1,i2))] 
 
@@ -3359,7 +3359,7 @@ Choices: integerSimplificationRules:full}
 == bsum_sub_same_index (bsum_sub_same_index) =========================================
 bsum_sub_same_index {
 \find(sub(bsum{uSub1 (variable)}(i0,i1,t1),bsum{uSub2 (variable)}(i0,i1,t2)))
-\sameUpdateLevel\varcond(\notFreeIn(uSub2 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub2 (variable), t1 (int term)), \notFreeIn(uSub1 (variable), t2 (int term)), \notFreeIn(uSub2 (variable), i0 (int term)), \notFreeIn(uSub1 (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub2 (variable), i1 (int term)), \notFreeIn(uSub1 (variable), i1 (int term)), \notFreeIn(uSub2 (variable), t1 (int term)), \notFreeIn(uSub1 (variable), t2 (int term)), \notFreeIn(uSub2 (variable), i0 (int term)), \notFreeIn(uSub1 (variable), i0 (int term)))
 \add [equals(bsum{uSub1 (variable)}(i0,i1,sub(t1,subst{uSub2 (variable)}(uSub1,t2))),sub(bsum{uSub1 (variable)}(i0,i1,t1),bsum{uSub2 (variable)}(i0,i1,t2)))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3367,7 +3367,7 @@ Choices: integerSimplificationRules:full}
 == bsum_upper_bound (bsum_upper_bound) =========================================
 bsum_upper_bound {
 \find(bsum{uSub (variable)}(i0,i1,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), j (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
+\varcond(\notFreeIn(uSub (variable), j (int term)), \notFreeIn(uSub (variable), i1 (int term)), \notFreeIn(uSub (variable), i0 (int term)))
 \add [imp(all{uSub (variable)}(imp(and(geq(uSub,i0),lt(uSub,i1)),leq(t,j))),leq(bsum{uSub (variable)}(i0,i1,t),if-then-else(gt(sub(i1,i0),Z(0(#))),mul(sub(i1,i0),j),Z(0(#)))))]==>[] 
 
 Choices: integerSimplificationRules:full}
@@ -3391,7 +3391,7 @@ Choices: integerSimplificationRules:full}
 == cancel_equation (cancel_equation) =========================================
 cancel_equation {
 \find(equals(mul(eqLeft,Fac),mul(eqRight,Fac)))
-\sameUpdateLevel\add []==>[not(equals(Fac,Z(0(#))))] ;
+\add []==>[not(equals(Fac,Z(0(#))))] ;
 \replacewith(equals(eqLeft,eqRight)) 
 \heuristics(simplify_enlarging)
 Choices: integerSimplificationRules:full}
@@ -3448,7 +3448,7 @@ Choices: true}
 castAdd {
 \assumes ([equals(instance<[CSub]>(strictCTerm2),TRUE)]==>[]) 
 \find(strictCTerm2)
-\sameUpdateLevel\replacewith(cast<[CSub]>(strictCTerm2)) 
+\replacewith(cast<[CSub]>(strictCTerm2)) 
 
 Choices: true}
 -----------------------------------------------------
@@ -3456,7 +3456,7 @@ Choices: true}
 castAdd2 {
 \assumes ([equals(cs,gt)]==>[]) 
 \find(gt)
-\sameUpdateLevel\varcond(\strict\sub(C, G))
+\varcond(\strict\sub(C, G))
 \replacewith(cast<[C]>(gt)) 
 
 Choices: true}
@@ -3472,7 +3472,7 @@ Choices: true}
 castDel2 {
 \assumes ([equals(cs,gt)]==>[]) 
 \find(cast<[C]>(gt))
-\sameUpdateLevel\replacewith(cs) 
+\replacewith(cs) 
 
 Choices: true}
 -----------------------------------------------------
@@ -5097,7 +5097,7 @@ Choices: programRules:Java}
 == contains (contains) =========================================
 contains {
 \find(clContains(seqConcat(seqSingleton(fstTextCharacter),textStringTail),searchString))
-\sameUpdateLevel\add [equals(seqLen(searchString),newSym)]==>[] \replacewith(and(lt(newSym,seqLen(textStringTail)),or(equals(seqSub(seqConcat(seqSingleton(fstTextCharacter),textStringTail),Z(0(#)),newSym),searchString),clContains(textStringTail,searchString)))) 
+\add [equals(seqLen(searchString),newSym)]==>[] \replacewith(and(lt(newSym,seqLen(textStringTail)),or(equals(seqSub(seqConcat(seqSingleton(fstTextCharacter),textStringTail),Z(0(#)),newSym),searchString),clContains(textStringTail,searchString)))) 
 \heuristics(stringsIntroduceNewSym, stringsContainsDefInline)
 Choices: Strings:on}
 -----------------------------------------------------
@@ -5120,7 +5120,7 @@ Choices: Strings:on}
 == cosIsNaN (cosIsNaN) =========================================
 cosIsNaN {
 \find(cosDouble(arg))
-\sameUpdateLevel\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(cosDouble(arg)))]==>[] 
+\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(cosDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -5134,21 +5134,21 @@ Choices: true}
 == cosIsNotNaN (cosIsNotNaN) =========================================
 cosIsNotNaN {
 \find(cosDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),not(doubleIsNaN(cosDouble(arg))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),not(doubleIsNaN(cosDouble(arg))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == cosRange (cosRange) =========================================
 cosRange {
 \find(cosDouble(arg))
-\sameUpdateLevel\add [or(and(geqDouble(cosDouble(arg),DFP(0(#))),leqDouble(cosDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(cosDouble(arg)))]==>[] 
+\add [or(and(geqDouble(cosDouble(arg),DFP(0(#))),leqDouble(cosDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(cosDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == cosRange2 (cosRange2) =========================================
 cosRange2 {
 \find(cosDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(cosDouble(arg),DFP(0(#))),leqDouble(cosDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(cosDouble(arg),DFP(0(#))),leqDouble(cosDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -5178,7 +5178,7 @@ Choices: programRules:Java}
 createdInHeapWithAllFieldsEQ {
 \assumes ([equals(allFields(o),EQ)]==>[]) 
 \find(createdInHeap(EQ,h))
-\sameUpdateLevel\replacewith(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))) 
+\replacewith(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5193,7 +5193,7 @@ Choices: programRules:Java}
 createdInHeapWithArrayRangeEQ {
 \assumes ([equals(arrayRange(o,lower,upper),EQ)]==>[]) 
 \find(createdInHeap(EQ,h))
-\sameUpdateLevel\replacewith(or(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE)),lt(upper,lower))) 
+\replacewith(or(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE)),lt(upper,lower))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5247,7 +5247,7 @@ Choices: programRules:Java}
 createdInHeapWithSetMinusFreshLocsEQ {
 \assumes ([equals(setMinus(s,freshLocs(h)),EQ)]==>[]) 
 \find(createdInHeap(EQ,h))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5262,7 +5262,7 @@ Choices: programRules:Java}
 createdInHeapWithSingletonEQ {
 \assumes ([equals(singleton(o,f),EQ)]==>[]) 
 \find(createdInHeap(EQ,h))
-\sameUpdateLevel\replacewith(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))) 
+\replacewith(or(equals(o,null),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5310,7 +5310,7 @@ Choices: true}
 == cut_direct (cut_direct) =========================================
 cut_direct {
 \find(cutFormula)
-\sameUpdateLevel\add []==>[cutFormula] \replacewith(false) ;
+\add []==>[cutFormula] \replacewith(false) ;
 \add [cutFormula]==>[] \replacewith(true) 
 \heuristics(cut_direct)
 Choices: true}
@@ -5553,7 +5553,7 @@ delete_unnecessary_cast {
 \find(#allmodal ((modal operator))|{{ ..
   #lhs = (#npit) #se;
 ... }}| (post))
-\sameUpdateLevel\varcond(\hasSort(#npit (program NonPrimitiveType), G), \sub(\typeof(#se (program SimpleExpression)), G))
+\varcond(\hasSort(#npit (program NonPrimitiveType), G), \sub(\typeof(#se (program SimpleExpression)), G))
 \add [or(equals(#se,null),equals(instance<[G]>(#se),TRUE))]==>[] \replacewith(update-application(elem-update(#lhs (program LeftHandSide))(#addCast(#se,#lhs)),#allmodal(post))) 
 \heuristics(simplify_prog)
 Choices: programRules:Java}
@@ -5659,7 +5659,7 @@ Choices: programRules:Java}
 disjointAllFields {
 \assumes ([equals(intersect(allFields(o),s),empty)]==>[]) 
 \find(elementOf(o,f,s))
-\sameUpdateLevel\replacewith(false) 
+\replacewith(false) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5674,7 +5674,7 @@ Choices: programRules:Java}
 disjointAllObjects {
 \assumes ([equals(intersect(allObjects(f),s),empty)]==>[]) 
 \find(elementOf(o,f,s))
-\sameUpdateLevel\replacewith(false) 
+\replacewith(false) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -5827,7 +5827,7 @@ Choices: programRules:Java}
 dismissNonSelectedFieldEQ {
 \assumes ([equals(store(h,o,f1,x),EQ)]==>[]) 
 \find(select<[alpha]>(EQ,u,f2))
-\sameUpdateLevel\varcond(\differentFields (f1 (Field term), f2 (Field term)))
+\varcond(\differentFields (f1 (Field term), f2 (Field term)))
 \replacewith(select<[alpha]>(h,u,f2)) 
 \heuristics(simplify_select_elim_store)
 Choices: programRules:Java}
@@ -5895,7 +5895,7 @@ Choices: programRules:Java}
 == divAddMultDenom (divAddMultDenom) =========================================
 divAddMultDenom {
 \find(div(add(divNum,mul(coef,divDenom)),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(add(div(divNum,divDenom),coef)) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -5943,7 +5943,7 @@ Choices: true}
 == divMinus (divMinus) =========================================
 divMinus {
 \find(div(neg(divNum),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(if-then-else(equals(mul(div(divNum,divDenom),divDenom),divNum),neg(div(divNum,divDenom)),if-then-else(gt(divDenom,Z(0(#))),sub(neg(div(divNum,divDenom)),Z(1(#))),add(neg(div(divNum,divDenom)),Z(1(#)))))) 
 
 Choices: true}
@@ -5951,7 +5951,7 @@ Choices: true}
 == divMinusDenom (divMinusDenom) =========================================
 divMinusDenom {
 \find(div(divNum,neg(divDenom)))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(neg(div(divNum,divDenom))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -5959,42 +5959,42 @@ Choices: true}
 == divResOne1 (divResOne1) =========================================
 divResOne1 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(and(gt(divDenom,Z(0(#))),lt(divNum,Z(0(#)))),lt(neg(divDenom),divNum)),equals(div(divNum,divDenom),Z(neglit(1(#)))))]==>[] 
+\add [imp(and(and(gt(divDenom,Z(0(#))),lt(divNum,Z(0(#)))),lt(neg(divDenom),divNum)),equals(div(divNum,divDenom),Z(neglit(1(#)))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == divResOne2 (divResOne2) =========================================
 divResOne2 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(and(lt(divDenom,Z(0(#))),lt(divNum,Z(0(#)))),lt(divDenom,divNum)),equals(div(divNum,divDenom),Z(1(#))))]==>[] 
+\add [imp(and(and(lt(divDenom,Z(0(#))),lt(divNum,Z(0(#)))),lt(divDenom,divNum)),equals(div(divNum,divDenom),Z(1(#))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == divResZero1 (divResZero1) =========================================
 divResZero1 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(and(gt(divDenom,Z(0(#))),leq(Z(0(#)),divNum)),lt(divNum,divDenom)),equals(div(divNum,divDenom),Z(0(#))))]==>[] 
+\add [imp(and(and(gt(divDenom,Z(0(#))),leq(Z(0(#)),divNum)),lt(divNum,divDenom)),equals(div(divNum,divDenom),Z(0(#))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == divResZero2 (divResZero2) =========================================
 divResZero2 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(and(lt(divDenom,Z(0(#))),leq(Z(0(#)),divNum)),lt(divNum,neg(divDenom))),equals(div(divNum,divDenom),Z(0(#))))]==>[] 
+\add [imp(and(and(lt(divDenom,Z(0(#))),leq(Z(0(#)),divNum)),lt(divNum,neg(divDenom))),equals(div(divNum,divDenom),Z(0(#))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == div_axiom (div_axiom) =========================================
 div_axiom {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [or(equals(divDenom,Z(0(#))),and(and(equals(div(divNum,divDenom),quotient),leq(mul(quotient,divDenom),divNum)),if-then-else(geq(divDenom,Z(0(#))),geq(mul(quotient,divDenom),add(add(Z(1(#)),divNum),mul(Z(neglit(1(#))),divDenom))),geq(mul(quotient,divDenom),add(add(Z(1(#)),divNum),divDenom)))))]==>[] 
+\add [or(equals(divDenom,Z(0(#))),and(and(equals(div(divNum,divDenom),quotient),leq(mul(quotient,divDenom),divNum)),if-then-else(geq(divDenom,Z(0(#))),geq(mul(quotient,divDenom),add(add(Z(1(#)),divNum),mul(Z(neglit(1(#))),divDenom))),geq(mul(quotient,divDenom),add(add(Z(1(#)),divNum),divDenom)))))]==>[] 
 \heuristics(notHumanReadable, polySimp_newSmallSym, defOps_div)
 Choices: true}
 -----------------------------------------------------
 == div_cancel1 (div_cancel1) =========================================
 div_cancel1 {
 \find(div(mul(divNum,divDenom),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(divNum) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -6002,7 +6002,7 @@ Choices: true}
 == div_cancel2 (div_cancel2) =========================================
 div_cancel2 {
 \find(div(mul(divDenom,divNum),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(divNum) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -6010,7 +6010,7 @@ Choices: true}
 == div_exists (div_exists) =========================================
 div_exists {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [all{cnom (variable)}(imp(not(equals(cnom,Z(0(#)))),all{a (variable)}(exists{qu (variable)}(exists{rm (variable)}(and(and(equals(a,add(mul(qu,cnom),rm)),leq(Z(0(#)),rm)),if-then-else(geq(cnom,Z(0(#))),and(geq(mul(qu,cnom),add(add(Z(1(#)),a),mul(Z(neglit(1(#))),cnom))),lt(rm,cnom)),and(geq(mul(qu,cnom),add(add(Z(1(#)),a),cnom)),lt(rm,neg(cnom))))))))))]==>[] 
+\add [all{cnom (variable)}(imp(not(equals(cnom,Z(0(#)))),all{a (variable)}(exists{qu (variable)}(exists{rm (variable)}(and(and(equals(a,add(mul(qu,cnom),rm)),leq(Z(0(#)),rm)),if-then-else(geq(cnom,Z(0(#))),and(geq(mul(qu,cnom),add(add(Z(1(#)),a),mul(Z(neglit(1(#))),cnom))),lt(rm,cnom)),and(geq(mul(qu,cnom),add(add(Z(1(#)),a),cnom)),lt(rm,neg(cnom))))))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -6031,21 +6031,21 @@ Choices: true}
 == div_unique1 (div_unique1) =========================================
 div_unique1 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(gt(cnom,Z(0(#))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),geq(mul(x,cnom),sub(add(Z(1(#)),a),cnom))),geq(mul(y,cnom),sub(add(Z(1(#)),a),cnom))),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(gt(cnom,Z(0(#))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),geq(mul(x,cnom),sub(add(Z(1(#)),a),cnom))),geq(mul(y,cnom),sub(add(Z(1(#)),a),cnom))),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == div_unique2 (div_unique2) =========================================
 div_unique2 {
 \find(div(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(lt(cnom,Z(0(#))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),geq(mul(x,cnom),add(add(Z(1(#)),a),cnom))),geq(mul(y,cnom),add(add(Z(1(#)),a),cnom))),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(lt(cnom,Z(0(#))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),geq(mul(x,cnom),add(add(Z(1(#)),a),cnom))),geq(mul(y,cnom),add(add(Z(1(#)),a),cnom))),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == div_zero (div_zero) =========================================
 div_zero {
 \find(div(Z(0(#)),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(Z(0(#))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -6292,7 +6292,7 @@ Choices: programRules:Java}
 elementOfArrayRangeEQ {
 \assumes ([equals(arrayRange(o2,lower,upper),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\varcond(\notFreeIn(iv (variable), upper (int term)), \notFreeIn(iv (variable), lower (int term)), \notFreeIn(iv (variable), f (Field term)))
+\varcond(\notFreeIn(iv (variable), upper (int term)), \notFreeIn(iv (variable), lower (int term)), \notFreeIn(iv (variable), f (Field term)))
 \replacewith(and(equals(o,o2),exists{iv (variable)}(and(and(equals(f,arr(iv)),leq(lower,iv)),leq(iv,upper))))) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -6338,7 +6338,7 @@ Choices: programRules:Java}
 elementOfInfiniteUnion2VarsEQ {
 \assumes ([equals(infiniteUnion{av (variable),bv (variable)}(s),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\varcond(\notFreeIn(bv (variable), f (Field term)), \notFreeIn(bv (variable), o (java.lang.Object term)), \notFreeIn(av (variable), f (Field term)), \notFreeIn(av (variable), o (java.lang.Object term)))
+\varcond(\notFreeIn(bv (variable), f (Field term)), \notFreeIn(bv (variable), o (java.lang.Object term)), \notFreeIn(av (variable), f (Field term)), \notFreeIn(av (variable), o (java.lang.Object term)))
 \replacewith(exists{av (variable)}(exists{bv (variable)}(elementOf(o,f,s)))) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -6347,7 +6347,7 @@ Choices: programRules:Java}
 elementOfInfiniteUnionEQ {
 \assumes ([equals(infiniteUnion{av (variable)}(s),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\varcond(\notFreeIn(av (variable), f (Field term)), \notFreeIn(av (variable), o (java.lang.Object term)))
+\varcond(\notFreeIn(av (variable), f (Field term)), \notFreeIn(av (variable), o (java.lang.Object term)))
 \replacewith(exists{av (variable)}(elementOf(o,f,s))) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -6363,7 +6363,7 @@ Choices: programRules:Java}
 elementOfIntersectEQ {
 \assumes ([equals(intersect(s,s2),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\replacewith(and(elementOf(o,f,s),elementOf(o,f,s2))) 
+\replacewith(and(elementOf(o,f,s),elementOf(o,f,s2))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -6378,7 +6378,7 @@ Choices: programRules:Java}
 elementOfSetMinusEQ {
 \assumes ([equals(setMinus(s,s2),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\replacewith(and(elementOf(o,f,s),not(elementOf(o,f,s2)))) 
+\replacewith(and(elementOf(o,f,s),not(elementOf(o,f,s2)))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -6401,7 +6401,7 @@ Choices: programRules:Java}
 elementOfSubsetOfUnion1 {
 \assumes ([subset(s,union(s2,s3))]==>[elementOf(o,f,s2)]) 
 \find(elementOf(o,f,s))
-\sameUpdateLevel\add [equiv(elementOf(o,f,s),elementOf(o,f,intersect(s,s3)))]==>[] 
+\add [equiv(elementOf(o,f,s),elementOf(o,f,intersect(s,s3)))]==>[] 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -6409,7 +6409,7 @@ Choices: programRules:Java}
 elementOfSubsetOfUnion2 {
 \assumes ([subset(s,union(s2,s3))]==>[elementOf(o,f,s3)]) 
 \find(elementOf(o,f,s))
-\sameUpdateLevel\add [equiv(elementOf(o,f,s),elementOf(o,f,intersect(s,s2)))]==>[] 
+\add [equiv(elementOf(o,f,s),elementOf(o,f,intersect(s,s2)))]==>[] 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -6424,7 +6424,7 @@ Choices: programRules:Java}
 elementOfUnionEQ {
 \assumes ([equals(union(s,s2),EQ)]==>[]) 
 \find(elementOf(o,f,EQ))
-\sameUpdateLevel\replacewith(or(elementOf(o,f,s),elementOf(o,f,s2))) 
+\replacewith(or(elementOf(o,f,s),elementOf(o,f,s2))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -7068,7 +7068,7 @@ Choices: true}
 == eqTermCut (eqTermCut) =========================================
 eqTermCut {
 \find(t)
-\sameUpdateLevel\add [not(equals(t,s))]==>[] ;
+\add [not(equals(t,s))]==>[] ;
 \add [equals(t,s)]==>[] 
 
 Choices: true}
@@ -8042,7 +8042,7 @@ Choices: programRules:Java}
 exact_instance_known_dynamic_type {
 \assumes ([equals(exactInstance<[G]>(a),TRUE)]==>[]) 
 \find(exactInstance<[H]>(a))
-\sameUpdateLevel\varcond(\not\same(G, H))
+\varcond(\not\same(G, H))
 \replacewith(FALSE) 
 \heuristics(evaluate_instanceof, simplify)
 Choices: true}
@@ -9279,21 +9279,21 @@ Choices: programRules:Java}
 == expIsInfinite (expIsInfinite) =========================================
 expIsInfinite {
 \find(expDouble(arg))
-\sameUpdateLevel\add [imp(and(doubleIsInfinite(arg),gtDouble(arg,DFP(0(#)))),and(doubleIsInfinite(expDouble(arg)),gtDouble(expDouble(arg),DFP(0(#)))))]==>[] 
+\add [imp(and(doubleIsInfinite(arg),gtDouble(arg,DFP(0(#)))),and(doubleIsInfinite(expDouble(arg)),gtDouble(expDouble(arg),DFP(0(#)))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == expIsNaN (expIsNaN) =========================================
 expIsNaN {
 \find(expDouble(arg))
-\sameUpdateLevel\add [imp(doubleIsNaN(arg),doubleIsNaN(expDouble(arg)))]==>[] 
+\add [imp(doubleIsNaN(arg),doubleIsNaN(expDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == expIsZero (expIsZero) =========================================
 expIsZero {
 \find(expDouble(arg))
-\sameUpdateLevel\add [imp(and(doubleIsInfinite(arg),ltDouble(arg,DFP(0(#)))),equals(expDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(and(doubleIsInfinite(arg),ltDouble(arg,DFP(0(#)))),equals(expDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -9597,7 +9597,7 @@ Choices: true}
 == getAnyOfArray2seq (getAnyOfArray2seq) =========================================
 getAnyOfArray2seq {
 \find(seqGet<[any]>(array2seq(h,a),idx))
-\sameUpdateLevel\add []==>[and(leq(Z(0(#)),idx),lt(idx,length(a)))] ;
+\add []==>[and(leq(Z(0(#)),idx),lt(idx,length(a)))] ;
 \replacewith(select<[any]>(h,a,arr(idx))) 
 
 Choices: sequences:on}
@@ -9617,7 +9617,7 @@ Choices: (programRules:Java & JavaCard:on)}
 == getOfArray2seq (getOfArray2seq) =========================================
 getOfArray2seq {
 \find(seqGet<[alpha]>(array2seq(h,a),idx))
-\sameUpdateLevel\add []==>[and(leq(Z(0(#)),idx),lt(idx,length(a)))] ;
+\add []==>[and(leq(Z(0(#)),idx),lt(idx,length(a)))] ;
 \replacewith(select<[alpha]>(h,a,arr(idx))) 
 
 Choices: sequences:on}
@@ -9682,7 +9682,7 @@ Choices: sequences:on}
 getOfSeqConcatEQ {
 \assumes ([equals(seqConcat(seq,seq2),EQ)]==>[]) 
 \find(seqGet<[alpha]>(EQ,idx))
-\sameUpdateLevel\replacewith(if-then-else(lt(idx,seqLen(seq)),seqGet<[alpha]>(seq,idx),seqGet<[alpha]>(seq2,sub(idx,seqLen(seq))))) 
+\replacewith(if-then-else(lt(idx,seqLen(seq)),seqGet<[alpha]>(seq,idx),seqGet<[alpha]>(seq2,sub(idx,seqLen(seq))))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -9698,7 +9698,7 @@ Choices: sequences:on}
 getOfSeqDefEQ {
 \assumes ([equals(seqDef{uSub (variable)}(from,to,t),EQ)]==>[]) 
 \find(seqGet<[alpha]>(EQ,idx))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), to (int term)), \notFreeIn(uSub (variable), from (int term)))
+\varcond(\notFreeIn(uSub (variable), to (int term)), \notFreeIn(uSub (variable), from (int term)))
 \replacewith(if-then-else(and(leq(Z(0(#)),idx),lt(idx,sub(to,from))),cast<[alpha]>(subst{uSub (variable)}(add(idx,from),t)),cast<[alpha]>(seqGetOutside))) 
 \heuristics(simplify_enlarging)
 Choices: sequences:on}
@@ -9714,7 +9714,7 @@ Choices: sequences:on}
 getOfSeqReverseEQ {
 \assumes ([equals(seqReverse(seq),EQ)]==>[]) 
 \find(seqGet<[alpha]>(EQ,idx))
-\sameUpdateLevel\replacewith(seqGet<[alpha]>(seq,sub(sub(seqLen(seq),Z(1(#))),idx))) 
+\replacewith(seqGet<[alpha]>(seq,sub(sub(seqLen(seq),Z(1(#))),idx))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -9736,7 +9736,7 @@ Choices: sequences:on}
 getOfSeqSingletonEQ {
 \assumes ([equals(seqSingleton(x),EQ)]==>[]) 
 \find(seqGet<[alpha]>(EQ,idx))
-\sameUpdateLevel\replacewith(if-then-else(equals(idx,Z(0(#))),cast<[alpha]>(x),cast<[alpha]>(seqGetOutside))) 
+\replacewith(if-then-else(equals(idx,Z(0(#))),cast<[alpha]>(x),cast<[alpha]>(seqGetOutside))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -9751,7 +9751,7 @@ Choices: sequences:on}
 getOfSeqSubEQ {
 \assumes ([equals(seqSub(seq,from,to),EQ)]==>[]) 
 \find(seqGet<[alpha]>(EQ,idx))
-\sameUpdateLevel\replacewith(if-then-else(and(leq(Z(0(#)),idx),lt(idx,sub(to,from))),seqGet<[alpha]>(seq,add(idx,from)),cast<[alpha]>(seqGetOutside))) 
+\replacewith(if-then-else(and(leq(Z(0(#)),idx),lt(idx,sub(to,from))),seqGet<[alpha]>(seq,add(idx,from)),cast<[alpha]>(seqGetOutside))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -10285,7 +10285,7 @@ Choices: true}
 == ifExthenelse1_solve (ifExthenelse1_solve) =========================================
 ifExthenelse1_solve {
 \find(ifExThenElse{intVar (variable)}(phi,then,else))
-\sameUpdateLevel\varcond(\notFreeIn(intVar (variable), intValue (int term)))
+\varcond(\notFreeIn(intVar (variable), intValue (int term)))
 \add []==>[and(subst{intVar (variable)}(intValue,phi),all{intVar (variable)}(imp(phi,wellOrderLeqInt(intValue,intVar))))] \replacewith(ifExThenElse{intVar (variable)}(phi,then,else)) ;
 \replacewith(subst{intVar (variable)}(intValue,then)) 
 
@@ -10294,7 +10294,7 @@ Choices: true}
 == ifExthenelse1_solve_for (ifExthenelse1_solve) =========================================
 ifExthenelse1_solve_for {
 \find(ifExThenElse{intVar (variable)}(phi,b,c))
-\sameUpdateLevel\varcond(\notFreeIn(intVar (variable), intValue (int term)))
+\varcond(\notFreeIn(intVar (variable), intValue (int term)))
 \add []==>[and(subst{intVar (variable)}(intValue,phi),all{intVar (variable)}(imp(phi,wellOrderLeqInt(intValue,intVar))))] \replacewith(ifExThenElse{intVar (variable)}(phi,b,c)) ;
 \replacewith(subst{intVar (variable)}(intValue,b)) 
 
@@ -10303,7 +10303,7 @@ Choices: true}
 == ifExthenelse1_split (ifExthenelse1_split) =========================================
 ifExthenelse1_split {
 \find(ifExThenElse{intVar (variable)}(phi,then,else))
-\sameUpdateLevel\varcond(\notFreeIn(intVar (variable), intSk (int skolem term)))
+\varcond(\notFreeIn(intVar (variable), intSk (int skolem term)))
 \add []==>[exists{intVar (variable)}(phi)] \replacewith(else) ;
 \add [subst{intVar (variable)}(intSk,phi),all{intVar (variable)}(imp(phi,wellOrderLeqInt(intSk,intVar)))]==>[] \replacewith(subst{intVar (variable)}(intSk,then)) 
 \heuristics(split_cond)
@@ -10312,7 +10312,7 @@ Choices: true}
 == ifExthenelse1_split_for (ifExthenelse1_split) =========================================
 ifExthenelse1_split_for {
 \find(ifExThenElse{intVar (variable)}(phi,b,c))
-\sameUpdateLevel\varcond(\notFreeIn(intVar (variable), intSk (int skolem term)))
+\varcond(\notFreeIn(intVar (variable), intSk (int skolem term)))
 \add []==>[exists{intVar (variable)}(phi)] \replacewith(c) ;
 \add [subst{intVar (variable)}(intSk,phi),all{intVar (variable)}(imp(phi,wellOrderLeqInt(intSk,intVar)))]==>[] \replacewith(subst{intVar (variable)}(intSk,b)) 
 \heuristics(split_cond)
@@ -10516,7 +10516,7 @@ Choices: true}
 == ifthenelse_split (ifthenelse_split) =========================================
 ifthenelse_split {
 \find(if-then-else(phi,then,else))
-\sameUpdateLevel\add []==>[phi] \replacewith(else) ;
+\add []==>[phi] \replacewith(else) ;
 \add [phi]==>[] \replacewith(then) 
 \heuristics(split_cond)
 Choices: true}
@@ -10524,7 +10524,7 @@ Choices: true}
 == ifthenelse_split_for (ifthenelse_split) =========================================
 ifthenelse_split_for {
 \find(if-then-else(phi,b,c))
-\sameUpdateLevel\add []==>[phi] \replacewith(c) ;
+\add []==>[phi] \replacewith(c) ;
 \add [phi]==>[] \replacewith(b) 
 \heuristics(split_cond)
 Choices: true}
@@ -10795,7 +10795,7 @@ Choices: true}
 inEqSimp_contradEq3 {
 \assumes ([leq(contradLeft,contradRightSmaller)]==>[]) 
 \find(equals(contradLeft,contradRightBigger))
-\sameUpdateLevel\replacewith(and(geq(add(contradRightSmaller,mul(Z(neglit(1(#))),contradRightBigger)),Z(0(#))),equals(contradLeft,contradRightBigger))) 
+\replacewith(and(geq(add(contradRightSmaller,mul(Z(neglit(1(#))),contradRightBigger)),Z(0(#))),equals(contradLeft,contradRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_contradEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10803,7 +10803,7 @@ Choices: true}
 inEqSimp_contradEq7 {
 \assumes ([geq(contradLeft,contradRightBigger)]==>[]) 
 \find(equals(contradLeft,contradRightSmaller))
-\sameUpdateLevel\replacewith(and(leq(add(contradRightBigger,mul(Z(neglit(1(#))),contradRightSmaller)),Z(0(#))),equals(contradLeft,contradRightSmaller))) 
+\replacewith(and(leq(add(contradRightBigger,mul(Z(neglit(1(#))),contradRightSmaller)),Z(0(#))),equals(contradLeft,contradRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_contradEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10811,7 +10811,7 @@ Choices: true}
 inEqSimp_contradInEq0 {
 \assumes ([leq(contradLeft,contradRightSmaller)]==>[]) 
 \find(geq(contradLeft,contradRightBigger))
-\sameUpdateLevel\replacewith(and(geq(contradRightSmaller,contradRightBigger),geq(contradLeft,contradRightBigger))) 
+\replacewith(and(geq(contradRightSmaller,contradRightBigger),geq(contradLeft,contradRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10819,7 +10819,7 @@ Choices: true}
 inEqSimp_contradInEq1 {
 \assumes ([geq(contradLeft,contradRightBigger)]==>[]) 
 \find(leq(contradLeft,contradRightSmaller))
-\sameUpdateLevel\replacewith(and(geq(contradRightSmaller,contradRightBigger),leq(contradLeft,contradRightSmaller))) 
+\replacewith(and(geq(contradRightSmaller,contradRightBigger),leq(contradLeft,contradRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10827,7 +10827,7 @@ Choices: true}
 inEqSimp_contradInEq2 {
 \assumes ([leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller)]==>[]) 
 \find(geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))
-\sameUpdateLevel\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),mul(contradCoeffSmaller,contradRightBigger)))),geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))) 
+\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),mul(contradCoeffSmaller,contradRightBigger)))),geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10835,7 +10835,7 @@ Choices: true}
 inEqSimp_contradInEq3 {
 \assumes ([leq(contradLeft,contradRightSmaller)]==>[]) 
 \find(geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))
-\sameUpdateLevel\replacewith(and(imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),contradRightBigger)),geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))) 
+\replacewith(and(imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),contradRightBigger)),geq(mul(contradLeft,contradCoeffBigger),contradRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10843,7 +10843,7 @@ Choices: true}
 inEqSimp_contradInEq4 {
 \assumes ([geq(mul(contradLeft,contradCoeffBigger),contradRightBigger)]==>[]) 
 \find(leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))
-\sameUpdateLevel\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),mul(contradCoeffSmaller,contradRightBigger)))),leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))) 
+\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),imp(gt(contradCoeffBigger,Z(0(#))),geq(mul(contradCoeffBigger,contradRightSmaller),mul(contradCoeffSmaller,contradRightBigger)))),leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -10851,7 +10851,7 @@ Choices: true}
 inEqSimp_contradInEq5 {
 \assumes ([geq(contradLeft,contradRightBigger)]==>[]) 
 \find(leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))
-\sameUpdateLevel\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),geq(contradRightSmaller,mul(contradCoeffSmaller,contradRightBigger))),leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))) 
+\replacewith(and(imp(gt(contradCoeffSmaller,Z(0(#))),geq(contradRightSmaller,mul(contradCoeffSmaller,contradRightBigger))),leq(mul(contradLeft,contradCoeffSmaller),contradRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_contradInEqs, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11145,7 +11145,7 @@ Choices: true}
 inEqSimp_subsumption0 {
 \assumes ([leq(subsumLeft,subsumRightSmaller)]==>[]) 
 \find(leq(subsumLeft,subsumRightBigger))
-\sameUpdateLevel\replacewith(or(leq(subsumRightSmaller,subsumRightBigger),leq(subsumLeft,subsumRightBigger))) 
+\replacewith(or(leq(subsumRightSmaller,subsumRightBigger),leq(subsumLeft,subsumRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11153,7 +11153,7 @@ Choices: true}
 inEqSimp_subsumption1 {
 \assumes ([geq(subsumLeft,subsumRightBigger)]==>[]) 
 \find(geq(subsumLeft,subsumRightSmaller))
-\sameUpdateLevel\replacewith(or(leq(subsumRightSmaller,subsumRightBigger),geq(subsumLeft,subsumRightSmaller))) 
+\replacewith(or(leq(subsumRightSmaller,subsumRightBigger),geq(subsumLeft,subsumRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11161,7 +11161,7 @@ Choices: true}
 inEqSimp_subsumption2 {
 \assumes ([leq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller)]==>[]) 
 \find(leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))
-\sameUpdateLevel\replacewith(or(and(and(gt(subsumCoeffSmaller,Z(0(#))),gt(subsumCoeffBigger,Z(0(#)))),leq(mul(subsumCoeffBigger,subsumRightSmaller),mul(subsumCoeffSmaller,subsumRightBigger))),leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))) 
+\replacewith(or(and(and(gt(subsumCoeffSmaller,Z(0(#))),gt(subsumCoeffBigger,Z(0(#)))),leq(mul(subsumCoeffBigger,subsumRightSmaller),mul(subsumCoeffSmaller,subsumRightBigger))),leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11169,7 +11169,7 @@ Choices: true}
 inEqSimp_subsumption4 {
 \assumes ([leq(subsumLeft,subsumRightSmaller)]==>[]) 
 \find(leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))
-\sameUpdateLevel\replacewith(or(and(gt(subsumCoeffBigger,Z(0(#))),leq(mul(subsumCoeffBigger,subsumRightSmaller),subsumRightBigger)),leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))) 
+\replacewith(or(and(gt(subsumCoeffBigger,Z(0(#))),leq(mul(subsumCoeffBigger,subsumRightSmaller),subsumRightBigger)),leq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11177,7 +11177,7 @@ Choices: true}
 inEqSimp_subsumption5 {
 \assumes ([geq(mul(subsumLeft,subsumCoeffBigger),subsumRightBigger)]==>[]) 
 \find(geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))
-\sameUpdateLevel\replacewith(or(and(and(gt(subsumCoeffSmaller,Z(0(#))),gt(subsumCoeffBigger,Z(0(#)))),leq(mul(subsumCoeffBigger,subsumRightSmaller),mul(subsumCoeffSmaller,subsumRightBigger))),geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))) 
+\replacewith(or(and(and(gt(subsumCoeffSmaller,Z(0(#))),gt(subsumCoeffBigger,Z(0(#)))),leq(mul(subsumCoeffBigger,subsumRightSmaller),mul(subsumCoeffSmaller,subsumRightBigger))),geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11185,7 +11185,7 @@ Choices: true}
 inEqSimp_subsumption6 {
 \assumes ([geq(subsumLeft,subsumRightBigger)]==>[]) 
 \find(geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))
-\sameUpdateLevel\replacewith(or(and(gt(subsumCoeffSmaller,Z(0(#))),leq(subsumRightSmaller,mul(subsumCoeffSmaller,subsumRightBigger))),geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))) 
+\replacewith(or(and(gt(subsumCoeffSmaller,Z(0(#))),leq(subsumRightSmaller,mul(subsumCoeffSmaller,subsumRightBigger))),geq(mul(subsumLeft,subsumCoeffSmaller),subsumRightSmaller))) 
 \heuristics(notHumanReadable, inEqSimp_subsumption, inEqSimp_propagation)
 Choices: true}
 -----------------------------------------------------
@@ -11200,7 +11200,7 @@ Choices: Strings:on}
 == indexOfSeqConcatFirst (indexOfSeqConcatFirst) =========================================
 indexOfSeqConcatFirst {
 \find(seqIndexOf(seqConcat(s1,s2),x))
-\sameUpdateLevel\varcond(\notFreeIn(idx (variable), x (any term)), \notFreeIn(idx (variable), s2 (Seq term)), \notFreeIn(idx (variable), s1 (Seq term)))
+\varcond(\notFreeIn(idx (variable), x (any term)), \notFreeIn(idx (variable), s2 (Seq term)), \notFreeIn(idx (variable), s1 (Seq term)))
 \add []==>[exists{idx (variable)}(and(and(leq(Z(0(#)),idx),lt(idx,seqLen(s1))),equals(seqGet<[any]>(s1,idx),x)))] ;
 \replacewith(seqIndexOf(s1,x)) 
 
@@ -11209,7 +11209,7 @@ Choices: sequences:on}
 == indexOfSeqConcatSecond (indexOfSeqConcatSecond) =========================================
 indexOfSeqConcatSecond {
 \find(seqIndexOf(seqConcat(s1,s2),x))
-\sameUpdateLevel\varcond(\notFreeIn(idx (variable), x (any term)), \notFreeIn(idx (variable), s2 (Seq term)), \notFreeIn(idx (variable), s1 (Seq term)))
+\varcond(\notFreeIn(idx (variable), x (any term)), \notFreeIn(idx (variable), s2 (Seq term)), \notFreeIn(idx (variable), s1 (Seq term)))
 \add []==>[and(not(exists{idx (variable)}(and(and(leq(Z(0(#)),idx),lt(idx,seqLen(s1))),equals(seqGet<[any]>(s1,idx),x)))),exists{idx (variable)}(and(and(leq(Z(0(#)),idx),lt(idx,seqLen(s2))),equals(seqGet<[any]>(s2,idx),x))))] ;
 \replacewith(add(seqIndexOf(s2,x),seqLen(s1))) 
 
@@ -11225,7 +11225,7 @@ Choices: sequences:on}
 == indexOfSeqSub (indexOfSeqSub) =========================================
 indexOfSeqSub {
 \find(seqIndexOf(seqSub(s,from,to),x))
-\sameUpdateLevel\varcond(\notFreeIn(nx (variable), to (int term)), \notFreeIn(nx (variable), from (int term)), \notFreeIn(nx (variable), x (any term)), \notFreeIn(nx (variable), s (Seq term)))
+\varcond(\notFreeIn(nx (variable), to (int term)), \notFreeIn(nx (variable), from (int term)), \notFreeIn(nx (variable), x (any term)), \notFreeIn(nx (variable), s (Seq term)))
 \add []==>[and(and(and(leq(from,seqIndexOf(s,x)),lt(seqIndexOf(s,x),to)),leq(Z(0(#)),from)),exists{nx (variable)}(and(and(leq(Z(0(#)),nx),lt(nx,seqLen(s))),equals(seqGet<[any]>(s,nx),x))))] ;
 \replacewith(sub(seqIndexOf(s,x),from)) 
 
@@ -11243,7 +11243,7 @@ Choices: Strings:on}
 ineffectiveCast {
 \assumes ([equals(instance<[H]>(t),TRUE)]==>[]) 
 \find(cast<[H]>(t))
-\sameUpdateLevel\add [equals(cast<[H]>(t),t)]==>[] 
+\add [equals(cast<[H]>(t),t)]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -11251,7 +11251,7 @@ Choices: true}
 ineffectiveCast2 {
 \assumes ([equals(cs,gt)]==>[]) 
 \find(cast<[C]>(gt))
-\sameUpdateLevel\add [equals(cast<[C]>(gt),gt)]==>[] 
+\add [equals(cast<[C]>(gt),gt)]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -11259,7 +11259,7 @@ Choices: true}
 ineffectiveCast3 {
 \assumes ([equals(exactInstance<[H]>(t),TRUE)]==>[]) 
 \find(cast<[H]>(t))
-\sameUpdateLevel\add [equals(cast<[H]>(t),t)]==>[] 
+\add [equals(cast<[H]>(t),t)]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -11315,7 +11315,7 @@ Choices: programRules:Java}
 insert_constant_string_value {
 \assumes ([wellFormed(heap)]==>[]) 
 \find(#csv)
-\sameUpdateLevel\add [or(equals(#constantvalue(#csv),null),and(not(equals(strPool(cast<[Seq]>(#constantvalue(#csv))),null)),equals(select<[boolean]>(heap,strPool(cast<[Seq]>(#constantvalue(#csv))),java.lang.Object::#$created),TRUE)))]==>[] \replacewith(if-then-else(equals(#constantvalue(#csv),null),null,strPool(cast<[Seq]>(#constantvalue(#csv))))) 
+\add [or(equals(#constantvalue(#csv),null),and(not(equals(strPool(cast<[Seq]>(#constantvalue(#csv))),null)),equals(select<[boolean]>(heap,strPool(cast<[Seq]>(#constantvalue(#csv))),java.lang.Object::#$created),TRUE)))]==>[] \replacewith(if-then-else(equals(#constantvalue(#csv),null),null,strPool(cast<[Seq]>(#constantvalue(#csv))))) 
 \heuristics(concrete)
 Choices: true}
 -----------------------------------------------------
@@ -11385,7 +11385,7 @@ Choices: true}
 instAll {
 \assumes ([all{u (variable)}(b)]==>[]) 
 \find(t)
-\sameUpdateLevel\add [subst{u (variable)}(t,b)]==>[] 
+\add [subst{u (variable)}(t,b)]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -11393,7 +11393,7 @@ Choices: true}
 instEx {
 \assumes ([]==>[exists{u (variable)}(b)]) 
 \find(t)
-\sameUpdateLevel\add []==>[subst{u (variable)}(t,b)] 
+\add []==>[subst{u (variable)}(t,b)] 
 
 Choices: true}
 -----------------------------------------------------
@@ -11474,7 +11474,7 @@ Choices: programRules:Java}
 instanceof_known_dynamic_type {
 \assumes ([equals(exactInstance<[G]>(a),TRUE)]==>[]) 
 \find(instance<[H]>(a))
-\sameUpdateLevel\varcond(\sub(G, H))
+\varcond(\sub(G, H))
 \replacewith(TRUE) 
 \heuristics(evaluate_instanceof, simplify)
 Choices: true}
@@ -11483,7 +11483,7 @@ Choices: true}
 instanceof_known_dynamic_type_2 {
 \assumes ([equals(exactInstance<[G]>(a),TRUE)]==>[]) 
 \find(instance<[H]>(a))
-\sameUpdateLevel\varcond(\not\sub(G, H))
+\varcond(\not\sub(G, H))
 \replacewith(FALSE) 
 \heuristics(evaluate_instanceof, simplify)
 Choices: true}
@@ -11524,7 +11524,7 @@ Choices: true}
 instanceof_not_compatible_5 {
 \assumes ([equals(instance<[H]>(a),TRUE)]==>[]) 
 \find(equals(instance<[G]>(a),TRUE))
-\sameUpdateLevel\varcond(\sub(Null, G), \disjointModuloNull(G, H))
+\varcond(\sub(Null, G), \disjointModuloNull(G, H))
 \replacewith(equals(a,null)) 
 \heuristics(evaluate_instanceof, concrete)
 Choices: true}
@@ -11541,7 +11541,7 @@ Choices: true}
 instanceof_static_type_2 {
 \assumes ([equals(a2,a)]==>[]) 
 \find(instance<[G]>(a))
-\sameUpdateLevel\varcond(\sub(\typeof(a2 (any term)), G))
+\varcond(\sub(\typeof(a2 (any term)), G))
 \replacewith(TRUE) 
 \heuristics(evaluate_instanceof, concrete)
 Choices: true}
@@ -11549,7 +11549,7 @@ Choices: true}
 == intDivRem (intDivRem) =========================================
 intDivRem {
 \find(jmod(divNum,divDenom))
-\sameUpdateLevel\add [imp(not(equals(divDenom,Z(0(#)))),equals(divNum,add(mul(jdiv(divNum,divDenom),divDenom),jmod(divNum,divDenom))))]==>[] 
+\add [imp(not(equals(divDenom,Z(0(#)))),equals(divNum,add(mul(jdiv(divNum,divDenom),divDenom),jmod(divNum,divDenom))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -11885,7 +11885,7 @@ Choices: true}
 == jdivMultDenom1 (jdivMultDenom1) =========================================
 jdivMultDenom1 {
 \find(jdiv(mul(divDenom,cfac),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(cfac) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -11893,7 +11893,7 @@ Choices: true}
 == jdivMultDenom2 (jdivMultDenom2) =========================================
 jdivMultDenom2 {
 \find(jdiv(mul(cfac,divDenom),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(cfac) 
 
 Choices: true}
@@ -11901,7 +11901,7 @@ Choices: true}
 == jdivPulloutMinusDenom (jdivPulloutMinusDenom) =========================================
 jdivPulloutMinusDenom {
 \find(jdiv(divNum,neg(divDenom)))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(neg(jdiv(divNum,divDenom))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -11909,7 +11909,7 @@ Choices: true}
 == jdivPulloutMinusNum (jdivPulloutMinusNum) =========================================
 jdivPulloutMinusNum {
 \find(jdiv(neg(divNum),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(neg(jdiv(divNum,divDenom))) 
 
 Choices: true}
@@ -11917,7 +11917,7 @@ Choices: true}
 == jdiv_axiom (jdiv_axiom) =========================================
 jdiv_axiom {
 \find(jdiv(divNum,divDenom))
-\sameUpdateLevel\add [equals(jdiv(divNum,divDenom),if-then-else(geq(divNum,Z(0(#))),div(divNum,divDenom),mul(div(mul(divNum,Z(neglit(1(#)))),divDenom),Z(neglit(1(#))))))]==>[] 
+\add [equals(jdiv(divNum,divDenom),if-then-else(geq(divNum,Z(0(#))),div(divNum,divDenom),mul(div(mul(divNum,Z(neglit(1(#)))),divDenom),Z(neglit(1(#))))))]==>[] 
 \heuristics(notHumanReadable, defOps_jdiv)
 Choices: true}
 -----------------------------------------------------
@@ -11938,35 +11938,35 @@ Choices: true}
 == jdiv_uniqueNegNeg (jdiv_uniqueNegNeg) =========================================
 jdiv_uniqueNegNeg {
 \find(jdiv(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(lt(a,Z(0(#))),lt(cnom,Z(0(#)))),geq(mul(x,cnom),a)),geq(mul(y,cnom),a)),lt(mul(add(x,Z(1(#))),cnom),a)),lt(mul(add(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(lt(a,Z(0(#))),lt(cnom,Z(0(#)))),geq(mul(x,cnom),a)),geq(mul(y,cnom),a)),lt(mul(add(x,Z(1(#))),cnom),a)),lt(mul(add(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jdiv_uniqueNegPos (jdiv_uniqueNegPos) =========================================
 jdiv_uniqueNegPos {
 \find(jdiv(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(lt(a,Z(0(#))),gt(cnom,Z(0(#)))),geq(mul(x,cnom),a)),geq(mul(y,cnom),a)),lt(mul(sub(x,Z(1(#))),cnom),a)),lt(mul(sub(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(lt(a,Z(0(#))),gt(cnom,Z(0(#)))),geq(mul(x,cnom),a)),geq(mul(y,cnom),a)),lt(mul(sub(x,Z(1(#))),cnom),a)),lt(mul(sub(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jdiv_uniquePosNeg (jdiv_uniquePosNeg) =========================================
 jdiv_uniquePosNeg {
 \find(jdiv(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(geq(a,Z(0(#))),lt(cnom,Z(0(#)))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),gt(mul(sub(x,Z(1(#))),cnom),a)),gt(mul(sub(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(geq(a,Z(0(#))),lt(cnom,Z(0(#)))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),gt(mul(sub(x,Z(1(#))),cnom),a)),gt(mul(sub(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jdiv_uniquePosPos (jdiv_uniquePosPos) =========================================
 jdiv_uniquePosPos {
 \find(jdiv(divNum,divDenom))
-\sameUpdateLevel\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(geq(a,Z(0(#))),gt(cnom,Z(0(#)))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),gt(mul(add(x,Z(1(#))),cnom),a)),gt(mul(add(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
+\add [all{a (variable)}(all{cnom (variable)}(all{x (variable)}(all{y (variable)}(imp(and(and(and(and(and(geq(a,Z(0(#))),gt(cnom,Z(0(#)))),leq(mul(x,cnom),a)),leq(mul(y,cnom),a)),gt(mul(add(x,Z(1(#))),cnom),a)),gt(mul(add(y,Z(1(#))),cnom),a)),equals(x,y))))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jdiv_zero (jdiv_zero) =========================================
 jdiv_zero {
 \find(jdiv(Z(0(#)),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(Z(0(#))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -11974,7 +11974,7 @@ Choices: true}
 == jmodAddMultDenomZero (jmodAddMultDenomZero) =========================================
 jmodAddMultDenomZero {
 \find(equals(jmod(add(N,mul(A,D)),D),Z(0(#))))
-\sameUpdateLevel\add []==>[not(equals(D,Z(0(#))))] ;
+\add []==>[not(equals(D,Z(0(#))))] ;
 \replacewith(equals(jmod(N,D),Z(0(#)))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -11994,7 +11994,7 @@ Choices: true}
 == jmodDivisibleRep (jmodDivisibleRep) =========================================
 jmodDivisibleRep {
 \find(jmod(mul(D,A),D))
-\sameUpdateLevel\add []==>[not(equals(D,Z(0(#))))] ;
+\add []==>[not(equals(D,Z(0(#))))] ;
 \replacewith(Z(0(#))) 
 \heuristics(simplify_enlarging)
 Choices: true}
@@ -12021,14 +12021,14 @@ Choices: true}
 == jmod_NumNeg (jmod_NumNeg) =========================================
 jmod_NumNeg {
 \find(jmod(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(not(equals(divDenom,Z(0(#)))),leq(divNum,Z(0(#)))),gt(jmod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),neg(divDenom),divDenom)))]==>[] 
+\add [imp(and(not(equals(divDenom,Z(0(#)))),leq(divNum,Z(0(#)))),gt(jmod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),neg(divDenom),divDenom)))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jmod_NumPos (jmod_NumPos) =========================================
 jmod_NumPos {
 \find(jmod(divNum,divDenom))
-\sameUpdateLevel\add [imp(and(not(equals(divDenom,Z(0(#)))),geq(divNum,Z(0(#)))),lt(jmod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),divDenom,neg(divDenom))))]==>[] 
+\add [imp(and(not(equals(divDenom,Z(0(#)))),geq(divNum,Z(0(#)))),lt(jmod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),divDenom,neg(divDenom))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12042,14 +12042,14 @@ Choices: true}
 == jmod_geZero (jmod_geZero) =========================================
 jmod_geZero {
 \find(jmod(divNum,divDenom))
-\sameUpdateLevel\add [imp(not(equals(divDenom,Z(0(#)))),leq(Z(0(#)),if-then-else(geq(divNum,Z(0(#))),jmod(divNum,divDenom),neg(jmod(divNum,divDenom)))))]==>[] 
+\add [imp(not(equals(divDenom,Z(0(#)))),leq(Z(0(#)),if-then-else(geq(divNum,Z(0(#))),jmod(divNum,divDenom),neg(jmod(divNum,divDenom)))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == jmod_pulloutminusDenom (jmod_pulloutminusDenom) =========================================
 jmod_pulloutminusDenom {
 \find(jmod(divNum,neg(divDenom)))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(jmod(divNum,divDenom)) 
 
 Choices: true}
@@ -12057,7 +12057,7 @@ Choices: true}
 == jmod_pulloutminusNum (jmod_pulloutminusNum) =========================================
 jmod_pulloutminusNum {
 \find(jmod(neg(divNum),divDenom))
-\sameUpdateLevel\add []==>[not(equals(divDenom,Z(0(#))))] ;
+\add []==>[not(equals(divDenom,Z(0(#))))] ;
 \replacewith(neg(jmod(divNum,divDenom))) 
 
 Choices: true}
@@ -12101,7 +12101,7 @@ Choices: true}
 == lenNonNegative (lenNonNegative) =========================================
 lenNonNegative {
 \find(seqLen(seq))
-\sameUpdateLevel\add [leq(Z(0(#)),seqLen(seq))]==>[] 
+\add [leq(Z(0(#)),seqLen(seq))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12123,7 +12123,7 @@ Choices: sequences:on}
 lenOfSeqConcatEQ {
 \assumes ([equals(seqConcat(seq,seq2),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(add(seqLen(seq),seqLen(seq2))) 
+\replacewith(add(seqLen(seq),seqLen(seq2))) 
 \heuristics(simplify)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12138,7 +12138,7 @@ Choices: sequences:on}
 lenOfSeqDefEQ {
 \assumes ([equals(seqDef{uSub (variable)}(from,to,t),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(if-then-else(leq(from,to),sub(to,from),Z(0(#)))) 
+\replacewith(if-then-else(leq(from,to),sub(to,from),Z(0(#)))) 
 \heuristics(simplify)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12153,7 +12153,7 @@ Choices: sequences:on}
 lenOfSeqEmptyEQ {
 \assumes ([equals(seqEmpty,EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(Z(0(#))) 
+\replacewith(Z(0(#))) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12168,7 +12168,7 @@ Choices: sequences:on}
 lenOfSeqReverseEQ {
 \assumes ([equals(seqReverse(seq),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(seqLen(seq)) 
+\replacewith(seqLen(seq)) 
 \heuristics(simplify)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12183,7 +12183,7 @@ Choices: sequences:on}
 lenOfSeqSingletonEQ {
 \assumes ([equals(seqSingleton(x),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(Z(1(#))) 
+\replacewith(Z(1(#))) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12198,7 +12198,7 @@ Choices: sequences:on}
 lenOfSeqSubEQ {
 \assumes ([equals(seqSub(seq,from,to),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(if-then-else(lt(from,to),sub(to,from),Z(0(#)))) 
+\replacewith(if-then-else(lt(from,to),sub(to,from),Z(0(#)))) 
 \heuristics(simplify)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -12220,7 +12220,7 @@ Choices: Strings:on}
 lengthReplaceEQ {
 \assumes ([equals(clReplace(str,searchChar,replaceChar),EQ)]==>[]) 
 \find(seqLen(EQ))
-\sameUpdateLevel\replacewith(seqLen(str)) 
+\replacewith(seqLen(str)) 
 \heuristics(stringsSimplify)
 Choices: Strings:on}
 -----------------------------------------------------
@@ -12417,7 +12417,7 @@ Choices: true}
 == less_is_total (less_is_total) =========================================
 less_is_total {
 \find(i)
-\sameUpdateLevel\add [lt(i0,i)]==>[] ;
+\add [lt(i0,i)]==>[] ;
 \add [equals(i,i0)]==>[] ;
 \add [lt(i,i0)]==>[] 
 
@@ -12508,7 +12508,7 @@ Choices: true}
 == less_zero_is_total (less_zero_is_total) =========================================
 less_zero_is_total {
 \find(i)
-\sameUpdateLevel\add [lt(Z(0(#)),i)]==>[] ;
+\add [lt(Z(0(#)),i)]==>[] ;
 \add [equals(i,Z(0(#)))]==>[] ;
 \add [lt(i,Z(0(#)))]==>[] 
 
@@ -12538,7 +12538,7 @@ Choices: true}
 == logLessThanPow (logLessThanPow) =========================================
 logLessThanPow {
 \find(lt(log(base,x),exp))
-\sameUpdateLevel\add [imp(and(and(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),lt(x,pow(base,exp))),geq(exp,Z(1(#)))),lt(log(base,x),exp))]==>[] 
+\add [imp(and(and(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),lt(x,pow(base,exp))),geq(exp,Z(1(#)))),lt(log(base,x),exp))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12552,7 +12552,7 @@ Choices: true}
 == logMono (logMono) =========================================
 logMono {
 \find(leq(log(base,x),log(base,x_2)))
-\sameUpdateLevel\add [imp(and(and(geq(x,Z(1(#))),geq(x_2,x)),gt(base,Z(1(#)))),leq(log(base,x),log(base,x_2)))]==>[] 
+\add [imp(and(and(geq(x,Z(1(#))),geq(x_2,x)),gt(base,Z(1(#)))),leq(log(base,x),log(base,x_2)))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12566,7 +12566,7 @@ Choices: true}
 == logPositive (logPositive) =========================================
 logPositive {
 \find(log(base,x))
-\sameUpdateLevel\add [imp(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),geq(log(base,x),Z(0(#))))]==>[] 
+\add [imp(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),geq(log(base,x),Z(0(#))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12580,7 +12580,7 @@ Choices: true}
 == logPowIdentity (logPowIdentity) =========================================
 logPowIdentity {
 \find(log(base,x))
-\sameUpdateLevel\varcond(\notFreeIn(i (variable), base (int term)), \notFreeIn(i (variable), x (int term)))
+\varcond(\notFreeIn(i (variable), base (int term)), \notFreeIn(i (variable), x (int term)))
 \add [imp(gt(base,Z(1(#))),all{i (variable)}(imp(geq(i,Z(0(#))),equals(log(base,pow(base,i)),i))))]==>[] 
 
 Choices: true}
@@ -12595,7 +12595,7 @@ Choices: true}
 == logProdIdentity (logProdIdentity) =========================================
 logProdIdentity {
 \find(log(base,bprod{i (variable)}(Z(0(#)),exp,base)))
-\sameUpdateLevel\varcond(\notFreeIn(i (variable), base (int term)), \notFreeIn(i (variable), exp (int term)))
+\varcond(\notFreeIn(i (variable), base (int term)), \notFreeIn(i (variable), exp (int term)))
 \add [imp(and(geq(exp,Z(0(#))),gt(base,Z(1(#)))),equals(log(base,bprod{i (variable)}(Z(0(#)),exp,base)),exp))]==>[] 
 
 Choices: true}
@@ -12611,7 +12611,7 @@ Choices: true}
 == logProduct (logProduct) =========================================
 logProduct {
 \find(log(base,mul(x,base)))
-\sameUpdateLevel\add [imp(and(geq(x,Z(1(#))),gt(base,Z(1(#)))),equals(log(base,mul(x,base)),add(log(base,x),Z(1(#)))))]==>[] 
+\add [imp(and(geq(x,Z(1(#))),gt(base,Z(1(#)))),equals(log(base,mul(x,base)),add(log(base,x),Z(1(#)))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12625,7 +12625,7 @@ Choices: true}
 == logSqueeze (logSqueeze) =========================================
 logSqueeze {
 \find(equals(log(base,x),exp))
-\sameUpdateLevel\add [imp(and(and(and(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),geq(x,pow(base,exp))),lt(x,pow(base,add(exp,Z(1(#)))))),geq(exp,Z(0(#)))),equals(log(base,x),exp))]==>[] 
+\add [imp(and(and(and(and(gt(base,Z(1(#))),geq(x,Z(1(#)))),geq(x,pow(base,exp))),lt(x,pow(base,add(exp,Z(1(#)))))),geq(exp,Z(0(#)))),equals(log(base,x),exp))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -12641,7 +12641,7 @@ loopScopeInvBox {
 \find(#box ((modal operator))|{{ ..
   while (#nse) #body
 ... }}| (post))
-\sameUpdateLevel\varcond(\new(#permissionsBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#savedHeapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#heapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#x (program Variable), (type, sort): (boolean,boolean)), \newLocalVars(#localVarDeclsBefore_LOOP (program Statement), #updateBefore_LOOP (update), #updateFrame_LOOP (update), #body (program Statement)), \varcond (\storeTermIn(loopFormula (formula), #box ((modal operator))|{{
+\varcond(\new(#permissionsBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#savedHeapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#heapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#x (program Variable), (type, sort): (boolean,boolean)), \newLocalVars(#localVarDeclsBefore_LOOP (program Statement), #updateBefore_LOOP (update), #updateFrame_LOOP (update), #body (program Statement)), \varcond (\storeTermIn(loopFormula (formula), #box ((modal operator))|{{
   while (#nse) #body
 }}| (post))), \varcond (\storeStmtIn(#loopStmt (program Statement), #box ((modal operator))|{{
   while (#nse) #body
@@ -12671,7 +12671,7 @@ loopScopeInvDia {
 \find(#dia ((modal operator))|{{ ..
   while (#nse) #body
 ... }}| (post))
-\sameUpdateLevel\varcond(\new(#permissionsBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#savedHeapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#heapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#variant (program Variable), KeYJavaType:null,any), \new(#x (program Variable), (type, sort): (boolean,boolean)), \newLocalVars(#localVarDeclsBefore_LOOP (program Statement), #updateBefore_LOOP (update), #updateFrame_LOOP (update), #body (program Statement)), \varcond (\storeTermIn(loopFormula (formula), #dia ((modal operator))|{{
+\varcond(\new(#permissionsBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#savedHeapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#heapBefore_LOOP (program Variable), KeYJavaType:null,Heap), \new(#variant (program Variable), KeYJavaType:null,any), \new(#x (program Variable), (type, sort): (boolean,boolean)), \newLocalVars(#localVarDeclsBefore_LOOP (program Statement), #updateBefore_LOOP (update), #updateFrame_LOOP (update), #body (program Statement)), \varcond (\storeTermIn(loopFormula (formula), #dia ((modal operator))|{{
   while (#nse) #body
 }}| (post))), \varcond (\storeStmtIn(#loopStmt (program Statement), #dia ((modal operator))|{{
   while (#nse) #body
@@ -12924,7 +12924,7 @@ Choices: true}
 == mapSizeNotNegativeForFiniteMaps (mapSizeNotNegativeForFiniteMaps) =========================================
 mapSizeNotNegativeForFiniteMaps {
 \find(mapSize(m))
-\sameUpdateLevel\add [imp(isFinite(m),geq(mapSize(m),Z(0(#))))]==>[] 
+\add [imp(isFinite(m),geq(mapSize(m),Z(0(#))))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -12955,7 +12955,7 @@ Choices: integerSimplificationRules:full}
 measuredByCheck {
 \assumes ([measuredBy(m)]==>[]) 
 \find(measuredByCheck(c))
-\sameUpdateLevel\replacewith(prec(c,m)) 
+\replacewith(prec(c,m)) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
@@ -12963,7 +12963,7 @@ Choices: true}
 measuredByCheckEmpty {
 \assumes ([measuredByEmpty]==>[]) 
 \find(measuredByCheck(c))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
@@ -13235,7 +13235,7 @@ Choices: true}
 == mod_geZero (mod_geZero) =========================================
 mod_geZero {
 \find(mod(divNum,divDenom))
-\sameUpdateLevel\add [imp(not(equals(divDenom,Z(0(#)))),leq(Z(0(#)),mod(divNum,divDenom)))]==>[] 
+\add [imp(not(equals(divDenom,Z(0(#)))),leq(Z(0(#)),mod(divNum,divDenom)))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -13249,7 +13249,7 @@ Choices: true}
 == mod_lessDenom (mod_lessDenom) =========================================
 mod_lessDenom {
 \find(mod(divNum,divDenom))
-\sameUpdateLevel\add [imp(not(equals(divDenom,Z(0(#)))),lt(mod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),divDenom,neg(divDenom))))]==>[] 
+\add [imp(not(equals(divDenom,Z(0(#)))),lt(mod(divNum,divDenom),if-then-else(geq(divDenom,Z(0(#))),divDenom,neg(divDenom))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -13257,14 +13257,14 @@ Choices: true}
 moduloByteFixpoint {
 \assumes ([inRangeByte(i)]==>[]) 
 \find(moduloByte(i))
-\sameUpdateLevel\replacewith(i) 
+\replacewith(i) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == moduloByteFixpointInline (moduloByteFixpointInline) =========================================
 moduloByteFixpointInline {
 \find(moduloByte(i))
-\sameUpdateLevel\add [equals(if-then-else(inRangeByte(i),i,moduloT),moduloT),equals(moduloByte(i),moduloT)]==>[] \replacewith(moduloT) 
+\add [equals(if-then-else(inRangeByte(i),i,moduloT),moduloT),equals(moduloByte(i),moduloT)]==>[] \replacewith(moduloT) 
 
 Choices: true}
 -----------------------------------------------------
@@ -13286,14 +13286,14 @@ Choices: true}
 moduloCharFixpoint {
 \assumes ([inRangeChar(i)]==>[]) 
 \find(moduloChar(i))
-\sameUpdateLevel\replacewith(i) 
+\replacewith(i) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == moduloCharFixpointInline (moduloCharFixpointInline) =========================================
 moduloCharFixpointInline {
 \find(moduloChar(i))
-\sameUpdateLevel\add [equals(if-then-else(inRangeChar(i),i,moduloT),moduloT),equals(moduloChar(i),moduloT)]==>[] \replacewith(moduloT) 
+\add [equals(if-then-else(inRangeChar(i),i,moduloT),moduloT),equals(moduloChar(i),moduloT)]==>[] \replacewith(moduloT) 
 
 Choices: true}
 -----------------------------------------------------
@@ -13315,14 +13315,14 @@ Choices: true}
 moduloIntFixpoint {
 \assumes ([inRangeInt(i)]==>[]) 
 \find(moduloInt(i))
-\sameUpdateLevel\replacewith(i) 
+\replacewith(i) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == moduloIntFixpointInline (moduloIntFixpointInline) =========================================
 moduloIntFixpointInline {
 \find(moduloInt(i))
-\sameUpdateLevel\add [equals(if-then-else(inRangeInt(i),i,moduloT),moduloT),equals(moduloInt(i),moduloT)]==>[] \replacewith(moduloT) 
+\add [equals(if-then-else(inRangeInt(i),i,moduloT),moduloT),equals(moduloInt(i),moduloT)]==>[] \replacewith(moduloT) 
 
 Choices: true}
 -----------------------------------------------------
@@ -13344,14 +13344,14 @@ Choices: true}
 moduloLongFixpoint {
 \assumes ([inRangeLong(i)]==>[]) 
 \find(moduloLong(i))
-\sameUpdateLevel\replacewith(i) 
+\replacewith(i) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == moduloLongFixpointInline (moduloLongFixpointInline) =========================================
 moduloLongFixpointInline {
 \find(moduloLong(i))
-\sameUpdateLevel\add [equals(if-then-else(inRangeLong(i),i,moduloT),moduloT),equals(moduloLong(i),moduloT)]==>[] \replacewith(moduloT) 
+\add [equals(if-then-else(inRangeLong(i),i,moduloT),moduloT),equals(moduloLong(i),moduloT)]==>[] \replacewith(moduloT) 
 
 Choices: true}
 -----------------------------------------------------
@@ -13373,14 +13373,14 @@ Choices: true}
 moduloShortFixpoint {
 \assumes ([inRangeShort(i)]==>[]) 
 \find(moduloShort(i))
-\sameUpdateLevel\replacewith(i) 
+\replacewith(i) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == moduloShortFixpointInline (moduloShortFixpointInline) =========================================
 moduloShortFixpointInline {
 \find(moduloShort(i))
-\sameUpdateLevel\add [equals(if-then-else(inRangeShort(i),i,moduloT),moduloT),equals(moduloShort(i),moduloT)]==>[] \replacewith(moduloT) 
+\add [equals(if-then-else(inRangeShort(i),i,moduloT),moduloT),equals(moduloShort(i),moduloT)]==>[] \replacewith(moduloT) 
 
 Choices: true}
 -----------------------------------------------------
@@ -13560,7 +13560,7 @@ Choices: integerSimplificationRules:full}
 narrowFinalArrayType {
 \assumes ([]==>[equals(o,null)]) 
 \find(final<[beta]>(o,arr(idx)))
-\sameUpdateLevel\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \strict\sub(alpha, beta))
+\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \strict\sub(alpha, beta))
 \replacewith(final<[alpha]>(o,arr(idx))) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -13569,7 +13569,7 @@ Choices: programRules:Java}
 narrowSelectArrayType {
 \assumes ([wellFormed(h)]==>[equals(o,null)]) 
 \find(select<[beta]>(h,o,arr(idx)))
-\sameUpdateLevel\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \strict\sub(alpha, beta))
+\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \strict\sub(alpha, beta))
 \replacewith(select<[alpha]>(h,o,arr(idx))) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -13578,7 +13578,7 @@ Choices: programRules:Java}
 narrowSelectType {
 \assumes ([wellFormed(h)]==>[]) 
 \find(select<[beta]>(h,o,f))
-\sameUpdateLevel\varcond(\fieldType(f (Field term), alpha), \strict\sub(alpha, beta))
+\varcond(\fieldType(f (Field term), alpha), \strict\sub(alpha, beta))
 \replacewith(select<[alpha]>(h,o,f)) 
 \heuristics(simplify)
 Choices: programRules:Java}
@@ -13945,7 +13945,7 @@ Choices: true}
 null_can_always_be_stored_in_a_reference_type_array {
 \assumes ([]==>[equals(array,null)]) 
 \find(arrayStoreValid(array,null))
-\sameUpdateLevel\varcond(\isReferenceArray(array (GOS term)))
+\varcond(\isReferenceArray(array (GOS term)))
 \replacewith(true) 
 \heuristics(simplify_java)
 Choices: programRules:Java}
@@ -13953,7 +13953,7 @@ Choices: programRules:Java}
 == observerDependency (observerDependency) =========================================
 observerDependency {
 \find(termWithLargeHeap)
-\sameUpdateLevel\inSequentState\varcond(\sameObserver (termWithLargeHeap (any term), termWithSmallHeap (any term)))
+\inSequentState\varcond(\sameObserver (termWithLargeHeap (any term), termWithSmallHeap (any term)))
 \add []==>[#ObserverEquality(termWithLargeHeap,termWithSmallHeap)] ;
 \replacewith(termWithSmallHeap) 
 
@@ -13962,7 +13962,7 @@ Choices: programRules:Java}
 == observerDependencyEQ (observerDependencyEQ) =========================================
 observerDependencyEQ {
 \find(equals(t1,t2))
-\sameUpdateLevel\inSequentState\varcond(\sameObserver (t1 (any term), t2 (any term)))
+\inSequentState\varcond(\sameObserver (t1 (any term), t2 (any term)))
 \add []==>[#ObserverEquality(t1,t2)] ;
 \replacewith(true) 
 
@@ -13971,7 +13971,7 @@ Choices: programRules:Java}
 == observerDependencyEquiv (observerDependencyEQ) =========================================
 observerDependencyEquiv {
 \find(equiv(t1,t2))
-\sameUpdateLevel\inSequentState\varcond(\sameObserver (t1 (formula), t2 (formula)))
+\inSequentState\varcond(\sameObserver (t1 (formula), t2 (formula)))
 \add []==>[#ObserverEquality(t1,t2)] ;
 \replacewith(true) 
 
@@ -13980,7 +13980,7 @@ Choices: programRules:Java}
 == observerDependencyFormula (observerDependency) =========================================
 observerDependencyFormula {
 \find(termWithLargeHeap)
-\sameUpdateLevel\inSequentState\varcond(\sameObserver (termWithLargeHeap (formula), termWithSmallHeap (formula)))
+\inSequentState\varcond(\sameObserver (termWithLargeHeap (formula), termWithSmallHeap (formula)))
 \add []==>[#ObserverEquality(termWithLargeHeap,termWithSmallHeap)] ;
 \replacewith(termWithSmallHeap) 
 
@@ -14021,7 +14021,7 @@ Choices: programRules:Java}
 == onlyCreatedObjectsAreObserved (onlyCreatedObjectsAreObserved) =========================================
 onlyCreatedObjectsAreObserved {
 \find(obs)
-\sameUpdateLevel\varcond(\isObserver (obs (deltaObject term), h (Heap term)))
+\varcond(\isObserver (obs (deltaObject term), h (Heap term)))
 \add [or(equals(obs,null),equals(select<[boolean]>(h,obs,java.lang.Object::#$created),TRUE))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: programRules:Java}
@@ -14047,7 +14047,7 @@ Choices: programRules:Java}
 onlyCreatedObjectsAreReferenced {
 \assumes ([wellFormed(h)]==>[]) 
 \find(select<[deltaObject]>(h,o,f))
-\sameUpdateLevel\add [or(equals(select<[deltaObject]>(h,o,f),null),equals(select<[boolean]>(h,select<[deltaObject]>(h,o,f),java.lang.Object::#$created),TRUE))]==>[] 
+\add [or(equals(select<[deltaObject]>(h,o,f),null),equals(select<[boolean]>(h,select<[deltaObject]>(h,o,f),java.lang.Object::#$created),TRUE))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -14055,7 +14055,7 @@ Choices: programRules:Java}
 onlyCreatedObjectsAreReferencedFinal {
 \assumes ([wellFormed(h),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE)]==>[]) 
 \find(final<[deltaObject]>(o,f))
-\sameUpdateLevel\add [or(equals(final<[deltaObject]>(o,f),null),equals(select<[boolean]>(h,final<[deltaObject]>(o,f),java.lang.Object::#$created),TRUE))]==>[] 
+\add [or(equals(final<[deltaObject]>(o,f),null),equals(select<[boolean]>(h,final<[deltaObject]>(o,f),java.lang.Object::#$created),TRUE))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -14098,7 +14098,7 @@ Choices: true}
 == orJintInInt (orJintInInt) =========================================
 orJintInInt {
 \find(orJint(left,right))
-\sameUpdateLevel\add [inRangeInt(orJint(left,right))]==>[] 
+\add [inRangeInt(orJint(left,right))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -14163,7 +14163,7 @@ Choices: true}
 == polyMod_ltdivDenom (polyMod_ltdivDenom) =========================================
 polyMod_ltdivDenom {
 \find(mod(divNum,divDenom))
-\sameUpdateLevel\add [and(imp(gt(divDenom,Z(0(#))),lt(mod(divNum,divDenom),divDenom)),imp(lt(divDenom,Z(0(#))),lt(mod(divNum,divDenom),neg(divDenom))))]==>[] 
+\add [and(imp(gt(divDenom,Z(0(#))),lt(mod(divNum,divDenom),divDenom)),imp(lt(divDenom,Z(0(#))),lt(mod(divNum,divDenom),neg(divDenom))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -14615,84 +14615,84 @@ Choices: true}
 == powIsInfinite1 (powIsInfinite1) =========================================
 powIsInfinite1 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(or(and(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),gtDouble(arg2,DFP(0(#)))),and(and(and(ltDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),gtDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),ltDouble(arg2,DFP(0(#))))),and(doubleIsInfinite(powDouble(arg1,arg2)),gtDouble(powDouble(arg1,arg2),DFP(0(#)))))]==>[] 
+\add [imp(or(and(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),gtDouble(arg2,DFP(0(#)))),and(and(and(ltDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),gtDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),ltDouble(arg2,DFP(0(#))))),and(doubleIsInfinite(powDouble(arg1,arg2)),gtDouble(powDouble(arg1,arg2),DFP(0(#)))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsInfinite2 (powIsInfinite2) =========================================
 powIsInfinite2 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(or(and(eqDouble(arg1,DFP(0(#))),ltDouble(arg2,DFP(0(#)))),and(and(doubleIsInfinite(arg1),gtDouble(arg1,DFP(0(#)))),gtDouble(arg2,DFP(0(#))))),and(doubleIsInfinite(powDouble(arg1,arg2)),gtDouble(powDouble(arg1,arg2),DFP(0(#)))))]==>[] 
+\add [imp(or(and(eqDouble(arg1,DFP(0(#))),ltDouble(arg2,DFP(0(#)))),and(and(doubleIsInfinite(arg1),gtDouble(arg1,DFP(0(#)))),gtDouble(arg2,DFP(0(#))))),and(doubleIsInfinite(powDouble(arg1,arg2)),gtDouble(powDouble(arg1,arg2),DFP(0(#)))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsNaN1 (powIsNaN1) =========================================
 powIsNaN1 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(doubleIsNaN(arg2),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
+\add [imp(doubleIsNaN(arg2),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsNaN2 (powIsNaN2) =========================================
 powIsNaN2 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(and(doubleIsNaN(arg1),not(equals(arg2,DFP(0(#))))),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
+\add [imp(and(doubleIsNaN(arg1),not(equals(arg2,DFP(0(#))))),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsNaN3 (powIsNaN3) =========================================
 powIsNaN3 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
+\add [imp(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),doubleIsNaN(powDouble(arg1,arg2)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsNotNaN (powIsNotNaN) =========================================
 powIsNotNaN {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg1)),equals(arg2,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),equals(powDouble(arg1,arg2),arg1))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg1)),equals(arg2,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),equals(powDouble(arg1,arg2),arg1))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsOne (powIsOne) =========================================
 powIsOne {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(equals(arg2,DFP(0(#))),equals(powDouble(arg1,arg2),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))]==>[] 
+\add [imp(equals(arg2,DFP(0(#))),equals(powDouble(arg1,arg2),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsZero1 (powIsZero1) =========================================
 powIsZero1 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(or(and(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),ltDouble(arg2,DFP(0(#)))),and(and(and(ltDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),gtDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),gtDouble(arg2,DFP(0(#))))),equals(powDouble(arg1,arg2),DFP(0(#))))]==>[] 
+\add [imp(or(and(and(or(geqDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),leqDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),ltDouble(arg2,DFP(0(#)))),and(and(and(ltDouble(arg1,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))),gtDouble(arg1,negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#))))))))))))))))))))))),doubleIsInfinite(arg2)),gtDouble(arg2,DFP(0(#))))),equals(powDouble(arg1,arg2),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powIsZero2 (powIsZero2) =========================================
 powIsZero2 {
 \find(powDouble(arg1,arg2))
-\sameUpdateLevel\add [imp(or(and(eqDouble(arg1,DFP(0(#))),gtDouble(arg2,DFP(0(#)))),and(and(doubleIsInfinite(arg1),gtDouble(arg1,DFP(0(#)))),ltDouble(arg2,DFP(0(#))))),equals(powDouble(arg1,arg2),DFP(0(#))))]==>[] 
+\add [imp(or(and(eqDouble(arg1,DFP(0(#))),gtDouble(arg2,DFP(0(#)))),and(and(doubleIsInfinite(arg1),gtDouble(arg1,DFP(0(#)))),ltDouble(arg2,DFP(0(#))))),equals(powDouble(arg1,arg2),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == powLogLess (powLogLess) =========================================
 powLogLess {
 \find(pow(base,log(base,exp)))
-\sameUpdateLevel\add [imp(and(geq(exp,Z(1(#))),gt(base,Z(1(#)))),leq(pow(base,log(base,exp)),exp))]==>[] 
+\add [imp(and(geq(exp,Z(1(#))),gt(base,Z(1(#)))),leq(pow(base,log(base,exp)),exp))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == powLogMore2 (powLogMore2) =========================================
 powLogMore2 {
 \find(pow(base,log(base,x)))
-\sameUpdateLevel\add [imp(and(equals(base,Z(2(#))),geq(x,Z(1(#)))),lt(sub(x,pow(base,log(base,x))),pow(base,log(base,x))))]==>[] 
+\add [imp(and(equals(base,Z(2(#))),geq(x,Z(1(#)))),lt(sub(x,pow(base,log(base,x))),pow(base,log(base,x))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
 == powMono (powMono) =========================================
 powMono {
 \find(leq(pow(base,exp),pow(base,exp_2)))
-\sameUpdateLevel\add [imp(and(and(geq(exp,Z(0(#))),geq(exp_2,exp)),geq(base,Z(1(#)))),leq(pow(base,exp),pow(base,exp_2)))]==>[] 
+\add [imp(and(and(geq(exp,Z(0(#))),geq(exp_2,exp)),geq(base,Z(1(#)))),leq(pow(base,exp),pow(base,exp_2)))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -14713,7 +14713,7 @@ Choices: true}
 == powPositive (powPositive) =========================================
 powPositive {
 \find(pow(base,exp))
-\sameUpdateLevel\add [imp(and(geq(exp,Z(0(#))),geq(base,Z(1(#)))),geq(pow(base,exp),Z(1(#))))]==>[] 
+\add [imp(and(geq(exp,Z(0(#))),geq(base,Z(1(#)))),geq(pow(base,exp),Z(1(#))))]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -14967,14 +14967,14 @@ Choices: integerSimplificationRules:full}
 == pullOut (pullOut) =========================================
 pullOut {
 \find(t)
-\sameUpdateLevel\add [equals(t,sk)]==>[] \replacewith(sk) 
+\add [equals(t,sk)]==>[] \replacewith(sk) 
 \heuristics(pull_out_heap)
 Choices: true}
 -----------------------------------------------------
 == pullOutSelect (pullOutSelect) =========================================
 pullOutSelect {
 \find(select<[beta]>(h,o,f))
-\sameUpdateLevel\add [equals(select<[beta]>(h,o,f),selectSK<<selectSK>>)]==>[] \replacewith(selectSK<<selectSK>>) 
+\add [equals(select<[beta]>(h,o,f),selectSK<<selectSK>>)]==>[] \replacewith(selectSK<<selectSK>>) 
 \heuristics(pull_out_select)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15040,7 +15040,7 @@ Choices: reach:on}
 == reachDependenciesAnon (reachDependenciesAnon) =========================================
 reachDependenciesAnon {
 \find(reach(anon(h,s2,h2),s,o,o2,n))
-\sameUpdateLevel\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), h2 (Heap term)), \notFreeIn(nv (variable), s2 (LocSet term)), \notFreeIn(nv (variable), h (Heap term)), \notFreeIn(fv (variable), n (int term)), \notFreeIn(fv (variable), o2 (java.lang.Object term)), \notFreeIn(fv (variable), o (java.lang.Object term)), \notFreeIn(fv (variable), s (LocSet term)), \notFreeIn(fv (variable), h2 (Heap term)), \notFreeIn(fv (variable), s2 (LocSet term)), \notFreeIn(fv (variable), h (Heap term)), \notFreeIn(ov (variable), n (int term)), \notFreeIn(ov (variable), o2 (java.lang.Object term)), \notFreeIn(ov (variable), o (java.lang.Object term)), \notFreeIn(ov (variable), s (LocSet term)), \notFreeIn(ov (variable), h2 (Heap term)), \notFreeIn(ov (variable), s2 (LocSet term)), \notFreeIn(ov (variable), h (Heap term)))
+\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), h2 (Heap term)), \notFreeIn(nv (variable), s2 (LocSet term)), \notFreeIn(nv (variable), h (Heap term)), \notFreeIn(fv (variable), n (int term)), \notFreeIn(fv (variable), o2 (java.lang.Object term)), \notFreeIn(fv (variable), o (java.lang.Object term)), \notFreeIn(fv (variable), s (LocSet term)), \notFreeIn(fv (variable), h2 (Heap term)), \notFreeIn(fv (variable), s2 (LocSet term)), \notFreeIn(fv (variable), h (Heap term)), \notFreeIn(ov (variable), n (int term)), \notFreeIn(ov (variable), o2 (java.lang.Object term)), \notFreeIn(ov (variable), o (java.lang.Object term)), \notFreeIn(ov (variable), s (LocSet term)), \notFreeIn(ov (variable), h2 (Heap term)), \notFreeIn(ov (variable), s2 (LocSet term)), \notFreeIn(ov (variable), h (Heap term)))
 \add [all{ov (variable)}(all{fv (variable)}(not(and(and(elementOf(ov,fv,s2),exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,ov,nv)))),elementOf(ov,fv,s)))))]==>[] \replacewith(reach(h,s,o,o2,n)) ;
 \add []==>[all{ov (variable)}(all{fv (variable)}(not(and(and(elementOf(ov,fv,s2),exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,ov,nv)))),elementOf(ov,fv,s)))))] 
 
@@ -15049,7 +15049,7 @@ Choices: reach:on}
 == reachDependenciesAnonCoarse (reachDependenciesAnonCoarse) =========================================
 reachDependenciesAnonCoarse {
 \find(reach(anon(h,s2,h2),s,o,o2,n))
-\sameUpdateLevel\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), h2 (Heap term)), \notFreeIn(nv (variable), s2 (LocSet term)), \notFreeIn(nv (variable), h (Heap term)), \notFreeIn(fv (variable), n (int term)), \notFreeIn(fv (variable), o2 (java.lang.Object term)), \notFreeIn(fv (variable), o (java.lang.Object term)), \notFreeIn(fv (variable), s (LocSet term)), \notFreeIn(fv (variable), h2 (Heap term)), \notFreeIn(fv (variable), s2 (LocSet term)), \notFreeIn(fv (variable), h (Heap term)), \notFreeIn(ov (variable), n (int term)), \notFreeIn(ov (variable), o2 (java.lang.Object term)), \notFreeIn(ov (variable), o (java.lang.Object term)), \notFreeIn(ov (variable), s (LocSet term)), \notFreeIn(ov (variable), h2 (Heap term)), \notFreeIn(ov (variable), s2 (LocSet term)), \notFreeIn(ov (variable), h (Heap term)))
+\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), h2 (Heap term)), \notFreeIn(nv (variable), s2 (LocSet term)), \notFreeIn(nv (variable), h (Heap term)), \notFreeIn(fv (variable), n (int term)), \notFreeIn(fv (variable), o2 (java.lang.Object term)), \notFreeIn(fv (variable), o (java.lang.Object term)), \notFreeIn(fv (variable), s (LocSet term)), \notFreeIn(fv (variable), h2 (Heap term)), \notFreeIn(fv (variable), s2 (LocSet term)), \notFreeIn(fv (variable), h (Heap term)), \notFreeIn(ov (variable), n (int term)), \notFreeIn(ov (variable), o2 (java.lang.Object term)), \notFreeIn(ov (variable), o (java.lang.Object term)), \notFreeIn(ov (variable), s (LocSet term)), \notFreeIn(ov (variable), h2 (Heap term)), \notFreeIn(ov (variable), s2 (LocSet term)), \notFreeIn(ov (variable), h (Heap term)))
 \add [all{ov (variable)}(all{fv (variable)}(not(and(and(elementOf(ov,fv,s2),exists{nv (variable)}(reach(h,s,o,ov,nv))),elementOf(ov,fv,s)))))]==>[] \replacewith(reach(h,s,o,o2,n)) ;
 \add []==>[all{ov (variable)}(all{fv (variable)}(not(and(and(elementOf(ov,fv,s2),exists{nv (variable)}(reach(h,s,o,ov,nv))),elementOf(ov,fv,s)))))] 
 
@@ -15058,7 +15058,7 @@ Choices: reach:on}
 == reachDependenciesStore (reachDependenciesStore) =========================================
 reachDependenciesStore {
 \find(reach(store(h,o3,f,x),s,o,o2,n))
-\sameUpdateLevel\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), x (any term)), \notFreeIn(nv (variable), f (Field term)), \notFreeIn(nv (variable), o3 (java.lang.Object term)), \notFreeIn(nv (variable), h (Heap term)))
+\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), x (any term)), \notFreeIn(nv (variable), f (Field term)), \notFreeIn(nv (variable), o3 (java.lang.Object term)), \notFreeIn(nv (variable), h (Heap term)))
 \add [not(and(exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,o3,nv))),elementOf(o3,f,s)))]==>[] \replacewith(reach(h,s,o,o2,n)) ;
 \add []==>[not(and(exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,o3,nv))),elementOf(o3,f,s)))] 
 
@@ -15068,7 +15068,7 @@ Choices: reach:on}
 reachDependenciesStoreEQ {
 \assumes ([equals(store(h,o3,f,x),EQ)]==>[]) 
 \find(reach(EQ,s,o,o2,n))
-\sameUpdateLevel\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), x (any term)), \notFreeIn(nv (variable), f (Field term)), \notFreeIn(nv (variable), o3 (java.lang.Object term)), \notFreeIn(nv (variable), h (Heap term)))
+\varcond(\notFreeIn(nv (variable), n (int term)), \notFreeIn(nv (variable), o2 (java.lang.Object term)), \notFreeIn(nv (variable), o (java.lang.Object term)), \notFreeIn(nv (variable), s (LocSet term)), \notFreeIn(nv (variable), x (any term)), \notFreeIn(nv (variable), f (Field term)), \notFreeIn(nv (variable), o3 (java.lang.Object term)), \notFreeIn(nv (variable), h (Heap term)))
 \add [not(and(exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,o3,nv))),elementOf(o3,f,s)))]==>[] \replacewith(reach(h,s,o,o2,n)) ;
 \add []==>[not(and(exists{nv (variable)}(and(lt(nv,n),reach(h,s,o,o3,nv))),elementOf(o3,f,s)))] 
 
@@ -15086,7 +15086,7 @@ Choices: reach:on}
 reachDependenciesStoreSimpleEQ {
 \assumes ([equals(store(h,o3,f2,x),EQ)]==>[]) 
 \find(reach(EQ,allObjects(f),o,o2,n))
-\sameUpdateLevel\varcond(\metaDisjoint f (Field term), f2 (Field term))
+\varcond(\metaDisjoint f (Field term), f2 (Field term))
 \replacewith(reach(h,allObjects(f),o,o2,n)) 
 \heuristics(simplify)
 Choices: reach:on}
@@ -15157,7 +15157,7 @@ Choices: reach:on}
 reach_does_not_depend_on_fresh_locs {
 \assumes ([]==>[equals(o,null)]) 
 \find(reach(anon(h,empty,h2),s,o,o2,n))
-\sameUpdateLevel\add []==>[and(wellFormed(h),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))] ;
+\add []==>[and(wellFormed(h),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))] ;
 \replacewith(reach(h,s,o,o2,n)) 
 \heuristics(simplify)
 Choices: reach:on}
@@ -15166,7 +15166,7 @@ Choices: reach:on}
 reach_does_not_depend_on_fresh_locsEQ {
 \assumes ([equals(anon(h,empty,h2),EQ)]==>[equals(o,null)]) 
 \find(reach(EQ,s,o,o2,n))
-\sameUpdateLevel\add []==>[and(wellFormed(h),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))] ;
+\add []==>[and(wellFormed(h),equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE))] ;
 \replacewith(reach(h,s,o,o2,n)) 
 \heuristics(simplify)
 Choices: reach:on}
@@ -15403,7 +15403,7 @@ Choices: Strings:on}
 == replaceDef (replaceDef) =========================================
 replaceDef {
 \find(clReplace(str,searchChar,replChar))
-\sameUpdateLevel\varcond(\notFreeIn(pos (variable), replChar (int term)), \notFreeIn(pos (variable), searchChar (int term)), \notFreeIn(pos (variable), str (Seq term)))
+\varcond(\notFreeIn(pos (variable), replChar (int term)), \notFreeIn(pos (variable), searchChar (int term)), \notFreeIn(pos (variable), str (Seq term)))
 \add [and(equals(clReplace(str,searchChar,replChar),newSym),equals(seqDef{pos (variable)}(Z(0(#)),seqLen(str),if-then-else(equals(seqGet<[int]>(str,pos),searchChar),replChar,seqGet<[int]>(str,pos))),newSym))]==>[] 
 \heuristics(stringsIntroduceNewSym, defOpsReplace)
 Choices: Strings:on}
@@ -15426,7 +15426,7 @@ Choices: Strings:on}
 replaceSubstring {
 \assumes ([equals(seqSub(str,startIdx,endIdx),subStr)]==>[]) 
 \find(clReplace(subStr,searchChar,replaceChar))
-\sameUpdateLevel\replacewith(if-then-else(and(and(geq(startIdx,Z(0(#))),geq(endIdx,startIdx)),leq(endIdx,seqLen(str))),seqSub(clReplace(str,searchChar,replaceChar),startIdx,endIdx),clReplace(subStr,searchChar,replaceChar))) 
+\replacewith(if-then-else(and(and(geq(startIdx,Z(0(#))),geq(endIdx,startIdx)),leq(endIdx,seqLen(str))),seqSub(clReplace(str,searchChar,replaceChar),startIdx,endIdx),clReplace(subStr,searchChar,replaceChar))) 
 \heuristics(stringsMoveReplaceInside)
 Choices: Strings:on}
 -----------------------------------------------------
@@ -15511,7 +15511,7 @@ Choices: true}
 replace_known_left {
 \assumes ([b]==>[]) 
 \find(b)
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(replace_known_left)
 Choices: true}
 -----------------------------------------------------
@@ -15519,7 +15519,7 @@ Choices: true}
 replace_known_right {
 \assumes ([]==>[b]) 
 \find(b)
-\sameUpdateLevel\replacewith(false) 
+\replacewith(false) 
 \heuristics(replace_known_right)
 Choices: true}
 -----------------------------------------------------
@@ -15616,7 +15616,7 @@ Choices: true}
 == sCardNonNegative (sCardNonNegative) =========================================
 sCardNonNegative {
 \find(sCard<[T]>(s))
-\sameUpdateLevel\add [geq(sCard<[T]>(s),Z(0(#)))]==>[] 
+\add [geq(sCard<[T]>(s),Z(0(#)))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -15661,7 +15661,7 @@ Choices: true}
 sElementOfSInfiniteUnionEQ {
 \assumes ([equals(sInfiniteUnion<[T]>{av (variable)}(s),EQ)]==>[]) 
 \find(sElementOf<[T]>(a,EQ))
-\sameUpdateLevel\varcond(\notFreeIn(av (variable), a (T term)))
+\varcond(\notFreeIn(av (variable), a (T term)))
 \replacewith(exists{av (variable)}(sElementOf<[T]>(a,s))) 
 \heuristics(simplify)
 Choices: true}
@@ -15677,7 +15677,7 @@ Choices: true}
 sElementOfSIntersectEQ {
 \assumes ([equals(sIntersect<[T]>(s,t),EQ)]==>[]) 
 \find(sElementOf<[T]>(a,EQ))
-\sameUpdateLevel\replacewith(and(sElementOf<[T]>(a,s),sElementOf<[T]>(a,t))) 
+\replacewith(and(sElementOf<[T]>(a,s),sElementOf<[T]>(a,t))) 
 \heuristics(simplify_enlarging)
 Choices: true}
 -----------------------------------------------------
@@ -15692,7 +15692,7 @@ Choices: true}
 sElementOfSSetMinusEQ {
 \assumes ([equals(sSetMinus<[T]>(s,t),EQ)]==>[]) 
 \find(sElementOf<[T]>(a,EQ))
-\sameUpdateLevel\replacewith(and(sElementOf<[T]>(a,s),not(sElementOf<[T]>(a,t)))) 
+\replacewith(and(sElementOf<[T]>(a,s),not(sElementOf<[T]>(a,t)))) 
 \heuristics(simplify_enlarging)
 Choices: true}
 -----------------------------------------------------
@@ -15714,7 +15714,7 @@ Choices: true}
 sElementOfSUnionEQ {
 \assumes ([equals(sUnion<[T]>(s,t),EQ)]==>[]) 
 \find(sElementOf<[T]>(a,EQ))
-\sameUpdateLevel\replacewith(or(sElementOf<[T]>(a,s),sElementOf<[T]>(a,t))) 
+\replacewith(or(sElementOf<[T]>(a,s),sElementOf<[T]>(a,t))) 
 \heuristics(simplify_enlarging)
 Choices: true}
 -----------------------------------------------------
@@ -15758,7 +15758,7 @@ Choices: true}
 sameTypeFalse {
 \assumes ([equals(exactInstance<[G]>(x1),TRUE),equals(exactInstance<[H]>(x2),TRUE)]==>[]) 
 \find(sameType(x1,x2))
-\sameUpdateLevel\varcond(\not\same(G, H))
+\varcond(\not\same(G, H))
 \replacewith(false) 
 \heuristics(concrete)
 Choices: true}
@@ -15767,7 +15767,7 @@ Choices: true}
 sameTypeTrue {
 \assumes ([equals(exactInstance<[G]>(x1),TRUE),equals(exactInstance<[G]>(x2),TRUE)]==>[]) 
 \find(sameType(x1,x2))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(concrete)
 Choices: true}
 -----------------------------------------------------
@@ -15868,7 +15868,7 @@ Choices: programRules:Java}
 selectCreatedOfAnonAsFormulaEQ {
 \assumes ([equals(anon(h,s,h2),EQ)]==>[]) 
 \find(equals(select<[boolean]>(EQ,o,java.lang.Object::#$created),TRUE))
-\sameUpdateLevel\replacewith(or(equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE),equals(select<[boolean]>(h2,o,java.lang.Object::#$created),TRUE))) 
+\replacewith(or(equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE),equals(select<[boolean]>(h2,o,java.lang.Object::#$created),TRUE))) 
 \heuristics(simplify_ENLARGING)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15876,7 +15876,7 @@ Choices: programRules:Java}
 selectCreatedOfAnonEQ {
 \assumes ([equals(anon(h,s,h2),EQ)]==>[]) 
 \find(select<[boolean]>(EQ,o,java.lang.Object::#$created))
-\sameUpdateLevel\replacewith(if-then-else(equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE),TRUE,select<[boolean]>(h2,o,java.lang.Object::#$created))) 
+\replacewith(if-then-else(equals(select<[boolean]>(h,o,java.lang.Object::#$created),TRUE),TRUE,select<[boolean]>(h2,o,java.lang.Object::#$created))) 
 \heuristics(simplify_heap_high_costs)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15891,7 +15891,7 @@ Choices: programRules:Java}
 selectOfAnonEQ {
 \assumes ([equals(anon(h,s,h2),EQ)]==>[]) 
 \find(select<[beta]>(EQ,o,f))
-\sameUpdateLevel\replacewith(if-then-else(or(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),elementOf(o,f,freshLocs(h))),select<[beta]>(h2,o,f),select<[beta]>(h,o,f))) 
+\replacewith(if-then-else(or(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),elementOf(o,f,freshLocs(h))),select<[beta]>(h2,o,f),select<[beta]>(h,o,f))) 
 \heuristics(simplify_heap_high_costs)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15906,7 +15906,7 @@ Choices: programRules:Java}
 selectOfCreateEQ {
 \assumes ([equals(create(h,o),EQ)]==>[]) 
 \find(select<[beta]>(EQ,o2,f))
-\sameUpdateLevel\replacewith(if-then-else(and(and(equals(o,o2),not(equals(o,null))),equals(f,java.lang.Object::#$created)),cast<[beta]>(TRUE),select<[beta]>(h,o2,f))) 
+\replacewith(if-then-else(and(and(equals(o,o2),not(equals(o,null))),equals(f,java.lang.Object::#$created)),cast<[beta]>(TRUE),select<[beta]>(h,o2,f))) 
 \heuristics(simplify_heap_high_costs)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15914,7 +15914,7 @@ Choices: programRules:Java}
 selectOfCreateReduce {
 \assumes ([]==>[equals(o,null)]) 
 \find(select<[beta]>(create(h,o),o,f))
-\sameUpdateLevel\replacewith(if-then-else(equals(f,java.lang.Object::#$created),cast<[beta]>(TRUE),select<[beta]>(h,o,f))) 
+\replacewith(if-then-else(equals(f,java.lang.Object::#$created),cast<[beta]>(TRUE),select<[beta]>(h,o,f))) 
 \heuristics(simplify_select_concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15922,7 +15922,7 @@ Choices: programRules:Java}
 selectOfCreateReduceConcrete {
 \assumes ([]==>[equals(o,null)]) 
 \find(select<[beta]>(create(h,o),o,java.lang.Object::#$created))
-\sameUpdateLevel\replacewith(cast<[beta]>(TRUE)) 
+\replacewith(cast<[beta]>(TRUE)) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15937,7 +15937,7 @@ Choices: programRules:Java}
 selectOfMemsetEQ {
 \assumes ([equals(memset(h,s,x),EQ)]==>[]) 
 \find(select<[beta]>(EQ,o,f))
-\sameUpdateLevel\replacewith(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o,f))) 
+\replacewith(if-then-else(and(elementOf(o,f,s),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o,f))) 
 \heuristics(simplify_heap_high_costs)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -15952,7 +15952,7 @@ Choices: programRules:Java}
 selectOfStoreEQ {
 \assumes ([equals(store(h,o,f,x),EQ)]==>[]) 
 \find(select<[beta]>(EQ,o2,f2))
-\sameUpdateLevel\replacewith(if-then-else(and(and(equals(o,o2),equals(f,f2)),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o2,f2))) 
+\replacewith(if-then-else(and(and(equals(o,o2),equals(f,f2)),not(equals(f,java.lang.Object::#$created))),cast<[beta]>(x),select<[beta]>(h,o2,f2))) 
 \heuristics(simplify_heap_high_costs)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16014,7 +16014,7 @@ Choices: sequences:on}
 == seqDef_empty (seqDef_empty) =========================================
 seqDef_empty {
 \find(seqDef{uSub (variable)}(from,idx,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub (variable), idx (int term)), \notFreeIn(uSub (variable), from (int term)))
+\varcond(\notFreeIn(uSub (variable), idx (int term)), \notFreeIn(uSub (variable), from (int term)))
 \replacewith(seqEmpty) ;
 \add []==>[leq(idx,from)] 
 
@@ -16079,7 +16079,7 @@ Choices: sequences:on}
 == seqDef_split_in_three (seqDef_split_in_three) =========================================
 seqDef_split_in_three {
 \find(seqDef{uSub (variable)}(from,to,t))
-\sameUpdateLevel\varcond(\notFreeIn(uSub1 (variable), to (int term)), \notFreeIn(uSub (variable), from (int term)), \notFreeIn(uSub1 (variable), idx (int term)), \notFreeIn(uSub1 (variable), t (any term)), \notFreeIn(uSub (variable), idx (int term)))
+\varcond(\notFreeIn(uSub1 (variable), to (int term)), \notFreeIn(uSub (variable), from (int term)), \notFreeIn(uSub1 (variable), idx (int term)), \notFreeIn(uSub1 (variable), t (any term)), \notFreeIn(uSub (variable), idx (int term)))
 \replacewith(seqConcat(seqDef{uSub (variable)}(from,idx,t),seqConcat(seqSingleton(subst{uSub (variable)}(idx,t)),seqDef{uSub1 (variable)}(add(idx,Z(1(#))),to,subst{uSub (variable)}(uSub1,t))))) ;
 \add []==>[and(leq(from,idx),lt(idx,to))] 
 
@@ -16088,7 +16088,7 @@ Choices: sequences:on}
 == seqGetAlphaCast (seqGetAlphaCast) =========================================
 seqGetAlphaCast {
 \find(seqGet<[alpha]>(seq,at))
-\sameUpdateLevel\add [equals(cast<[alpha]>(seqGet<[any]>(seq,at)),seqGet<[alpha]>(seq,at))]==>[] 
+\add [equals(cast<[alpha]>(seqGet<[any]>(seq,at)),seqGet<[alpha]>(seq,at))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -16121,7 +16121,7 @@ Choices: programRules:Java}
 == seqIndexOf (seqIndexOf) =========================================
 seqIndexOf {
 \find(seqIndexOf(s,t))
-\sameUpdateLevel\varcond(\notFreeIn(m (variable), t (any term)), \notFreeIn(m (variable), s (Seq term)), \notFreeIn(n (variable), t (any term)), \notFreeIn(n (variable), s (Seq term)))
+\varcond(\notFreeIn(m (variable), t (any term)), \notFreeIn(m (variable), s (Seq term)), \notFreeIn(n (variable), t (any term)), \notFreeIn(n (variable), s (Seq term)))
 \add [imp(exists{n (variable)}(and(and(leq(Z(0(#)),n),lt(n,seqLen(s))),equals(seqGet<[any]>(s,n),t))),and(and(and(leq(Z(0(#)),seqIndexOf(s,t)),lt(seqIndexOf(s,t),seqLen(s))),equals(seqGet<[any]>(s,seqIndexOf(s,t)),t)),all{m (variable)}(imp(and(leq(Z(0(#)),m),lt(m,seqIndexOf(s,t))),not(equals(seqGet<[any]>(s,m),t))))))]==>[] 
 
 Choices: sequences:on}
@@ -16168,7 +16168,7 @@ Choices: programRules:Java}
 == seqOutsideValue (seqOutsideValue) =========================================
 seqOutsideValue {
 \find(seqGetOutside)
-\sameUpdateLevel\add [all{s (variable)}(all{iv (variable)}(imp(or(lt(iv,Z(0(#))),leq(seqLen(s),iv)),equals(seqGet<[any]>(s,iv),seqGetOutside))))]==>[] 
+\add [all{s (variable)}(all{iv (variable)}(imp(or(lt(iv,Z(0(#))),leq(seqLen(s),iv)),equals(seqGet<[any]>(s,iv),seqGetOutside))))]==>[] 
 
 Choices: sequences:on}
 -----------------------------------------------------
@@ -16195,7 +16195,7 @@ Choices: programRules:Java}
 == seqSelfDefinition (seqSelfDefinition) =========================================
 seqSelfDefinition {
 \find(seq)
-\sameUpdateLevel\add [all{s (variable)}(equals(s,seqDef{u (variable)}(Z(0(#)),seqLen(s),seqGet<[any]>(s,u))))]==>[] 
+\add [all{s (variable)}(equals(s,seqDef{u (variable)}(Z(0(#)),seqLen(s),seqGet<[any]>(s,u))))]==>[] 
 
 Choices: sequences:on}
 -----------------------------------------------------
@@ -16203,7 +16203,7 @@ Choices: sequences:on}
 seqSelfDefinitionEQ2 {
 \assumes ([equals(seqLen(s),x)]==>[]) 
 \find(seqDef{u (variable)}(Z(0(#)),x,seqGet<[any]>(s,u)))
-\sameUpdateLevel\varcond(\notFreeIn(u (variable), s (Seq term)), \notFreeIn(u (variable), x (int term)))
+\varcond(\notFreeIn(u (variable), s (Seq term)), \notFreeIn(u (variable), x (int term)))
 \replacewith(s) 
 \heuristics(simplify)
 Choices: sequences:on}
@@ -16335,7 +16335,7 @@ Choices: programRules:Java}
 setMinusOfUnionEQ {
 \assumes ([equals(union(s,s2),EQ)]==>[]) 
 \find(setMinus(EQ,s3))
-\sameUpdateLevel\replacewith(union(setMinus(s,s3),setMinus(s2,s3))) 
+\replacewith(union(setMinus(s,s3),setMinus(s2,s3))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16343,7 +16343,7 @@ Choices: programRules:Java}
 setMinusSingleton {
 \assumes ([]==>[elementOf(o,f,s)]) 
 \find(setMinus(s,singleton(o,f)))
-\sameUpdateLevel\replacewith(s) 
+\replacewith(s) 
 \heuristics(simplify)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16589,7 +16589,7 @@ Choices: programRules:Java}
 simplifySelectOfMemsetWithArrayRangeDiffArray {
 \assumes ([]==>[equals(o,o2)]) 
 \find(select<[beta]>(memset(h,arrayRange(o,low,high),x),o2,f))
-\sameUpdateLevel\replacewith(select<[beta]>(h,o2,f)) 
+\replacewith(select<[beta]>(h,o2,f)) 
 \heuristics(simplify_select_elim_store)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16608,7 +16608,7 @@ Choices: programRules:Java}
 simplifySelectOfStoreDiffObjects {
 \assumes ([]==>[equals(o,o2)]) 
 \find(select<[beta]>(store(h,o,f,x),o2,f))
-\sameUpdateLevel\replacewith(select<[beta]>(h,o2,f)) 
+\replacewith(select<[beta]>(h,o2,f)) 
 \heuristics(simplify_select_elim_store)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -16651,28 +16651,28 @@ Choices: true}
 == sinIsNaN (sinIsNaN) =========================================
 sinIsNaN {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(sinDouble(arg)))]==>[] 
+\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(sinDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sinIsNotNaN (sinIsNotNaN) =========================================
 sinIsNotNaN {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),not(doubleIsNaN(sinDouble(arg))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),not(doubleIsNaN(sinDouble(arg))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sinRange2 (sinRange2) =========================================
 sinRange2 {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(sinDouble(arg),negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(sinDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(sinDouble(arg),negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(sinDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sinRange3 (sinRange3) =========================================
 sinRange3 {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(mulDouble(sinDouble(arg),sinDouble(arg)),DFP(0(#))),leqDouble(mulDouble(sinDouble(arg),sinDouble(arg)),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),not(doubleIsInfinite(arg))),and(geqDouble(mulDouble(sinDouble(arg),sinDouble(arg)),DFP(0(#))),leqDouble(mulDouble(sinDouble(arg),sinDouble(arg)),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -16686,14 +16686,14 @@ Choices: true}
 == sineIsZero (sineIsZero) =========================================
 sineIsZero {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [imp(equals(arg,DFP(0(#))),equals(sinDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(equals(arg,DFP(0(#))),equals(sinDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sineRange (sineRange) =========================================
 sineRange {
 \find(sinDouble(arg))
-\sameUpdateLevel\add [or(and(geqDouble(sinDouble(arg),negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(sinDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(sinDouble(arg)))]==>[] 
+\add [or(and(geqDouble(sinDouble(arg),negDouble(DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),leqDouble(sinDouble(arg),DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),doubleIsNaN(sinDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -16743,7 +16743,7 @@ Choices: true}
 == sizeOfMapRemove (sizeOfMapRemove) =========================================
 sizeOfMapRemove {
 \find(mapSize(mapRemove(m,key)))
-\sameUpdateLevel\add [imp(isFinite(m),equals(mapSize(mapRemove(m,key)),if-then-else(inDomain(m,key),sub(mapSize(m),Z(1(#))),mapSize(m))))]==>[] 
+\add [imp(isFinite(m),equals(mapSize(mapRemove(m,key)),if-then-else(inDomain(m,key),sub(mapSize(m),Z(1(#))),mapSize(m))))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -16757,7 +16757,7 @@ Choices: true}
 == sizeOfMapUpdate (sizeOfMapUpdate) =========================================
 sizeOfMapUpdate {
 \find(mapSize(mapUpdate(m,key,value)))
-\sameUpdateLevel\add [imp(isFinite(m),equals(mapSize(mapUpdate(m,key,value)),if-then-else(inDomain(m,key),mapSize(m),add(mapSize(m),Z(1(#))))))]==>[] 
+\add [imp(isFinite(m),equals(mapSize(mapUpdate(m,key,value)),if-then-else(inDomain(m,key),mapSize(m),add(mapSize(m),Z(1(#))))))]==>[] 
 \heuristics(inReachableStateImplication)
 Choices: true}
 -----------------------------------------------------
@@ -16829,35 +16829,35 @@ Choices: true}
 == sqrtIsInfinite (sqrtIsInfinite) =========================================
 sqrtIsInfinite {
 \find(sqrtDouble(arg))
-\sameUpdateLevel\add [imp(and(doubleIsInfinite(arg),gtDouble(arg,DFP(0(#)))),and(doubleIsInfinite(sqrtDouble(arg)),gtDouble(sqrtDouble(arg),DFP(0(#)))))]==>[] 
+\add [imp(and(doubleIsInfinite(arg),gtDouble(arg,DFP(0(#)))),and(doubleIsInfinite(sqrtDouble(arg)),gtDouble(sqrtDouble(arg),DFP(0(#)))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sqrtIsNaN (sqrtIsNaN) =========================================
 sqrtIsNaN {
 \find(sqrtDouble(arg))
-\sameUpdateLevel\add [imp(or(doubleIsNaN(arg),ltDouble(arg,DFP(0(#)))),doubleIsNaN(sqrtDouble(arg)))]==>[] 
+\add [imp(or(doubleIsNaN(arg),ltDouble(arg,DFP(0(#)))),doubleIsNaN(sqrtDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sqrtIsNotNaN (sqrtIsNotNaN) =========================================
 sqrtIsNotNaN {
 \find(sqrtDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsNaN(arg)),geqDouble(arg,DFP(0(#)))),not(doubleIsNaN(sqrtDouble(arg))))]==>[] 
+\add [imp(and(not(doubleIsNaN(arg)),geqDouble(arg,DFP(0(#)))),not(doubleIsNaN(sqrtDouble(arg))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sqrtIsSmaller (sqrtIsSmaller) =========================================
 sqrtIsSmaller {
 \find(sqrtDouble(arg))
-\sameUpdateLevel\add [imp(and(not(doubleIsInfinite(arg)),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),ltDouble(sqrtDouble(arg),arg))]==>[] 
+\add [imp(and(not(doubleIsInfinite(arg)),gtDouble(arg,DFP(8(0(4(7(1(0(0(0(8(8(1(4(2(8(1(7(0(6(4(#)))))))))))))))))))))),ltDouble(sqrtDouble(arg),arg))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == sqrtIsZero (sqrtIsZero) =========================================
 sqrtIsZero {
 \find(sqrtDouble(arg))
-\sameUpdateLevel\add [imp(equals(arg,DFP(0(#))),equals(sqrtDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(equals(arg,DFP(0(#))),equals(sqrtDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -16953,7 +16953,7 @@ stringAssignment {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #slit;
 ... }}| (post))
-\sameUpdateLevel\add [not(equals(strPool(#slit),null)),equals(select<[boolean]>(heap,strPool(#slit),java.lang.Object::#$created),TRUE)]==>[] \replacewith(update-application(elem-update(#v (program Variable))(strPool(#slit)),#normalassign(post))) 
+\add [not(equals(strPool(#slit),null)),equals(select<[boolean]>(heap,strPool(#slit),java.lang.Object::#$created),TRUE)]==>[] \replacewith(update-application(elem-update(#v (program Variable))(strPool(#slit)),#normalassign(post))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -16962,7 +16962,7 @@ stringConcat {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #sstr1 + #sstr2;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(strContent(#sstr1),strContent(#sstr2)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(strContent(#sstr1),strContent(#sstr2)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -16971,7 +16971,7 @@ stringConcatBooleanLeft {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #seLeft + #sstrRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(if-then-else(equals(#seLeft,TRUE),seqConcat(seqSingleton(C(6(1(1(#))))),seqConcat(seqSingleton(C(4(1(1(#))))),seqConcat(seqSingleton(C(7(1(1(#))))),seqSingleton(C(1(0(1(#)))))))),seqConcat(seqSingleton(C(2(0(1(#))))),seqConcat(seqSingleton(C(7(9(#)))),seqConcat(seqSingleton(C(8(0(1(#))))),seqConcat(seqSingleton(C(5(1(1(#))))),seqSingleton(C(1(0(1(#)))))))))),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(if-then-else(equals(#seLeft,TRUE),seqConcat(seqSingleton(C(6(1(1(#))))),seqConcat(seqSingleton(C(4(1(1(#))))),seqConcat(seqSingleton(C(7(1(1(#))))),seqSingleton(C(1(0(1(#)))))))),seqConcat(seqSingleton(C(2(0(1(#))))),seqConcat(seqSingleton(C(7(9(#)))),seqConcat(seqSingleton(C(8(0(1(#))))),seqConcat(seqSingleton(C(5(1(1(#))))),seqSingleton(C(1(0(1(#)))))))))),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -16980,7 +16980,7 @@ stringConcatBooleanRight {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #sstrLeft + #seRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),if-then-else(equals(#seRight,TRUE),seqConcat(seqSingleton(C(6(1(1(#))))),seqConcat(seqSingleton(C(4(1(1(#))))),seqConcat(seqSingleton(C(7(1(1(#))))),seqSingleton(C(1(0(1(#)))))))),seqConcat(seqSingleton(C(2(0(1(#))))),seqConcat(seqSingleton(C(7(9(#)))),seqConcat(seqSingleton(C(8(0(1(#))))),seqConcat(seqSingleton(C(5(1(1(#))))),seqSingleton(C(1(0(1(#))))))))))))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),if-then-else(equals(#seRight,TRUE),seqConcat(seqSingleton(C(6(1(1(#))))),seqConcat(seqSingleton(C(4(1(1(#))))),seqConcat(seqSingleton(C(7(1(1(#))))),seqSingleton(C(1(0(1(#)))))))),seqConcat(seqSingleton(C(2(0(1(#))))),seqConcat(seqSingleton(C(7(9(#)))),seqConcat(seqSingleton(C(8(0(1(#))))),seqConcat(seqSingleton(C(5(1(1(#))))),seqSingleton(C(1(0(1(#))))))))))))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -16989,7 +16989,7 @@ stringConcatCharExpLeft {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #seLeft + #sstrRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(seqSingleton(#seLeft),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(seqSingleton(#seLeft),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -16998,7 +16998,7 @@ stringConcatCharExpRight {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #sstrLeft + #seRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),seqSingleton(#seRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),seqSingleton(#seRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -17007,7 +17007,7 @@ stringConcatIntExpLeft {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #seLeft + #sstrRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(clTranslateInt(#seLeft),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(clTranslateInt(#seLeft),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -17016,7 +17016,7 @@ stringConcatIntExpRight {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #sstrLeft + #seRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),clTranslateInt(#seRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
+\add [equals(strContent(sk),seqConcat(strContent(#sstrLeft),clTranslateInt(#seRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) 
 \heuristics(simplify_prog_subset, simplify_prog)
 Choices: true}
 -----------------------------------------------------
@@ -17025,7 +17025,7 @@ stringConcatObjectLeft {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #seLeft + #sstrRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(#seLeft,null),equals(strContent(sk),seqConcat(strContent(null),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) ;
+\add [equals(#seLeft,null),equals(strContent(sk),seqConcat(strContent(null),strContent(#sstrRight)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) ;
 \add []==>[equals(#seLeft,null)] \replacewith(#normalassign ((modal operator))|{{ ..
   #v = #seLeft.toString() + #sstrRight;
 ... }}| (post)) 
@@ -17037,7 +17037,7 @@ stringConcatObjectRight {
 \find(#normalassign ((modal operator))|{{ ..
   #v = #sstrLeft + #seRight;
 ... }}| (post))
-\sameUpdateLevel\add [equals(#seRight,null),equals(strContent(sk),seqConcat(strContent(#sstrLeft),strContent(null)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) ;
+\add [equals(#seRight,null),equals(strContent(sk),seqConcat(strContent(#sstrLeft),strContent(null)))]==>[equals(sk,null)] \replacewith(update-application(elem-update(#v (program Variable))(sk),update-application(elem-update(heap)(create(heap,sk)),#normalassign(post)))) ;
 \add []==>[equals(#seRight,null)] \replacewith(#normalassign ((modal operator))|{{ ..
   #v = #sstrLeft + #seRight.toString();
 ... }}| (post)) 
@@ -17069,7 +17069,7 @@ Choices: sequences:on}
 subSeqCompleteSeqDefEQ {
 \assumes ([equals(seqDef{i (variable)}(Z(0(#)),u,a),EQ)]==>[]) 
 \find(seqSub(EQ,Z(0(#)),u))
-\sameUpdateLevel\replacewith(seqDef{i (variable)}(Z(0(#)),u,a)) 
+\replacewith(seqDef{i (variable)}(Z(0(#)),u,a)) 
 \heuristics(no_self_application, concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17084,7 +17084,7 @@ Choices: sequences:on}
 subSeqConcatEQ {
 \assumes ([equals(seqConcat(s1,s2),EQ)]==>[]) 
 \find(seqSub(EQ,l,u))
-\sameUpdateLevel\replacewith(seqConcat(seqSub(s1,l,if-then-else(lt(seqLen(s1),u),seqLen(s1),u)),seqSub(s2,if-then-else(lt(l,seqLen(s1)),Z(0(#)),sub(l,seqLen(s1))),sub(u,seqLen(s1))))) 
+\replacewith(seqConcat(seqSub(s1,l,if-then-else(lt(seqLen(s1),u),seqLen(s1),u)),seqSub(s2,if-then-else(lt(l,seqLen(s1)),Z(0(#)),sub(l,seqLen(s1))),sub(u,seqLen(s1))))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17106,7 +17106,7 @@ Choices: sequences:on}
 subSeqHeadSeqDefEQ {
 \assumes ([equals(seqDef{i (variable)}(Z(0(#)),u,a),EQ)]==>[]) 
 \find(seqSub(seqConcat(EQ,seq),Z(0(#)),u))
-\sameUpdateLevel\replacewith(seqDef{i (variable)}(Z(0(#)),u,a)) 
+\replacewith(seqDef{i (variable)}(Z(0(#)),u,a)) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17128,7 +17128,7 @@ Choices: sequences:on}
 subSeqSingleton2EQ {
 \assumes ([equals(seqSingleton(x),EQ)]==>[]) 
 \find(seqSub(EQ,l,u))
-\sameUpdateLevel\replacewith(seqConcat(seqSub(seqEmpty,if-then-else(lt(l,Z(0(#))),l,Z(0(#))),if-then-else(lt(u,Z(0(#))),u,Z(0(#)))),seqConcat(if-then-else(and(leq(l,Z(0(#))),geq(u,Z(1(#)))),seqSingleton(x),seqEmpty),seqSub(seqEmpty,if-then-else(gt(l,Z(0(#))),l,Z(1(#))),if-then-else(gt(u,Z(0(#))),u,Z(1(#))))))) 
+\replacewith(seqConcat(seqSub(seqEmpty,if-then-else(lt(l,Z(0(#))),l,Z(0(#))),if-then-else(lt(u,Z(0(#))),u,Z(0(#)))),seqConcat(if-then-else(and(leq(l,Z(0(#))),geq(u,Z(1(#)))),seqSingleton(x),seqEmpty),seqSub(seqEmpty,if-then-else(gt(l,Z(0(#))),l,Z(1(#))),if-then-else(gt(u,Z(0(#))),u,Z(1(#))))))) 
 \heuristics(no_self_application, simplify_enlarging)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17136,7 +17136,7 @@ Choices: sequences:on}
 subSeqSingletonEQ {
 \assumes ([equals(seqSingleton(x),EQ)]==>[]) 
 \find(seqSub(EQ,Z(0(#)),Z(1(#))))
-\sameUpdateLevel\replacewith(seqSingleton(x)) 
+\replacewith(seqSingleton(x)) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17151,7 +17151,7 @@ Choices: sequences:on}
 subSeqTailLEQ {
 \assumes ([equals(seqLen(seq),EQ)]==>[]) 
 \find(seqSub(seqConcat(seqSingleton(x),seq),Z(1(#)),add(Z(1(#)),EQ)))
-\sameUpdateLevel\replacewith(seq) 
+\replacewith(seq) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17166,7 +17166,7 @@ Choices: sequences:on}
 subSeqTailREQ {
 \assumes ([equals(seqLen(seq),EQ)]==>[]) 
 \find(seqSub(seqConcat(seqSingleton(x),seq),Z(1(#)),add(EQ,Z(1(#)))))
-\sameUpdateLevel\replacewith(seq) 
+\replacewith(seq) 
 \heuristics(concrete)
 Choices: sequences:on}
 -----------------------------------------------------
@@ -17232,7 +17232,7 @@ Choices: programRules:Java}
 subsetOfIntersectWithItSelf1EQ {
 \assumes ([equals(intersect(s,s2),EQ)]==>[]) 
 \find(subset(s,EQ))
-\sameUpdateLevel\replacewith(subset(s,s2)) 
+\replacewith(subset(s,s2)) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17247,7 +17247,7 @@ Choices: programRules:Java}
 subsetOfIntersectWithItSelf2EQ {
 \assumes ([equals(intersect(s2,s),EQ)]==>[]) 
 \find(subset(s,EQ))
-\sameUpdateLevel\replacewith(subset(s,s2)) 
+\replacewith(subset(s,s2)) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17269,7 +17269,7 @@ Choices: programRules:Java}
 subsetOfUnionWithItSelf1EQ {
 \assumes ([equals(union(s,s2),EQ)]==>[]) 
 \find(subset(s,EQ))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17284,7 +17284,7 @@ Choices: programRules:Java}
 subsetOfUnionWithItSelf2EQ {
 \assumes ([equals(union(s2,s),EQ)]==>[]) 
 \find(subset(s,EQ))
-\sameUpdateLevel\replacewith(true) 
+\replacewith(true) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17299,7 +17299,7 @@ Choices: programRules:Java}
 subsetSingletonLeftEQ {
 \assumes ([equals(singleton(o,f),EQ)]==>[]) 
 \find(subset(EQ,s))
-\sameUpdateLevel\replacewith(elementOf(o,f,s)) 
+\replacewith(elementOf(o,f,s)) 
 \heuristics(simplify)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17314,7 +17314,7 @@ Choices: programRules:Java}
 subsetSingletonRightEQ {
 \assumes ([equals(singleton(o,f),EQ)]==>[]) 
 \find(subset(s,EQ))
-\sameUpdateLevel\replacewith(or(equals(s,empty),equals(s,singleton(o,f)))) 
+\replacewith(or(equals(s,empty),equals(s,singleton(o,f)))) 
 \heuristics(simplify)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17345,7 +17345,7 @@ Choices: programRules:Java}
 subsetUnionLeftEQ {
 \assumes ([equals(union(s,s2),EQ)]==>[]) 
 \find(subset(EQ,s3))
-\sameUpdateLevel\replacewith(and(subset(s,s3),subset(s2,s3))) 
+\replacewith(and(subset(s,s3),subset(s2,s3))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17381,7 +17381,7 @@ Choices: programRules:Java}
 subsetWithSetMinusLeftEQ {
 \assumes ([equals(setMinus(s,s2),EQ)]==>[]) 
 \find(subset(EQ,s3))
-\sameUpdateLevel\replacewith(subset(s,union(s2,s3))) 
+\replacewith(subset(s,union(s2,s3))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -17395,21 +17395,21 @@ Choices: true}
 == subst_to_eq (subst_to_eq) =========================================
 subst_to_eq {
 \find(subst{u (variable)}(t,target))
-\sameUpdateLevel\add [equals(sk,t)]==>[] \replacewith(subst{u (variable)}(sk,target)) 
+\add [equals(sk,t)]==>[] \replacewith(subst{u (variable)}(sk,target)) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == subst_to_eq_for (subst_to_eq) =========================================
 subst_to_eq_for {
 \find(subst{u (variable)}(t,phi))
-\sameUpdateLevel\add [equals(sk,t)]==>[] \replacewith(subst{u (variable)}(sk,phi)) 
+\add [equals(sk,t)]==>[] \replacewith(subst{u (variable)}(sk,phi)) 
 \heuristics(simplify)
 Choices: true}
 -----------------------------------------------------
 == substringSubstring (substringSubstring) =========================================
 substringSubstring {
 \find(seqSub(seqSub(str,innerStartIdx,innerEndIdx),outerStartIdx,outerEndIdx))
-\sameUpdateLevel\add [imp(and(and(and(and(and(geq(innerStartIdx,Z(0(#))),geq(innerEndIdx,innerStartIdx)),leq(innerEndIdx,seqLen(str))),geq(outerStartIdx,Z(0(#)))),geq(outerEndIdx,outerStartIdx)),leq(outerEndIdx,sub(innerEndIdx,innerStartIdx))),and(equals(seqSub(seqSub(str,innerStartIdx,innerEndIdx),outerStartIdx,outerEndIdx),newSym),equals(seqSub(str,add(outerStartIdx,innerStartIdx),add(innerStartIdx,outerEndIdx)),newSym)))]==>[] 
+\add [imp(and(and(and(and(and(geq(innerStartIdx,Z(0(#))),geq(innerEndIdx,innerStartIdx)),leq(innerEndIdx,seqLen(str))),geq(outerStartIdx,Z(0(#)))),geq(outerEndIdx,outerStartIdx)),leq(outerEndIdx,sub(innerEndIdx,innerStartIdx))),and(equals(seqSub(seqSub(str,innerStartIdx,innerEndIdx),outerStartIdx,outerEndIdx),newSym),equals(seqSub(str,add(outerStartIdx,innerStartIdx),add(innerStartIdx,outerEndIdx)),newSym)))]==>[] 
 \heuristics(stringsIntroduceNewSym, stringsReduceSubstring)
 Choices: Strings:on}
 -----------------------------------------------------
@@ -17417,7 +17417,7 @@ Choices: Strings:on}
 substringSubstring2 {
 \assumes ([equals(seqSub(str,innerStartIdx,innerEndIdx),innerSub)]==>[]) 
 \find(seqSub(innerSub,outerStartIdx,outerEndIdx))
-\sameUpdateLevel\add [imp(and(and(and(and(and(geq(innerStartIdx,Z(0(#))),geq(innerEndIdx,innerStartIdx)),leq(innerEndIdx,seqLen(str))),geq(outerStartIdx,Z(0(#)))),geq(outerEndIdx,outerStartIdx)),leq(outerEndIdx,sub(innerEndIdx,innerStartIdx))),and(equals(seqSub(innerSub,outerStartIdx,outerEndIdx),newSym),equals(seqSub(str,add(outerStartIdx,innerStartIdx),add(innerStartIdx,outerEndIdx)),newSym)))]==>[] 
+\add [imp(and(and(and(and(and(geq(innerStartIdx,Z(0(#))),geq(innerEndIdx,innerStartIdx)),leq(innerEndIdx,seqLen(str))),geq(outerStartIdx,Z(0(#)))),geq(outerEndIdx,outerStartIdx)),leq(outerEndIdx,sub(innerEndIdx,innerStartIdx))),and(equals(seqSub(innerSub,outerStartIdx,outerEndIdx),newSym),equals(seqSub(str,add(outerStartIdx,innerStartIdx),add(innerStartIdx,outerEndIdx)),newSym)))]==>[] 
 \heuristics(stringsIntroduceNewSym, stringsReduceSubstring)
 Choices: Strings:on}
 -----------------------------------------------------
@@ -17514,14 +17514,14 @@ Choices: programRules:Java}
 == tanIsNaN (tanIsNaN) =========================================
 tanIsNaN {
 \find(tanDouble(arg))
-\sameUpdateLevel\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(tanDouble(arg)))]==>[] 
+\add [imp(or(doubleIsNaN(arg),doubleIsInfinite(arg)),doubleIsNaN(tanDouble(arg)))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
 == tanIsZero (tanIsZero) =========================================
 tanIsZero {
 \find(tanDouble(arg))
-\sameUpdateLevel\add [imp(equals(arg,DFP(0(#))),equals(tanDouble(arg),DFP(0(#))))]==>[] 
+\add [imp(equals(arg,DFP(0(#))),equals(tanDouble(arg),DFP(0(#))))]==>[] 
 \heuristics(userTaclets1)
 Choices: true}
 -----------------------------------------------------
@@ -18185,7 +18185,7 @@ tryCatchThrow {
     #slist1
   }
 ... }}| (post))
-\sameUpdateLevel\add []==>[equals(#se,null)] \replacewith(#allmodal ((modal operator))|{{ ..
+\add []==>[equals(#se,null)] \replacewith(#allmodal ((modal operator))|{{ ..
   if (#se instanceof #t) {
     #t #v0;
     #v0 = (#t) #se;
@@ -18475,7 +18475,7 @@ Choices: true}
 typeEqDerived {
 \assumes ([equals(s,t1)]==>[]) 
 \find(instance<[H]>(s))
-\sameUpdateLevel\replacewith(TRUE) 
+\replacewith(TRUE) 
 \heuristics(concrete, simplify)
 Choices: true}
 -----------------------------------------------------
@@ -18483,14 +18483,14 @@ Choices: true}
 typeEqDerived2 {
 \assumes ([equals(s,t1)]==>[]) 
 \find(instance<[G]>(t1))
-\sameUpdateLevel\replacewith(TRUE) 
+\replacewith(TRUE) 
 \heuristics(concrete, simplify)
 Choices: true}
 -----------------------------------------------------
 == typeStatic (typeStatic) =========================================
 typeStatic {
 \find(s)
-\sameUpdateLevel\add [equals(instance<[G]>(s),TRUE)]==>[] 
+\add [equals(instance<[G]>(s),TRUE)]==>[] 
 
 Choices: true}
 -----------------------------------------------------
@@ -18550,7 +18550,7 @@ Choices: programRules:Java}
 unionEqualsEmptyEQ {
 \assumes ([equals(union(s,s2),EQ)]==>[]) 
 \find(equals(EQ,empty))
-\sameUpdateLevel\replacewith(and(equals(s,empty),equals(s2,empty))) 
+\replacewith(and(equals(s,empty),equals(s2,empty))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -18779,7 +18779,7 @@ Choices: programRules:Java}
 wellFormedAnonEQ {
 \assumes ([equals(anon(h,s,h2),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\replacewith(and(wellFormed(h),wellFormed(h2))) 
+\succedentPolarity\replacewith(and(wellFormed(h),wellFormed(h2))) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -18794,7 +18794,7 @@ Choices: programRules:Java}
 wellFormedCreateEQ {
 \assumes ([equals(create(h,o),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\replacewith(wellFormed(h)) 
+\succedentPolarity\replacewith(wellFormed(h)) 
 \heuristics(concrete)
 Choices: programRules:Java}
 -----------------------------------------------------
@@ -18826,7 +18826,7 @@ Choices: programRules:Java}
 wellFormedStoreArrayEQ {
 \assumes ([equals(store(h,o,arr(idx),x),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha))
+\succedentPolarity\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha))
 \replacewith(and(wellFormed(h),or(equals(x,null),and(equals(select<[boolean]>(h,x,java.lang.Object::#$created),TRUE),arrayStoreValid(o,x))))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
@@ -18843,7 +18843,7 @@ Choices: programRules:Java}
 wellFormedStoreLocSetEQ {
 \assumes ([equals(store(h,o,f,x),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\varcond(\fieldType(f (Field term), alpha), \sub(LocSet, alpha))
+\succedentPolarity\varcond(\fieldType(f (Field term), alpha), \sub(LocSet, alpha))
 \replacewith(and(wellFormed(h),createdInHeap(x,h))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
@@ -18860,7 +18860,7 @@ Choices: programRules:Java}
 wellFormedStoreObjectEQ {
 \assumes ([equals(store(h,o,f,x),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\varcond(\fieldType(f (Field term), alpha))
+\succedentPolarity\varcond(\fieldType(f (Field term), alpha))
 \replacewith(and(wellFormed(h),or(equals(x,null),and(equals(select<[boolean]>(h,x,java.lang.Object::#$created),TRUE),equals(instance<[alpha]>(x),TRUE))))) 
 \heuristics(simplify_enlarging)
 Choices: programRules:Java}
@@ -18885,7 +18885,7 @@ Choices: programRules:Java}
 wellFormedStorePrimitiveArrayEQ {
 \assumes ([equals(store(h,o,arr(idx),x),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \not\sub(beta, java.lang.Object), \not\sub(beta, LocSet), \sub(beta, alpha))
+\succedentPolarity\varcond(\hasSort(\elemSort(o (java.lang.Object term)), alpha), \not\sub(beta, java.lang.Object), \not\sub(beta, LocSet), \sub(beta, alpha))
 \replacewith(wellFormed(h)) 
 \heuristics(concrete)
 Choices: programRules:Java}
@@ -18894,7 +18894,7 @@ Choices: programRules:Java}
 wellFormedStorePrimitiveEQ {
 \assumes ([equals(store(h,o,f,x),EQ)]==>[]) 
 \find(wellFormed(EQ))
-\sameUpdateLevel\succedentPolarity\varcond(\fieldType(f (Field term), alpha), \not\sub(beta, java.lang.Object), \not\sub(beta, LocSet), \sub(beta, alpha))
+\succedentPolarity\varcond(\fieldType(f (Field term), alpha), \not\sub(beta, java.lang.Object), \not\sub(beta, LocSet), \sub(beta, alpha))
 \replacewith(wellFormed(h)) 
 \heuristics(concrete)
 Choices: programRules:Java}

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/rules/ApplicationRestriction.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/rules/ApplicationRestriction.java
@@ -86,4 +86,23 @@ public record ApplicationRestriction(int value) {
         }
         return res;
     }
+
+    public String toString(boolean needsSameUpdateLevel) {
+        String res = "";
+        if (!needsSameUpdateLevel && matches(SAME_UPDATE_LEVEL)) {
+            res += "\\sameUpdateLevel";
+        } else if (needsSameUpdateLevel && !matches(SAME_UPDATE_LEVEL)) {
+            res += "\\ignoreUpdateLevel";
+        }
+        if (matches(IN_SEQUENT_STATE)) {
+            res += "\\inSequentState";
+        }
+        if (matches(ANTECEDENT_POLARITY)) {
+            res += "\\antecedentPolarity";
+        }
+        if (matches(SUCCEDENT_POLARITY)) {
+            res += "\\succedentPolarity";
+        }
+        return res;
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Previously, taclet printing followed the old semantics of requiring manual `\sameUpdateLevel` everywhere. This PR changes the behavior to bring taclet parsing and printing in line. `\sameUpdateLevel` is not printed. Instead, `\ignoreUpdateLevel` is printed where necessary.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: Checked taclet equality oracle

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
