### PR TITLE
Rendering performance improvements

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
@@ -69,6 +69,11 @@ public class KeYProgModelInfo {
     /** Size of the type model {@link #subtypeCache} was computed from. */
     private int subtypeCachedSize = -1;
 
+    /**
+     * Caches locally declared fields; does not need to be invalidated as
+     * an existing class declaration is immutable
+     */
+    private final Map<KeYJavaType, List<Field>> localDeclaredFields = new LinkedHashMap<>();
 
 
     public KeYProgModelInfo(JavaService service) {
@@ -460,9 +465,20 @@ public class KeYProgModelInfo {
         if (ct.getJavaType() instanceof ArrayType) {
             return getVisibleArrayFields(ct);
         }
-        return getReferenceType(ct)
+        List<Field> fields;
+        synchronized (localDeclaredFields) {
+            fields = localDeclaredFields.get(ct);
+            if (fields != null) {
+                return fields;
+            }
+        }
+        fields = Collections.unmodifiableList(getReferenceType(ct)
                 .map(r -> asKeYFieldsR(r.getDeclaredFields().stream()))
-                .orElseGet(ArrayList::new);
+                .orElseGet(ArrayList::new));
+        synchronized (localDeclaredFields) {
+            localDeclaredFields.put(ct, fields);
+        }
+        return fields;
     }
 
 

--- a/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/KeYProgModelInfo.java
@@ -4,6 +4,7 @@
 package de.uka.ilkd.key.java;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -73,7 +74,8 @@ public class KeYProgModelInfo {
      * Caches locally declared fields; does not need to be invalidated as
      * an existing class declaration is immutable
      */
-    private final Map<KeYJavaType, List<Field>> localDeclaredFields = new LinkedHashMap<>();
+    private final Map<KeYJavaType, ImmutableList<Field>> localDeclaredFields =
+        new ConcurrentHashMap<>();
 
 
     public KeYProgModelInfo(JavaService service) {
@@ -461,21 +463,16 @@ public class KeYProgModelInfo {
      * @param ct the class type whose fields are returned
      * @return the list of field members of the given type.
      */
-    public List<Field> getAllFieldsLocallyDeclaredIn(KeYJavaType ct) {
-        if (ct.getJavaType() instanceof ArrayType) {
-            return getVisibleArrayFields(ct);
-        }
-        List<Field> fields;
-        synchronized (localDeclaredFields) {
-            fields = localDeclaredFields.get(ct);
-            if (fields != null) {
-                return fields;
+    public ImmutableList<Field> getAllFieldsLocallyDeclaredIn(KeYJavaType ct) {
+        ImmutableList<Field> fields = localDeclaredFields.get(ct);
+        if (fields == null) {
+            if (ct.getJavaType() instanceof ArrayType) {
+                fields = ImmutableList.fromList(getVisibleArrayFields(ct));
+            } else {
+                fields = ImmutableList.fromList(getReferenceType(ct)
+                        .map(r -> asKeYFieldsR(r.getDeclaredFields().stream()))
+                        .orElseGet(ArrayList::new));
             }
-        }
-        fields = Collections.unmodifiableList(getReferenceType(ct)
-                .map(r -> asKeYFieldsR(r.getDeclaredFields().stream()))
-                .orElseGet(ArrayList::new));
-        synchronized (localDeclaredFields) {
             localDeclaredFields.put(ct, fields);
         }
         return fields;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/GUIOneStepChildTreeNode.java
@@ -53,13 +53,14 @@ public class GUIOneStepChildTreeNode extends GUIAbstractTreeNode {
         return true;
     }
 
+    /**
+     * The node's label without the applied on information.
+     * The term is shown in the tooltip and can still be
+     * searched through {@link #getSearchString()}.
+     */
     @Override
     public String toString() {
-        // For prettyprinting
-        Services services = parent.getNode().proof().getServices();
-        String prettySubTerm =
-            LogicPrinter.quickPrintTerm((JTerm) app.posInOccurrence().subTerm(), services);
-        return app.rule().name() + " ON " + prettySubTerm;
+        return app.rule().name().toString();
     }
 
     public RuleApp getRuleApp() {
@@ -77,6 +78,9 @@ public class GUIOneStepChildTreeNode extends GUIAbstractTreeNode {
 
     @Override
     public @NonNull String getSearchString() {
-        return toString();
+        Services services = parent.getNode().proof().getServices();
+        String prettySubTerm =
+            LogicPrinter.quickPrintTerm((JTerm) app.posInOccurrence().subTerm(), services);
+        return app.rule().name() + " ON " + prettySubTerm;
     }
 }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -1228,12 +1228,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
                 result.append(" ");
             }
             if (fragment.value instanceof final PosInOccurrence pio) {
-                if (pio != null) {
-                    String on = LogicPrinter.quickPrintTerm((JTerm) pio.subTerm(), services);
-                    result.append(LogicPrinter.escapeHTML(cutIfTooLong(on), true));
-                } else {
-                    result.append("sequent");
-                }
+                String on = LogicPrinter.quickPrintTerm((JTerm) pio.subTerm(), services);
+                result.append(LogicPrinter.escapeHTML(cutIfTooLong(on), true));
             } else {
                 result.append(fragment.value);
             }

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/ProofTreeView.java
@@ -212,7 +212,8 @@ public class ProofTreeView extends JPanel implements TabPanel {
 
                     Style style = renderer.initStyleForNode(node);
                     if (style.tooltip != null) {
-                        return renderTooltip(style.tooltip);
+                        return renderTooltip(style.tooltip,
+                            node.getNode().proof().getServices());
                     }
                 }
 
@@ -1197,7 +1198,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
         }
     }
 
-    private static String renderTooltip(Style.Tooltip tooltip) {
+    private static String renderTooltip(Style.Tooltip tooltip, Services services) {
         String title = tooltip.getTitle();
         List<Style.Tooltip.Fragment> fragments = tooltip.getAdditionalInfos();
         boolean titleEmpty = title == null || title.isEmpty();
@@ -1226,7 +1227,16 @@ public class ProofTreeView extends JPanel implements TabPanel {
             } else {
                 result.append(" ");
             }
-            result.append(fragment.value);
+            if (fragment.value instanceof final PosInOccurrence pio) {
+                if (pio != null) {
+                    String on = LogicPrinter.quickPrintTerm((JTerm) pio.subTerm(), services);
+                    result.append(LogicPrinter.escapeHTML(cutIfTooLong(on), true));
+                } else {
+                    result.append("sequent");
+                }
+            } else {
+                result.append(fragment.value);
+            }
         }
         result.append("</html>");
         return result.toString();
@@ -1278,11 +1288,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
         private void renderBranch(Style style, GUIBranchNode node) {
             style.icon = getIcon();
 
-            var text = style.text;
+            var text = style.text();
             // Elide text and move it to additional info
             // This does not influence the search since it does not use the text
             if (text.length() > 60) {
-                style.text = text.substring(0, 60) + "...";
+                style.setText(text.substring(0, 60) + "...");
                 style.tooltip.setTitle(text);
             }
 
@@ -1382,9 +1392,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             style.tooltip.addRule(node.getAppliedRuleApp().rule().name().toString());
             PosInOccurrence pio = node.getAppliedRuleApp().posInOccurrence();
             if (pio != null) {
-                String on = LogicPrinter.quickPrintTerm(
-                    (JTerm) pio.subTerm(), node.proof().getServices());
-                style.tooltip.addAppliedOn(cutIfTooLong(on));
+                style.tooltip.addPosInOccurrence(pio);
             }
 
             final String notes = node.getNodeInfo().getNotes();
@@ -1412,7 +1420,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             if (!(treeNode instanceof GUIOneStepChildTreeNode) && child.size() == 1
                     && child.get(0).getNodeInfo().getBranchLabel() != null) {
                 isBranch = true;
-                style.text = style.text + ": " + child.get(0).getNodeInfo().getBranchLabel();
+                style.setText(style.text() + ": " + child.get(0).getNodeInfo().getBranchLabel());
             }
             if (isBranch && node.childrenCount() > 1) {
                 defaultIcon = getOpenIcon();
@@ -1420,11 +1428,11 @@ public class ProofTreeView extends JPanel implements TabPanel {
             }
             style.icon = defaultIcon;
 
-            var text = style.text;
+            var text = style.text();
             // Elide text and move it to additional info
             // This does not influence the search since it does not use the text
             if (text.length() > 60 && treeNode instanceof GUIProofTreeNode) {
-                style.text = text.substring(0, 60) + "...";
+                style.setText(text.substring(0, 60) + "...");
                 // This should only happen if node.name() uses the active statement
                 // Pretty print it to make it readable
                 style.tooltip.setTitle(node.getAppliedRuleApp().rule().name().toString());
@@ -1459,12 +1467,9 @@ public class ProofTreeView extends JPanel implements TabPanel {
             style.foreground = GRAY_COLOR.get();
             style.icon = IconFactory.oneStepSimplifier(16);
             RuleApp app = node.getRuleApp();
-            style.text = app.rule().name().toString();
-            Services services = node.getNode().proof().getServices();
-            String on =
-                LogicPrinter.quickPrintTerm((JTerm) app.posInOccurrence().subTerm(), services);
-            style.tooltip.addRule(style.text);
-            style.tooltip.addAppliedOn(cutIfTooLong(on));
+            style.setText(app.rule().name().toString());
+            style.tooltip.addRule(style.text());
+            style.tooltip.addPosInOccurrence(app.posInOccurrence());
         }
 
         @Override
@@ -1495,7 +1500,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             // For performance reasons, we render the tooltips now lazily ...
             // String tooltip = renderTooltip(style.tooltip);
             // setToolTipText(tooltip);
-            setText(style.text);
+            setText(style.text());
             setIcon(style.icon);
 
             return this;
@@ -1512,7 +1517,7 @@ public class ProofTreeView extends JPanel implements TabPanel {
             style.foreground = UIManager.getColor("Label.foreground");
             style.background = UIManager.getColor("Label.background");
             // Normalize whitespace
-            style.text = node.toString().replaceAll("\\s+", " ");
+            style.setText(node.toString().replaceAll("\\s+", " "));
             style.border = null;
             style.tooltip = new Style.Tooltip();
             style.icon = null;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.swing.Icon;
 
-import de.uka.ilkd.key.pp.LogicPrinter;
+import org.key_project.prover.sequent.PosInOccurrence;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -19,8 +19,7 @@ import org.jspecify.annotations.Nullable;
  * @version 1 (20.05.19)
  */
 public class Style {
-    /** the text of this node */
-    public String text;
+    private String text;
 
     /** the tooltip */
     public @Nullable Tooltip tooltip;
@@ -36,6 +35,15 @@ public class Style {
 
     /** icon of the node */
     public @Nullable Icon icon;
+
+    /** the text of this node */
+    public String text() {
+        return text;
+    }
+
+    public void setText(String s) {
+        this.text = s;
+    }
 
     /** Wrapper class for the tooltip */
     public static class Tooltip {
@@ -68,8 +76,8 @@ public class Style {
          * @param value the value
          * @param block whether this should be rendered as a block
          */
-        public void addAdditionalInfo(@NonNull String key, @NonNull String value, boolean block) {
-            additionalInfo.add(new Fragment(key, value, block));
+        public <T> void addAdditionalInfo(@NonNull String key, @NonNull T value, boolean block) {
+            additionalInfo.add(new Fragment<>(key, value, block));
         }
 
         /**
@@ -90,13 +98,8 @@ public class Style {
             addAdditionalInfo("Rule", rule, false);
         }
 
-        /**
-         * Adds applied on infos
-         *
-         * @param on the info
-         */
-        public void addAppliedOn(@NonNull String on) {
-            addAdditionalInfo("Applied on", LogicPrinter.escapeHTML(on, true), true);
+        public void addPosInOccurrence(@NonNull PosInOccurrence pio) {
+            addAdditionalInfo("Applied on", pio, true);
         }
 
         /**
@@ -107,15 +110,15 @@ public class Style {
         }
 
         /** wrapper class for additional infos */
-        public static final class Fragment {
+        public static final class Fragment<T> {
             /** key */
             public final String key;
             /** value */
-            public final String value;
+            public final T value;
             /** whether this is a block */
             public final boolean block;
 
-            public Fragment(String key, String value, boolean block) {
+            public Fragment(String key, T value, boolean block) {
                 this.key = key;
                 this.value = value;
                 this.block = block;

--- a/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
+++ b/key.ui/src/main/java/de/uka/ilkd/key/gui/prooftree/Style.java
@@ -76,8 +76,8 @@ public class Style {
          * @param value the value
          * @param block whether this should be rendered as a block
          */
-        public <T> void addAdditionalInfo(@NonNull String key, @NonNull T value, boolean block) {
-            additionalInfo.add(new Fragment<>(key, value, block));
+        public void addAdditionalInfo(@NonNull String key, @NonNull Object value, boolean block) {
+            additionalInfo.add(new Fragment(key, value, block));
         }
 
         /**
@@ -110,15 +110,15 @@ public class Style {
         }
 
         /** wrapper class for additional infos */
-        public static final class Fragment<T> {
+        public static final class Fragment {
             /** key */
             public final String key;
             /** value */
-            public final T value;
+            public final Object value;
             /** whether this is a block */
             public final boolean block;
 
-            public Fragment(String key, T value, boolean block) {
+            public Fragment(String key, Object value, boolean block) {
                 this.key = key;
                 this.value = value;
                 this.block = block;


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Improves rendering speed of proof tree and sequent view by
* rendering the applied on information (potentially long term) first when tooltip is shown (proof tree)
* caching locally declared fields (sequent view and proof tree)

The proof tree part could lead to a minute long wait even for rather small proofs on at least macOS
where a JTree is walked by the OSes accessibility feature to provide navigation via voice over. The walk
caused to render the term part of the tooltip for each node.

The second part helps the proof tree and sequent view by caching an information often accessed by 
the pretty printer to decide how to print an attribute name.

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I made sure that introduced/changed code is well documented (javadoc and inline comments).
- I have tested the feature as follows: the render is now instantenuous on macos and the shown information on the proof tree and tooltips is identical.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
