### PR TITLE
Improve MT experience for Scripts/Macros

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/macros/ApplyScriptsMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/ApplyScriptsMacro.java
@@ -261,14 +261,14 @@ public class ApplyScriptsMacro extends AbstractProofMacro {
         }
         listener.taskStarted(new DefaultTaskStartedInfo(TaskStartedInfo.TaskKind.Other,
             "Running fallback macro on the remaining goals", 0));
-        for (Goal goal : laterGoals) {
-            if (Thread.interrupted()) {
-                throw new InterruptedException();
-            }
-            if (fallBackMacro != null) {
-                fallBackMacro.applyTo(uic, proof, ImmutableList.of(goal), posInOcc, listener);
-            }
 
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+
+        if (fallBackMacro != null && !laterGoals.isEmpty()) {
+            fallBackMacro.applyTo(uic, proof, ImmutableList.fromList(laterGoals), posInOcc,
+                listener);
         }
 
         return new ProofMacroFinishedInfo(this, proof);

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/StrategyProofMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/StrategyProofMacro.java
@@ -15,6 +15,7 @@ import de.uka.ilkd.key.strategy.FocussedRuleApplicationManager;
 import de.uka.ilkd.key.strategy.Strategy;
 
 import org.key_project.prover.engine.GoalChooser;
+import org.key_project.prover.engine.ProofSearchInformation;
 import org.key_project.prover.engine.ProverCore;
 import org.key_project.prover.engine.ProverTaskListener;
 import org.key_project.prover.sequent.PosInOccurrence;
@@ -132,7 +133,11 @@ public abstract class StrategyProofMacro extends AbstractProofMacro {
         try {
             // find the relevant goals
             // and start
-            applyStrategy.start(proof, goals);
+            final ProofSearchInformation<Proof, Goal> result = applyStrategy.start(proof, goals);
+            if (result.isError()) {
+                throw new RuntimeException("Proof search failed: " + result.getException(),
+                    result.getException());
+            }
             synchronized (applyStrategy) { // wait for applyStrategy to finish its last rule
                                            // application
                 if (applyStrategy.hasBeenInterrupted()) { // reraise interrupted exception if

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
@@ -4,6 +4,8 @@
 package de.uka.ilkd.key.macros;
 
 
+import java.util.List;
+
 import de.uka.ilkd.key.control.UserInterfaceControl;
 import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
@@ -170,12 +172,11 @@ public class TryCloseMacro extends AbstractProofMacro {
         //
         // start actual autoprove
         try {
-            for (final Goal goal : goals) {
-                Node node = goal.node();
-                final ProofSearchInformation<Proof, Goal> result = applyStrategy.start(proof,
-                    ImmutableList.singleton(goal), maxSteps, -1, false);
-                // final Goal closedGoal;
-
+            final List<Node> initialGoalNodes = goals.map(g -> g.node()).toList();
+            final ProofSearchInformation<Proof, Goal> result =
+                applyStrategy.startEach(proof, goals, maxSteps, -1);
+            // final Goal closedGoal;
+            for (final Node node : initialGoalNodes) {
                 // retreat if not closed
                 if (!node.isClosed()) {
                     proof.pruneProof(node);
@@ -184,22 +185,21 @@ public class TryCloseMacro extends AbstractProofMacro {
                 } else {
                     // closedGoal = goal;
                 }
-
-                synchronized (applyStrategy) { // wait for applyStrategy to finish its last rule
-                                               // application
-                    // update statistics
-                    /*
-                     * if (closedGoal == null) { TODO: This incremental approach would be nicer, but
-                     * therefore the comparison of Goal needs to be fixed. info = new
-                     * ProofMacroFinishedInfo(info, result); } else { info = new
-                     * ProofMacroFinishedInfo(info, result,
-                     * info.getGoals().removeFirst(closedGoal)); }
-                     */
-                    info = new ProofMacroFinishedInfo(info, result);
-                    if (applyStrategy.hasBeenInterrupted()) { // only now reraise the interruption
-                                                              // exception
-                        throw new InterruptedException();
-                    }
+            }
+            synchronized (applyStrategy) { // wait for applyStrategy to finish its last rule
+                // application
+                // update statistics
+                /*
+                 * if (closedGoal == null) { TODO: This incremental approach would be nicer, but
+                 * therefore the comparison of Goal needs to be fixed. info = new
+                 * ProofMacroFinishedInfo(info, result); } else { info = new
+                 * ProofMacroFinishedInfo(info, result,
+                 * info.getGoals().removeFirst(closedGoal)); }
+                 */
+                info = new ProofMacroFinishedInfo(info, result);
+                if (applyStrategy.hasBeenInterrupted()) { // only now reraise the interruption
+                    // exception
+                    throw new InterruptedException();
                 }
             }
         } finally {

--- a/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/macros/TryCloseMacro.java
@@ -71,6 +71,11 @@ public class TryCloseMacro extends AbstractProofMacro {
     private final int numberSteps;
 
     /**
+     * Number of goals per parallel batch (bound due to memory reasons with too many open goals)
+     */
+    private static final int GOALS_PER_RUN = 100;
+
+    /**
      * Instantiates a new try close macro. No changes to the max number of steps.
      */
     public TryCloseMacro() {
@@ -172,34 +177,28 @@ public class TryCloseMacro extends AbstractProofMacro {
         //
         // start actual autoprove
         try {
-            final List<Node> initialGoalNodes = goals.map(g -> g.node()).toList();
-            final ProofSearchInformation<Proof, Goal> result =
-                applyStrategy.startEach(proof, goals, maxSteps, -1);
-            // final Goal closedGoal;
-            for (final Node node : initialGoalNodes) {
-                // retreat if not closed
-                if (!node.isClosed()) {
-                    proof.pruneProof(node);
-                    pml.incrementNotClosedGoals();
-                    // closedGoal = null;
-                } else {
-                    // closedGoal = goal;
+            for (ImmutableList<Goal> batch = goals; !batch.isEmpty();) {
+                final int size = Math.min(GOALS_PER_RUN, batch.size());
+                final ImmutableList<Goal> current = batch.take(size);
+                batch = batch.skip(size);
+                final List<Node> initialGoalNodes = current.map(g -> g.node()).toList();
+                final ProofSearchInformation<Proof, Goal> result =
+                    applyStrategy.startEach(proof, current, maxSteps, -1);
+                if (result.isError()) {
+                    throw new RuntimeException("Proof search failed: " + result.getException(),
+                        result.getException());
                 }
-            }
-            synchronized (applyStrategy) { // wait for applyStrategy to finish its last rule
-                // application
-                // update statistics
-                /*
-                 * if (closedGoal == null) { TODO: This incremental approach would be nicer, but
-                 * therefore the comparison of Goal needs to be fixed. info = new
-                 * ProofMacroFinishedInfo(info, result); } else { info = new
-                 * ProofMacroFinishedInfo(info, result,
-                 * info.getGoals().removeFirst(closedGoal)); }
-                 */
-                info = new ProofMacroFinishedInfo(info, result);
-                if (applyStrategy.hasBeenInterrupted()) { // only now reraise the interruption
-                    // exception
-                    throw new InterruptedException();
+                for (final Node node : initialGoalNodes) {
+                    if (!node.isClosed()) {
+                        proof.pruneProof(node);
+                        pml.incrementNotClosedGoals();
+                    }
+                }
+                synchronized (applyStrategy) {
+                    info = new ProofMacroFinishedInfo(info, result);
+                    if (applyStrategy.hasBeenInterrupted()) {
+                        throw new InterruptedException();
+                    }
                 }
             }
         } finally {

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Node.java
@@ -796,14 +796,7 @@ public class Node implements Iterable<Node> {
      * @see #register(Object, Class)
      */
     public <T> @Nullable T lookup(Class<T> service) {
-        try {
-            if (userData == null) {
-                return null;
-            }
-            return userData.get(service);
-        } catch (IllegalStateException ignored) {
-            return null;
-        }
+        return userData == null ? null : userData.getOrNull(service);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/Proof.java
@@ -1074,9 +1074,9 @@ public class Proof implements ProofObject<Goal>, Named {
      */
     private static ImmutableList<Goal> getGoalsBelow(Node node, ImmutableList<Goal> fromGoals) {
         ImmutableList<Goal> result = ImmutableList.nil();
-        List<Node> leaves = node.getLeaves();
+        final Set<Node> leaves = Collections.newSetFromMap(new IdentityHashMap<>());
+        leaves.addAll(node.getLeaves());
         for (final Goal goal : fromGoals) {
-            // if list contains node, remove it to make the list faster later
             if (leaves.remove(goal.node())) {
                 result = result.prepend(goal);
             }

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/GoalScheduler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/GoalScheduler.java
@@ -7,6 +7,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.key_project.prover.proof.ProofGoal;
@@ -45,6 +46,23 @@ import org.jspecify.annotations.Nullable;
  * @param <T> the goal type
  */
 public final class GoalScheduler<T extends ProofGoal<T>> {
+
+    /** Remaining work for one task */
+    private static final class Budget {
+        int remaining;
+        boolean progressMade;
+
+        Budget(int remaining) {
+            this.remaining = remaining;
+        }
+
+        boolean isSpent() {
+            return remaining <= 0;
+        }
+    }
+
+    /** Task budget per goal, or {@code null} for a run without budgets */
+    private @Nullable Map<T, Budget> taskBudget;
 
     private final Deque<T> available = new ArrayDeque<>();
     /**
@@ -113,6 +131,25 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
         }
     }
 
+    public synchronized void offerAllAsTasks(Iterable<? extends T> goals, int maxSteps) {
+        taskBudget = new IdentityHashMap<>();
+        for (T goal : goals) {
+            taskBudget.put(goal, new Budget(maxSteps));
+            offer(goal);
+        }
+    }
+
+    /**
+     * retrieves the budget for the given goal
+     *
+     * @param goal the Goal
+     * @return the Budget or null if running with unlimited budget
+     */
+    private @Nullable Budget getBudgetFor(T goal) {
+        assert Thread.holdsLock(this);
+        return taskBudget == null ? null : taskBudget.get(goal);
+    }
+
     /**
      * Atomically claims the next available goal, moving it to the in-flight set.
      *
@@ -129,12 +166,27 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
      * @return the claimed goal, or {@code null} if none is currently available
      */
     public synchronized @Nullable T claimNext() {
-        T goal = available.pollLast();
-        if (goal != null) {
+        T goal;
+        while ((goal = available.pollLast()) != null) {
             availableSet.remove(goal);
+            final Budget budget = getBudgetFor(goal);
+            if (budget != null) {
+                if (budget.isSpent()) {
+                    continue;
+                }
+                budget.remaining -= 1;
+            }
             inFlight.add(goal);
+            return goal;
         }
-        return goal;
+        return null;
+    }
+
+    private void refund(T goal) {
+        final Budget budget = getBudgetFor(goal);
+        if (budget != null) {
+            budget.remaining += 1;
+        }
     }
 
     /**
@@ -173,7 +225,17 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
      * Moves all stalled goals back to the available queue for another attempt (caller holds lock).
      */
     private void reactivateStalled() {
+        final Deque<T> stillStalled = new ArrayDeque<>();
+        final Set<Budget> progressedTasks = Collections.newSetFromMap(new IdentityHashMap<>());
         for (T g : stalledOrder) {
+            final Budget budget = getBudgetFor(g);
+            if (budget == null ? !progressMade : !budget.progressMade) {
+                stillStalled.addLast(g);
+                continue;
+            }
+            if (budget != null) {
+                progressedTasks.add(budget);
+            }
             // The inFlight guard is a defensive backstop: stall() keeps stalled disjoint from
             // inFlight, so a stalled goal is never also owned by a worker; skipping any that were
             // makes it impossible to re-queue an in-flight goal (a double-schedule).
@@ -183,6 +245,13 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
         }
         stalled.clear();
         stalledOrder.clear();
+        for (T g : stillStalled) {
+            stalled.add(g);
+            stalledOrder.addLast(g);
+        }
+        for (Budget budget : progressedTasks) {
+            budget.progressMade = false;
+        }
         progressMade = false;
     }
 
@@ -195,6 +264,7 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
      */
     public synchronized void stall(T goal) {
         inFlight.remove(goal);
+        refund(goal);
         if (stalled.add(goal)) {
             stalledOrder.addLast(goal);
         }
@@ -203,8 +273,8 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
 
     /**
      * Returns an in-flight goal to the available queue for immediate re-processing. Used when a
-     * rule
-     * application aborted but the goal still has further candidate rules to try: dropping it (via
+     * rule application aborted but the goal still has further candidate rules to try: dropping it
+     * (via
      * {@link #complete}) would lose the goal and leave the proof open, while {@link #stall}ing
      * would defer it to a progress-gated retry. Re-offering makes it available again right away,
      * mirroring the single-threaded prover, which simply retries the goal after an aborted
@@ -214,6 +284,7 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
      */
     public synchronized void reoffer(T goal) {
         inFlight.remove(goal);
+        refund(goal);
         if (!stalled.contains(goal) && availableSet.add(goal)) {
             available.addLast(goal);
         }
@@ -223,6 +294,7 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
     /** Marks an in-flight goal as done and wakes any threads waiting in {@link #claimOrAwait}. */
     public synchronized void complete(T goal) {
         inFlight.remove(goal);
+        refund(goal);
         notifyAll();
     }
 
@@ -246,8 +318,15 @@ public final class GoalScheduler<T extends ProofGoal<T>> {
      */
     public synchronized void completeAndOffer(T goal, @Nullable Iterable<? extends T> successors) {
         inFlight.remove(goal);
+        final Budget budget = getBudgetFor(goal);
+        if (budget != null) {
+            budget.progressMade = true;
+        }
         if (successors != null) {
             for (T s : successors) {
+                if (budget != null) {
+                    taskBudget.put(s, budget);
+                }
                 makeAvailable(s);
             }
         }

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/GoalScheduler.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/GoalScheduler.java
@@ -9,6 +9,8 @@ import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Set;
 
+import org.key_project.prover.proof.ProofGoal;
+
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -40,9 +42,9 @@ import org.jspecify.annotations.Nullable;
  * This is the natural termination condition for a worker loop, and is <em>weaker</em> than
  * {@link #isQuiescent()}: a worker may terminate with stalled goals still held.
  *
- * @param <T> the goal type (the prover uses {@code GoalScheduler<Goal>}; tests use tokens)
+ * @param <T> the goal type
  */
-public final class GoalScheduler<T> {
+public final class GoalScheduler<T extends ProofGoal<T>> {
 
     private final Deque<T> available = new ArrayDeque<>();
     /**
@@ -83,11 +85,25 @@ public final class GoalScheduler<T> {
      * brings it back once progress is made.
      */
     public synchronized void offer(T goal) {
+        if (makeAvailable(goal)) {
+            notifyAll();
+        }
+    }
+
+    /**
+     * Queues {@code goal} unless it is already available, in flight or stalled (by identity).
+     * <p>
+     * Caller holds monitor and is responsible for calling {@code notifyAll}.
+     *
+     * @param goal the goal to queue
+     * @return whether the goal became available
+     */
+    private boolean makeAvailable(T goal) {
         if (inFlight.contains(goal) || stalled.contains(goal) || !availableSet.add(goal)) {
-            return;
+            return false;
         }
         available.addLast(goal);
-        notifyAll();
+        return true;
     }
 
     /** Offers each goal in {@code goals} (see {@link #offer}). */
@@ -232,9 +248,7 @@ public final class GoalScheduler<T> {
         inFlight.remove(goal);
         if (successors != null) {
             for (T s : successors) {
-                if (!inFlight.contains(s) && !stalled.contains(s) && availableSet.add(s)) {
-                    available.addLast(s);
-                }
+                makeAvailable(s);
             }
         }
         // A rule was applied, which may have made the stalled goals applicable again.

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
@@ -350,10 +350,7 @@ public final class ParallelProver extends DefaultProver<Proof, Goal> {
     public synchronized ApplyStrategyInfo<Proof, Goal> startEach(Proof proof,
             ImmutableList<Goal> goals, int maxSteps, long timeout) {
         // Tasks never stop the run: a task that runs out of budget or of rules leaves its goals
-        // open for the caller to deal with, and the other tasks keep going.
-        return run(proof, goals,
-            (int) Math.min(Integer.MAX_VALUE, (long) goals.size() * maxSteps),
-            timeout, false, maxSteps);
+        return run(proof, goals, Integer.MAX_VALUE, timeout, false, maxSteps);
     }
 
     /**

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
@@ -322,7 +322,9 @@ public final class ParallelProver extends DefaultProver<Proof, Goal> {
     private ApplyStrategyInfo<Proof, Goal> runParallel(ImmutableList<Goal> goals) {
         final long startTime = System.currentTimeMillis();
         final GoalScheduler<Goal> scheduler = new GoalScheduler<>();
-        scheduler.offerAll(goals);
+        // pass only enabled goals to scheduler (works only as long as goals cannot be disabled
+        // during an automatic prover run, otherwise claimNext needs to be changed)
+        scheduler.offerAll(goals.filter(Goal::isAutomatic));
         final Object commitLock = new Object();
 
         // Enter the multi-worker run scope (MT-active marker + sealed Java types) with guaranteed

--- a/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/prover/impl/ParallelProver.java
@@ -288,7 +288,37 @@ public final class ParallelProver extends DefaultProver<Proof, Goal> {
     public synchronized ApplyStrategyInfo<Proof, Goal> start(Proof proof, ImmutableList<Goal> goals,
             int maxSteps,
             long timeout, boolean stopAtFirstNonCloseableGoal) {
+        return run(proof, goals, maxSteps, timeout, stopAtFirstNonCloseableGoal, 0);
+    }
+
+    /**
+     * Runs the workers over {@code goals} and reports the outcome
+     *
+     * @param proof the Proof the goals belong too
+     * @param goals the goals to
+     * @param maxSteps the run-wide limit on rule applications
+     * @param perTaskSteps the budget each goal is assigned, or {@code 0} when the
+     *        step budget applies to all as a whole
+     */
+    private ApplyStrategyInfo<Proof, Goal> run(Proof proof, ImmutableList<Goal> goals, int maxSteps,
+            long timeout, boolean stopAtFirstNonCloseableGoal, int perTaskSteps) {
         assert proof != null;
+        initializeProverRun(proof, maxSteps, timeout, stopAtFirstNonCloseableGoal);
+
+        fireTaskStarted(new DefaultTaskStartedInfo(TaskStartedInfo.TaskKind.Strategy,
+            PROCESSING_STRATEGY, -1));
+
+        final ApplyStrategyInfo<Proof, Goal> result = runParallel(goals, perTaskSteps);
+
+        proof.addAutoModeTime(result.getTime());
+        fireTaskFinished(new DefaultTaskFinishedInfo(this, result, proof, result.getTime(),
+            result.getNumberOfAppliedRuleApps(), result.getNumberOfClosedGoals()));
+
+        return result;
+    }
+
+    private void initializeProverRun(Proof proof, int maxSteps, long timeout,
+            boolean stopAtFirstNonCloseableGoal) {
         this.proof = proof;
         this.stopAtFirstNonClosableGoal = stopAtFirstNonCloseableGoal;
         this.stopCondition =
@@ -304,27 +334,48 @@ public final class ParallelProver extends DefaultProver<Proof, Goal> {
         this.stopMessage = null;
         this.nonCloseableGoal = null;
         this.firstError.set(null);
-
-        // the status line shows an indeterminate ("busy") bar (<code>size == -1</code>):
-        // the parallel prover does not report a meaningful per-step progress value (workers
-        // commit concurrently)
-        fireTaskStarted(new DefaultTaskStartedInfo(TaskStartedInfo.TaskKind.Strategy,
-            PROCESSING_STRATEGY, -1));
-
-        ApplyStrategyInfo<Proof, Goal> result = runParallel(goals);
-
-        proof.addAutoModeTime(result.getTime());
-        fireTaskFinished(new DefaultTaskFinishedInfo(this, result, proof, result.getTime(),
-            result.getNumberOfAppliedRuleApps(), result.getNumberOfClosedGoals()));
-        return result;
     }
 
-    private ApplyStrategyInfo<Proof, Goal> runParallel(ImmutableList<Goal> goals) {
+    /// Starts a proof search for a list of goals, each goal is treated as its own task with its own
+    /// step count, timeout is global for all tasks
+    ///
+    /// @param proof The [ProofObject] representing the proof instance.
+    /// @param goals An [ImmutableList] of [ProofGoal] objects to prove.
+    /// @param maxSteps The maximum number of rule applications to perform per goal task.
+    /// @param timeout The maximum duration (in milliseconds) to perform the proof search (global
+    /// over all tasks).
+    /// @return An [ProofSearchInformation] object containing information about the performed
+    /// work, such as the number of rules applied.
+    @Override
+    public synchronized ApplyStrategyInfo<Proof, Goal> startEach(Proof proof,
+            ImmutableList<Goal> goals, int maxSteps, long timeout) {
+        // Tasks never stop the run: a task that runs out of budget or of rules leaves its goals
+        // open for the caller to deal with, and the other tasks keep going.
+        return run(proof, goals,
+            (int) Math.min(Integer.MAX_VALUE, (long) goals.size() * maxSteps),
+            timeout, false, maxSteps);
+    }
+
+    /**
+     * runs the parallel prover on the given goals; per task steps decides whether
+     * {@link #maxApplications} limits the rule apps per goal or for all goals together
+     *
+     * @param goals the Goal objects to prove in parallel
+     * @param perTaskSteps the budget each goal is assigned, or {@code 0} when the
+     *        step budget applies to all as a whole
+     */
+    private ApplyStrategyInfo<Proof, Goal> runParallel(ImmutableList<Goal> goals,
+            int perTaskSteps) {
         final long startTime = System.currentTimeMillis();
         final GoalScheduler<Goal> scheduler = new GoalScheduler<>();
         // pass only enabled goals to scheduler (works only as long as goals cannot be disabled
         // during an automatic prover run, otherwise claimNext needs to be changed)
-        scheduler.offerAll(goals.filter(Goal::isAutomatic));
+        final ImmutableList<Goal> enabledGoals = goals.filter(Goal::isAutomatic);
+        if (perTaskSteps > 0) {
+            scheduler.offerAllAsTasks(enabledGoals, perTaskSteps);
+        } else {
+            scheduler.offerAll(enabledGoals);
+        }
         final Object commitLock = new Object();
 
         // Enter the multi-worker run scope (MT-active marker + sealed Java types) with guaranteed

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
@@ -13,6 +13,7 @@ import de.uka.ilkd.key.proof.Proof;
 import de.uka.ilkd.key.proof.init.Profile;
 import de.uka.ilkd.key.prover.impl.AutoProvers;
 import de.uka.ilkd.key.scripts.meta.*;
+import de.uka.ilkd.key.settings.StrategySettings;
 import de.uka.ilkd.key.strategy.FocussedBreakpointRuleApplicationManager;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.StrategyProperties;
@@ -109,14 +110,16 @@ public class AutoCommand extends AbstractCommand {
 
         // start actual autoprove
         try {
-            for (Goal goal : goals) {
-                applyStrategy.start(state().getProof(), ImmutableList.<Goal>singleton(goal));
-
-                // only now reraise the interruption exception
-                if (applyStrategy.hasBeenInterrupted()) {
-                    throw new InterruptedException();
-                }
-
+            final Proof proof = state().getProof();
+            if (arguments.onAllOpenGoals) {
+                final StrategySettings strategySettings = proof.getSettings().getStrategySettings();
+                applyStrategy.startEach(proof, goals, strategySettings.getMaxSteps(),
+                    strategySettings.getTimeout());
+            } else {
+                applyStrategy.start(proof, goals);
+            }
+            if (applyStrategy.hasBeenInterrupted()) {
+                throw new InterruptedException();
             }
         } finally {
             state().setMaxAutomaticSteps(oldNumberOfSteps);

--- a/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/scripts/AutoCommand.java
@@ -18,6 +18,7 @@ import de.uka.ilkd.key.strategy.FocussedBreakpointRuleApplicationManager;
 import de.uka.ilkd.key.strategy.Strategy;
 import de.uka.ilkd.key.strategy.StrategyProperties;
 
+import org.key_project.prover.engine.ProofSearchInformation;
 import org.key_project.prover.engine.ProverCore;
 import org.key_project.prover.strategy.RuleApplicationManager;
 import org.key_project.util.collection.ImmutableList;
@@ -111,12 +112,17 @@ public class AutoCommand extends AbstractCommand {
         // start actual autoprove
         try {
             final Proof proof = state().getProof();
+            final ProofSearchInformation<Proof, Goal> result;
             if (arguments.onAllOpenGoals) {
                 final StrategySettings strategySettings = proof.getSettings().getStrategySettings();
-                applyStrategy.startEach(proof, goals, strategySettings.getMaxSteps(),
+                result = applyStrategy.startEach(proof, goals, strategySettings.getMaxSteps(),
                     strategySettings.getTimeout());
             } else {
-                applyStrategy.start(proof, goals);
+                result = applyStrategy.start(proof, goals);
+            }
+            if (result.isError()) {
+                throw new ScriptException("Proof search failed: " + result.getException(),
+                    result.getException());
             }
             if (applyStrategy.hasBeenInterrupted()) {
                 throw new InterruptedException();

--- a/key.core/src/test/java/de/uka/ilkd/key/prover/mt/GoalSchedulerTest.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/prover/mt/GoalSchedulerTest.java
@@ -14,6 +14,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import de.uka.ilkd.key.prover.impl.GoalScheduler;
 
+import org.key_project.prover.proof.ProofGoal;
+import org.key_project.prover.proof.ProofObject;
+import org.key_project.prover.rules.RuleApp;
+import org.key_project.prover.sequent.Sequent;
+import org.key_project.prover.strategy.RuleApplicationManager;
+import org.key_project.util.collection.ImmutableList;
+
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,21 +37,73 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class GoalSchedulerTest {
 
+    private static final class TestGoal implements ProofGoal<TestGoal> {
+        private final String name;
+        private final int splitsLeft;
+        private final boolean automatic;
+
+        private TestGoal(String name, int splitsLeft, boolean automatic) {
+            this.name = name;
+            this.splitsLeft = splitsLeft;
+            this.automatic = automatic;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
+        public @Nullable ProofObject<TestGoal> proof() {
+            return null;
+        }
+
+        @Override
+        public @Nullable Sequent sequent() {
+            return null;
+        }
+
+        @Override
+        public @Nullable ImmutableList<TestGoal> apply(RuleApp ruleApp) {
+            return null;
+        }
+
+        @Override
+        public @Nullable RuleApplicationManager<TestGoal> getRuleAppManager() {
+            return null;
+        }
+
+        @Override
+        public long getTime() {
+            return 0;
+        }
+    }
+
+    /** An automatic goal that never splits. */
+    private static TestGoal goal(String name) {
+        return new TestGoal(name, 0, true);
+    }
+
+    /** An automatic goal that still splits {@code splitsLeft} times. */
+    private static TestGoal splitting(int splitsLeft) {
+        return new TestGoal("d" + splitsLeft, splitsLeft, true);
+    }
+
     @Test
     void basicLifecycleAndQuiescence() {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
         assertTrue(scheduler.isQuiescent());
 
-        scheduler.offer("a");
-        scheduler.offer("b");
+        scheduler.offer(goal("a"));
+        scheduler.offer(goal("b"));
         assertEquals(2, scheduler.availableCount());
         assertFalse(scheduler.isQuiescent());
 
-        String first = scheduler.claimNext();
+        TestGoal first = scheduler.claimNext();
         assertEquals(1, scheduler.inFlightCount());
         assertFalse(scheduler.isQuiescent(), "in-flight work means not quiescent");
 
-        String second = scheduler.claimNext(); // claim the other (order is an impl detail)
+        TestGoal second = scheduler.claimNext(); // claim the other (order is an impl detail)
         assertNull(scheduler.claimNext(), "nothing left to claim");
 
         scheduler.complete(first);
@@ -54,13 +114,13 @@ public class GoalSchedulerTest {
 
     @Test
     void deduplicatesByIdentity() {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String g = "goal";
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal g = goal("goal");
         scheduler.offer(g);
         scheduler.offer(g); // same identity, ignored
         assertEquals(1, scheduler.availableCount());
 
-        String claimed = scheduler.claimNext();
+        TestGoal claimed = scheduler.claimNext();
         scheduler.offer(claimed); // in flight, must not be re-queued
         assertEquals(0, scheduler.availableCount());
     }
@@ -71,15 +131,15 @@ public class GoalSchedulerTest {
         final int initialGoals = 500;
         // Each goal, when processed, "splits" into children a bounded number of times, modelling
         // proof-tree growth. Total processed count is deterministic regardless of scheduling.
-        final GoalScheduler<int[]> scheduler = new GoalScheduler<>();
+        final GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
 
-        final Set<int[]> claimedOnce = ConcurrentHashMap.newKeySet();
-        final List<int[]> claimedTwice = new CopyOnWriteArrayList<>();
+        final Set<TestGoal> claimedOnce = ConcurrentHashMap.newKeySet();
+        final List<TestGoal> claimedTwice = new CopyOnWriteArrayList<>();
         final AtomicInteger processed = new AtomicInteger();
         final List<Throwable> failures = new CopyOnWriteArrayList<>();
 
         for (int i = 0; i < initialGoals; i++) {
-            scheduler.offer(new int[] { 3 }); // depth budget 3
+            scheduler.offer(splitting(3)); // depth budget 3
         }
 
         final CountDownLatch ready = new CountDownLatch(workers);
@@ -90,16 +150,16 @@ public class GoalSchedulerTest {
                 try {
                     ready.countDown();
                     go.await();
-                    int[] goal;
+                    TestGoal goal;
                     while ((goal = scheduler.claimOrAwait()) != null) {
                         if (!claimedOnce.add(goal)) {
                             claimedTwice.add(goal);
                         }
                         processed.incrementAndGet();
                         // "Splitting": produce two children with a smaller depth budget.
-                        if (goal[0] > 0) {
-                            scheduler.offer(new int[] { goal[0] - 1 });
-                            scheduler.offer(new int[] { goal[0] - 1 });
+                        if (goal.splitsLeft > 0) {
+                            scheduler.offer(splitting(goal.splitsLeft - 1));
+                            scheduler.offer(splitting(goal.splitsLeft - 1));
                         }
                         scheduler.complete(goal);
                     }
@@ -139,10 +199,10 @@ public class GoalSchedulerTest {
         final int depth = 13; // full binary tree: 2^(depth+1) - 1 nodes
         final int expected = (1 << (depth + 1)) - 1;
         for (int rep = 0; rep < 5; rep++) {
-            final GoalScheduler<int[]> scheduler = new GoalScheduler<>();
+            final GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
             final AtomicInteger processed = new AtomicInteger();
             final List<Throwable> failures = new CopyOnWriteArrayList<>();
-            scheduler.offer(new int[] { depth }); // single root -> small frontier
+            scheduler.offer(splitting(depth)); // single root -> small frontier
 
             final CountDownLatch go = new CountDownLatch(1);
             List<Thread> threads = new ArrayList<>();
@@ -150,11 +210,12 @@ public class GoalSchedulerTest {
                 Thread t = new Thread(() -> {
                     try {
                         go.await();
-                        int[] goal;
+                        TestGoal goal;
                         while ((goal = scheduler.claimOrAwait()) != null) {
                             processed.incrementAndGet();
-                            List<int[]> kids = goal[0] > 0
-                                    ? List.of(new int[] { goal[0] - 1 }, new int[] { goal[0] - 1 })
+                            List<TestGoal> kids = goal.splitsLeft > 0
+                                    ? List.of(splitting(goal.splitsLeft - 1),
+                                        splitting(goal.splitsLeft - 1))
                                     : null;
                             scheduler.completeAndOffer(goal, kids);
                         }
@@ -184,9 +245,9 @@ public class GoalSchedulerTest {
      */
     @Test
     void offeringAStalledGoalDoesNotDoubleScheduleIt() throws Exception {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String g = "g";
-        String driver = "driver"; // a second goal whose completion signals progress
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal g = goal("g");
+        TestGoal driver = goal("driver"); // a second goal whose completion signals progress
         // offer driver first so g is on top of the LIFO stack and is claimed first
         scheduler.offer(driver);
         scheduler.offer(g);
@@ -216,15 +277,15 @@ public class GoalSchedulerTest {
      */
     @Test
     void stalledGoalsReactivateOnlyAfterProgressInDeterministicOrder() throws Exception {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String driver = "driver";
-        String g1 = "g1";
-        String g2 = "g2";
-        String g3 = "g3";
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal driver = goal("driver");
+        TestGoal g1 = goal("g1");
+        TestGoal g2 = goal("g2");
+        TestGoal g3 = goal("g3");
         scheduler.offer(driver);
 
         // Stall g1, g2, g3 in that order (each is the LIFO top when claimed).
-        for (String g : new String[] { g1, g2, g3 }) {
+        for (TestGoal g : new TestGoal[] { g1, g2, g3 }) {
             scheduler.offer(g);
             assertEquals(g, scheduler.claimNext());
             scheduler.stall(g);
@@ -236,8 +297,8 @@ public class GoalSchedulerTest {
         scheduler.completeAndOffer(driver, null);
 
         // Reactivation appends g1,g2,g3 (insertion order); LIFO hand-out then claims g3,g2,g1.
-        List<String> claimOrder = new ArrayList<>();
-        String claimed;
+        List<TestGoal> claimOrder = new ArrayList<>();
+        TestGoal claimed;
         while ((claimed = scheduler.claimOrAwait()) != null) {
             claimOrder.add(claimed);
             scheduler.completeAndOffer(claimed, null);
@@ -252,8 +313,8 @@ public class GoalSchedulerTest {
      */
     @Test
     void reofferMakesGoalImmediatelyClaimable() {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String g = "g";
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal g = goal("g");
         scheduler.offer(g);
         assertEquals(g, scheduler.claimNext());
         assertEquals(0, scheduler.availableCount());
@@ -275,14 +336,14 @@ public class GoalSchedulerTest {
      */
     @Test
     void offerAllMakesEachGoalAvailableAndDeduplicates() {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String a = "a";
-        String b = "b";
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal a = goal("a");
+        TestGoal b = goal("b");
         scheduler.offerAll(List.of(a, b, a)); // duplicate a collapses
         assertEquals(2, scheduler.availableCount());
 
-        String claimed = scheduler.claimNext();
-        scheduler.offerAll(List.of(claimed, "c")); // in-flight claimed ignored, c added
+        TestGoal claimed = scheduler.claimNext();
+        scheduler.offerAll(List.of(claimed, goal("c"))); // in-flight claimed ignored, c added
         assertEquals(2, scheduler.availableCount(), "in-flight goal not re-queued; new goal added");
     }
 
@@ -295,8 +356,8 @@ public class GoalSchedulerTest {
      */
     @Test
     void searchTerminatesButIsQuiescentStaysFalseWhenGoalsEndStalled() throws Exception {
-        GoalScheduler<String> scheduler = new GoalScheduler<>();
-        String g = "g";
+        GoalScheduler<TestGoal> scheduler = new GoalScheduler<>();
+        TestGoal g = goal("g");
         scheduler.offer(g);
         assertEquals(g, scheduler.claimNext());
         scheduler.stall(g); // no progress was made this pass

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/engine/ProofSearchInformation.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/engine/ProofSearchInformation.java
@@ -116,4 +116,11 @@ public interface ProofSearchInformation<P extends ProofObject<G>, G extends @Nul
     /// @return the number of rule applications performed
     int getNumberOfAppliedRuleApps();
 
+    /// join several ProofSearchInformation into an aggregate
+    /// needed for batch runs (messages becomes a generic message)
+    /// counters are summed and in case of error and non-closeable goal
+    /// the first current one is kept
+    /// @param other the ProofSearchInformation<P,G> to combine with
+    /// @return the aggregated ProofSearchInformation<P,G>
+    ProofSearchInformation<P, G> join(ProofSearchInformation<P, G> other);
 }

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/engine/ProverCore.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/engine/ProverCore.java
@@ -67,6 +67,43 @@ public interface ProverCore<P extends ProofObject<G>, G extends @Nullable ProofG
     ProofSearchInformation<P, G> start(P proof, ImmutableList<G> goals, int maxSteps, long timeout,
             boolean stopAtFirstNonCloseableGoal);
 
+    /// Starts a proof search for a list of goals, each goal is treated as its own task with its own
+    /// step count, timeout is global for all tasks
+    ///
+    ///
+    /// @param proof The [ProofObject] representing the proof instance.
+    /// @param goals An [ImmutableList] of [ProofGoal] objects to prove.
+    /// @param maxSteps The maximum number of rule applications to perform per goal task.
+    /// @param timeout The maximum duration (in milliseconds) to perform the proof search (global
+    /// over all tasks).
+    /// @return An [ProofSearchInformation] object containing information about the performed
+    /// work, such as the number of rules applied.
+    default ProofSearchInformation<P, G> startEach(P proof, ImmutableList<G> goals, int maxSteps,
+            long timeout) {
+
+        ProofSearchInformation<P, G> aggregatedResult = null;
+        long deadline = timeout >= 0 ? System.currentTimeMillis() + timeout : -1;
+
+        for (G goal : goals) {
+            final ProofSearchInformation<P, G> result;
+            long remainingTime = deadline;
+            if (deadline >= 0 &&
+                    (remainingTime -= System.currentTimeMillis()) <= 0) {
+                break;
+            }
+            result = start(proof, ImmutableList.singleton(goal), maxSteps, remainingTime, false);
+
+            aggregatedResult = aggregatedResult == null ? result : aggregatedResult.join(result);
+
+            if (hasBeenInterrupted()) {
+                break;
+            }
+        }
+        return aggregatedResult != null ? aggregatedResult
+                : // stupid hack to get an info object without having to create one here explicitly
+                start(proof, ImmutableList.nil(), maxSteps, timeout, false);
+    }
+
     /// Adds a listener to monitor proof task events.
     ///
     /// @param observer The [ProverTaskListener] to add.

--- a/key.ncore.calculus/src/main/java/org/key_project/prover/engine/impl/ApplyStrategyInfo.java
+++ b/key.ncore.calculus/src/main/java/org/key_project/prover/engine/impl/ApplyStrategyInfo.java
@@ -123,6 +123,22 @@ public class ApplyStrategyInfo<Proof extends ProofObject<Goal>, Goal extends @Nu
         return appliedRuleAppsCount;
     }
 
+    @Override
+    public ApplyStrategyInfo<Proof, Goal> join(ProofSearchInformation<Proof, Goal> other) {
+        if (other.getProof() != proof) {
+            throw new IllegalArgumentException("Tried to combine ProofSearchInformations from" +
+                "different proof objects");
+        }
+
+        return new ApplyStrategyInfo<>("Aggregated Information (batched)",
+            proof,
+            error != null ? error : other.getException(),
+            nonCloseableGoal != null ? nonCloseableGoal : other.nonCloseableGoal(),
+            timeInMillis + other.getTime(),
+            appliedRuleAppsCount + other.getNumberOfAppliedRuleApps(),
+            nrClosedGoals + other.getNumberOfClosedGoals());
+    }
+
     /// {@inheritDoc}
     @Override
     public Proof getProof() {

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroMenu.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/ProofMacroMenu.java
@@ -12,10 +12,12 @@ import de.uka.ilkd.key.gui.actions.ProofScriptInputAction;
 import de.uka.ilkd.key.gui.actions.useractions.ProofMacroUserAction;
 import de.uka.ilkd.key.gui.keyshortcuts.KeyStrokeManager;
 import de.uka.ilkd.key.macros.ProofMacro;
+import de.uka.ilkd.key.proof.Goal;
 import de.uka.ilkd.key.proof.Node;
 import de.uka.ilkd.key.settings.FeatureSettings;
 
 import org.key_project.prover.sequent.PosInOccurrence;
+import org.key_project.util.collection.ImmutableList;
 import org.key_project.util.reflection.ClassLoaderUtil;
 
 import static de.uka.ilkd.key.settings.FeatureSettings.createFeature;
@@ -82,8 +84,10 @@ public class ProofMacroMenu extends JMenu {
 
         int count = 0;
         Node node = mediator.getSelectedNode();
+        final ImmutableList<Goal> goals =
+            node == null ? null : node.proof().getSubtreeEnabledGoals(node);
         for (ProofMacro macro : REGISTERED_MACROS) {
-            boolean applicable = node != null && macro.canApplyTo(node, posInOcc);
+            boolean applicable = goals != null && macro.canApplyTo(node.proof(), goals, posInOcc);
 
             if (applicable) {
                 JMenuItem menuItem = createMenuItem(macro, mediator, posInOcc);

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -94,6 +94,12 @@ public class ProofTreeView extends JPanel implements TabPanel {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProofTreeView.class);
 
     /**
+     * Number of modified subtrees changed by one automatic run {@link GUIProofTreeProofListener}
+     * which if exceeded cause the whole tree to be updated (not just the affected subtrees).
+     */
+    private static final int MAX_PARTIAL_TREE_UPDATES = 16;
+
+    /**
      * Whether to expand oss nodes when using expand all
      */
     private boolean expandOSSNodes = false;
@@ -1094,11 +1100,21 @@ public class ProofTreeView extends JPanel implements TabPanel {
             delegateView.removeTreeSelectionListener(treeSelectionListener);
             setProof(mediator.getSelectedProof());
             if (modifiedSubtrees != null) {
+                final List<Node> changed = new ArrayList<>();
                 for (final Node n : modifiedSubtrees) {
                     // skip nodes of other proofs: the displayed proof may have changed since the
                     // subtrees were recorded in autoModeStarted (see #3713)
                     if (n.proof() == proof
                             && proof.openGoals().filter(g -> g.node() == n).isEmpty()) {
+                        changed.add(n);
+                    }
+                }
+                if (changed.size() > MAX_PARTIAL_TREE_UPDATES) {
+                    // update whole tree
+                    delegateModel.updateTree(null);
+                } else {
+                    // update only affected subtrees
+                    for (final Node n : changed) {
                         delegateModel.updateTree(n);
                     }
                 }

--- a/key.util/src/main/java/org/key_project/util/lookup/Lookup.java
+++ b/key.util/src/main/java/org/key_project/util/lookup/Lookup.java
@@ -105,6 +105,24 @@ public class Lookup {
     }
 
     /**
+     * The first implementation registered for {@code service}, here or in a parent lookup, or
+     * {@code null} if there is none. Unlike {@link #get(Class)} this does not throw in case of
+     * a miss.
+     *
+     * @param service the requested service class
+     * @param <T> the service type
+     * @return the first registered implementation, or {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends @Nullable Object> @Nullable T getOrNull(Class<T> service) {
+        LinkedList<?> t = serviceMap.get(service);
+        if (t != null && !t.isEmpty()) {
+            return (T) t.getFirst();
+        }
+        return parent != null ? parent.getOrNull(service) : null;
+    }
+
+    /**
      * Register
      *
      * @param obj


### PR DESCRIPTION
This PR should improve the MT experience for scripts and macros
- MT now respects the interactive/automated goal markers (Leave command should work as expected undet MT)
- Parellelism for Autocommand and TryClose improved by moving sequential loop across goals into parallel prover. In MT mode the step budget is per goal (not overall)

**Quicksort.sort Script:** 
- current main speed up on MT4x vs SC: 1.63x
- speed up on this branch: **2.31x**

**Quicksort.split Script:**
- current main speed up on MT4x vs SC: 1.59x
- speed up on this branch: **2.38x**


## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I made sure that new/changed end-user features are well documented (https://github.com/KeYProject/key-docs).
- I added new test case(s) for new functionality.
- I have tested the feature as follows: tests, 3xRAP (1xSC, 2x MT4x), benchmarking of 5 examples, benchmarking of macros and scripts
- I have checked that runtime performance has not deteriorated. 

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
