### PR TITLE
repairing NPE when invoking KeY on a local file.

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/KeYFile.java
@@ -321,6 +321,9 @@ public class KeYFile implements EnvInput {
             if (!absFile.isAbsolute()) {
                 // convert to absolute by resolving against the parent path of the parsed file
                 Path parent = file.file().getParent();
+                if (parent == null) {
+                    parent = Path.of(".");
+                }
                 absFile = parent.resolve(javaPath).normalize();
             }
             if (!Files.exists(absFile)) {


### PR DESCRIPTION
## Related Issue

#3643

This pull request is related to the above PR which did not fully fix it.

## Intended Change

When invoking KeY on a local file

    key a.key

in case a.key contains a `javaSource "..."` directive, there should not be an NPE.

## Type of pull request

- Bug fix (non-breaking change which fixes an issue):
  *One line added: In case no directory is used use "." for directory resolution.*

## Ensuring quality

running it on CLI examples.

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
