### PR TITLE
Tweaks for Immutable* data structures

### DIFF
--- a/key.ui/examples/standard_key/pred_log/tptp/NUM/NUM325+1.key
+++ b/key.ui/examples/standard_key/pred_log/tptp/NUM/NUM325+1.key
@@ -1,0 +1,700 @@
+// From TPTP FOF: NUM325+1.p
+
+\settings {
+    "Strategy" : {
+        "MaximumNumberOfAutomaticApplications" : 10000,
+        "Timeout" : -1,
+        "options" : {
+            "NON_LIN_ARITH_OPTIONS_KEY" : "NON_LIN_ARITH_DEF_OPS",
+            "QUANTIFIERS_OPTIONS_KEY" : "QUANTIFIERS_INSTANTIATE",
+            "SPLITTING_OPTIONS_KEY" : "SPLITTING_DELAYED",
+            "TRIGGERS_OPTIONS_KEY" : "TRIGGERS_BEST"
+        }
+    }
+}
+
+\sorts {
+    TPTP_i;
+}
+
+\functions {
+    TPTP_i tptp_n23;
+    TPTP_i tptp_rdn_pos(TPTP_i);
+    TPTP_i tptp_rdn(TPTP_i, TPTP_i);
+    TPTP_i tptp_rdnn(TPTP_i);
+    TPTP_i tptp_n3;
+    TPTP_i tptp_n2;
+    TPTP_i tptp_nn58;
+    TPTP_i tptp_rdn_neg(TPTP_i);
+    TPTP_i tptp_n8;
+    TPTP_i tptp_n5;
+    TPTP_i tptp_nn51;
+    TPTP_i tptp_n1;
+    TPTP_i tptp_n77;
+    TPTP_i tptp_n7;
+    TPTP_i tptp_n90;
+    TPTP_i tptp_n0;
+    TPTP_i tptp_n9;
+    TPTP_i tptp_n55;
+    TPTP_i tptp_n118;
+    TPTP_i tptp_nn8;
+    TPTP_i tptp_n106;
+    TPTP_i tptp_n6;
+    TPTP_i tptp_nn80;
+    TPTP_i tptp_n107;
+    TPTP_i tptp_nn7;
+    TPTP_i tptp_nn108;
+    TPTP_i tptp_n72;
+    TPTP_i tptp_nn24;
+    TPTP_i tptp_n4;
+    TPTP_i tptp_n22;
+    TPTP_i tptp_n21;
+    TPTP_i tptp_n126;
+    TPTP_i tptp_nn111;
+    TPTP_i tptp_nn26;
+    TPTP_i tptp_nn62;
+    TPTP_i tptp_nn13;
+    TPTP_i tptp_n89;
+    TPTP_i tptp_n84;
+    TPTP_i tptp_nn50;
+    TPTP_i tptp_nn4;
+    TPTP_i tptp_nn17;
+    TPTP_i tptp_nn97;
+    TPTP_i tptp_nn47;
+    TPTP_i tptp_n11;
+    TPTP_i tptp_n82;
+    TPTP_i tptp_n93;
+    TPTP_i tptp_nn110;
+    TPTP_i tptp_nn127;
+    TPTP_i tptp_n58;
+    TPTP_i tptp_nn14;
+    TPTP_i tptp_n31;
+    TPTP_i tptp_n16;
+    TPTP_i tptp_nn75;
+    TPTP_i tptp_nn67;
+    TPTP_i tptp_nn112;
+    TPTP_i tptp_nn28;
+    TPTP_i tptp_nn78;
+    TPTP_i tptp_n52;
+    TPTP_i tptp_nn73;
+    TPTP_i tptp_n127;
+    TPTP_i tptp_n70;
+    TPTP_i tptp_nn109;
+    TPTP_i tptp_nn94;
+    TPTP_i tptp_nn115;
+    TPTP_i tptp_nn31;
+    TPTP_i tptp_nn9;
+    TPTP_i tptp_n40;
+    TPTP_i tptp_n121;
+    TPTP_i tptp_n36;
+    TPTP_i tptp_nn120;
+    TPTP_i tptp_nn52;
+    TPTP_i tptp_nn12;
+    TPTP_i tptp_n108;
+    TPTP_i tptp_n28;
+    TPTP_i tptp_n124;
+    TPTP_i tptp_n63;
+    TPTP_i tptp_n74;
+    TPTP_i tptp_n43;
+    TPTP_i tptp_n105;
+    TPTP_i tptp_nn29;
+    TPTP_i tptp_nn63;
+    TPTP_i tptp_n12;
+    TPTP_i tptp_nn33;
+    TPTP_i tptp_nn90;
+    TPTP_i tptp_nn116;
+    TPTP_i tptp_nn20;
+    TPTP_i tptp_n71;
+    TPTP_i tptp_nn91;
+    TPTP_i tptp_nn86;
+    TPTP_i tptp_n92;
+    TPTP_i tptp_nn10;
+    TPTP_i tptp_nn53;
+    TPTP_i tptp_n14;
+    TPTP_i tptp_nn22;
+    TPTP_i tptp_nn42;
+    TPTP_i tptp_nn15;
+    TPTP_i tptp_n33;
+    TPTP_i tptp_n122;
+    TPTP_i tptp_n17;
+    TPTP_i tptp_nn88;
+    TPTP_i tptp_n44;
+    TPTP_i tptp_n37;
+    TPTP_i tptp_nn6;
+    TPTP_i tptp_n100;
+    TPTP_i tptp_nn96;
+    TPTP_i tptp_nn41;
+    TPTP_i tptp_nn57;
+    TPTP_i tptp_nn121;
+    TPTP_i tptp_nn126;
+    TPTP_i tptp_n24;
+    TPTP_i tptp_nn32;
+    TPTP_i tptp_nn113;
+    TPTP_i tptp_nn83;
+    TPTP_i tptp_n87;
+    TPTP_i tptp_nn44;
+    TPTP_i tptp_nn81;
+    TPTP_i tptp_n125;
+    TPTP_i tptp_n123;
+    TPTP_i tptp_nn5;
+    TPTP_i tptp_nn54;
+    TPTP_i tptp_n60;
+    TPTP_i tptp_n115;
+    TPTP_i tptp_n61;
+    TPTP_i tptp_nn89;
+    TPTP_i tptp_n47;
+    TPTP_i tptp_nn43;
+    TPTP_i tptp_n27;
+    TPTP_i tptp_nn119;
+    TPTP_i tptp_nn102;
+    TPTP_i tptp_nn101;
+    TPTP_i tptp_nn118;
+    TPTP_i tptp_n69;
+    TPTP_i tptp_nn76;
+    TPTP_i tptp_n99;
+    TPTP_i tptp_nn39;
+    TPTP_i tptp_n75;
+    TPTP_i tptp_nn60;
+    TPTP_i tptp_nn92;
+    TPTP_i tptp_n29;
+    TPTP_i tptp_nn93;
+    TPTP_i tptp_n45;
+    TPTP_i tptp_nn128;
+    TPTP_i tptp_n83;
+    TPTP_i tptp_n104;
+    TPTP_i tptp_n41;
+    TPTP_i tptp_n30;
+    TPTP_i tptp_n102;
+    TPTP_i tptp_nn125;
+    TPTP_i tptp_nn69;
+    TPTP_i tptp_nn23;
+    TPTP_i tptp_n50;
+    TPTP_i tptp_nn34;
+    TPTP_i tptp_nn117;
+    TPTP_i tptp_nn18;
+    TPTP_i tptp_n110;
+    TPTP_i tptp_nn11;
+    TPTP_i tptp_n26;
+    TPTP_i tptp_nn106;
+    TPTP_i tptp_nn3;
+    TPTP_i tptp_nn104;
+    TPTP_i tptp_nn37;
+    TPTP_i tptp_nn45;
+    TPTP_i tptp_nn123;
+    TPTP_i tptp_n20;
+    TPTP_i tptp_nn2;
+    TPTP_i tptp_nn72;
+    TPTP_i tptp_n25;
+    TPTP_i tptp_nn99;
+    TPTP_i tptp_nn56;
+    TPTP_i tptp_n59;
+    TPTP_i tptp_n101;
+    TPTP_i tptp_n85;
+    TPTP_i tptp_n67;
+    TPTP_i tptp_nn85;
+    TPTP_i tptp_nn30;
+    TPTP_i tptp_n15;
+    TPTP_i tptp_n62;
+    TPTP_i tptp_nn35;
+    TPTP_i tptp_n32;
+    TPTP_i tptp_n18;
+    TPTP_i tptp_nn1;
+    TPTP_i tptp_nn16;
+    TPTP_i tptp_n103;
+    TPTP_i tptp_n119;
+    TPTP_i tptp_nn55;
+    TPTP_i tptp_n48;
+    TPTP_i tptp_nn36;
+    TPTP_i tptp_n88;
+    TPTP_i tptp_nn27;
+    TPTP_i tptp_n53;
+    TPTP_i tptp_n97;
+    TPTP_i tptp_n34;
+    TPTP_i tptp_n65;
+    TPTP_i tptp_nn65;
+    TPTP_i tptp_n113;
+    TPTP_i tptp_nn66;
+    TPTP_i tptp_nn48;
+    TPTP_i tptp_n49;
+    TPTP_i tptp_nn124;
+    TPTP_i tptp_n120;
+    TPTP_i tptp_n95;
+    TPTP_i tptp_n73;
+    TPTP_i tptp_n78;
+    TPTP_i tptp_nn107;
+    TPTP_i tptp_nn122;
+    TPTP_i tptp_n51;
+    TPTP_i tptp_n68;
+    TPTP_i tptp_nn59;
+    TPTP_i tptp_nn74;
+    TPTP_i tptp_n76;
+    TPTP_i tptp_nn61;
+    TPTP_i tptp_n64;
+    TPTP_i tptp_n66;
+    TPTP_i tptp_nn87;
+    TPTP_i tptp_nn64;
+    TPTP_i tptp_nn40;
+    TPTP_i tptp_nn103;
+    TPTP_i tptp_nn46;
+    TPTP_i tptp_n19;
+    TPTP_i tptp_n10;
+    TPTP_i tptp_nn71;
+    TPTP_i tptp_n116;
+    TPTP_i tptp_n57;
+    TPTP_i tptp_nn38;
+    TPTP_i tptp_n98;
+    TPTP_i tptp_n38;
+    TPTP_i tptp_nn82;
+    TPTP_i tptp_n81;
+    TPTP_i tptp_n117;
+    TPTP_i tptp_n96;
+    TPTP_i tptp_n80;
+    TPTP_i tptp_nn98;
+    TPTP_i tptp_nn77;
+    TPTP_i tptp_nn95;
+    TPTP_i tptp_n109;
+    TPTP_i tptp_n42;
+    TPTP_i tptp_n111;
+    TPTP_i tptp_nn21;
+    TPTP_i tptp_nn114;
+    TPTP_i tptp_n94;
+    TPTP_i tptp_nn68;
+    TPTP_i tptp_n79;
+    TPTP_i tptp_n91;
+    TPTP_i tptp_nn49;
+    TPTP_i tptp_nn84;
+    TPTP_i tptp_n46;
+    TPTP_i tptp_n56;
+    TPTP_i tptp_nn25;
+    TPTP_i tptp_n13;
+    TPTP_i tptp_nn70;
+    TPTP_i tptp_n39;
+    TPTP_i tptp_nn100;
+    TPTP_i tptp_nn105;
+    TPTP_i tptp_n86;
+    TPTP_i tptp_nn79;
+    TPTP_i tptp_n54;
+    TPTP_i tptp_nn19;
+    TPTP_i tptp_n114;
+    TPTP_i tptp_n112;
+    TPTP_i tptp_n35;
+}
+
+\predicates {
+    tptp_rdn_translate(TPTP_i, TPTP_i);
+    tptp_rdn_positive_less(TPTP_i, TPTP_i);
+    tptp_rdn_non_zero(TPTP_i);
+    tptp_less(TPTP_i, TPTP_i);
+    tptp_rdn_non_zero_digit(TPTP_i);
+    tptp_sum(TPTP_i, TPTP_i, TPTP_i);
+    tptp_less_or_equal(TPTP_i, TPTP_i);
+    tptp_rdn_digit_add(TPTP_i, TPTP_i, TPTP_i, TPTP_i);
+    tptp_rdn_add_with_carry(TPTP_i, TPTP_i, TPTP_i, TPTP_i);
+    tptp_difference(TPTP_i, TPTP_i, TPTP_i);
+}
+
+\problem {
+    tptp_rdn_translate(tptp_n23, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn58, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn51, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n77, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n90, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n55, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n118, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn8, tptp_rdn_neg(tptp_rdnn(tptp_n8))),
+    tptp_rdn_translate(tptp_n106, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn80, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n107, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn7, tptp_rdn_neg(tptp_rdnn(tptp_n7))),
+    tptp_rdn_translate(tptp_nn108, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n72, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn24, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n22, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n21, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n126, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn111, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn26, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn62, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn13, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n89, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n84, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn50, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn4, tptp_rdn_neg(tptp_rdnn(tptp_n4))),
+    tptp_rdn_translate(tptp_nn17, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn97, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn47, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n11, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n82, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n93, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn110, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn127, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n58, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn14, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n31, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n16, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn75, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn67, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn112, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn28, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn78, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n52, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn73, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n127, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n70, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn109, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn94, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn115, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn31, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn9, tptp_rdn_neg(tptp_rdnn(tptp_n9))),
+    tptp_rdn_translate(tptp_n40, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n121, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n36, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn120, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn52, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn12, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n1, tptp_rdn_pos(tptp_rdnn(tptp_n1))),
+    tptp_rdn_translate(tptp_n108, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n28, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n124, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n8, tptp_rdn_pos(tptp_rdnn(tptp_n8))),
+    tptp_rdn_translate(tptp_n63, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n74, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n43, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n105, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn29, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn63, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n12, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn33, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn90, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn116, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn20, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n71, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn91, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn86, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n92, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn10, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn53, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n14, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn22, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn42, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn15, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n33, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n122, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n17, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn88, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n44, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n37, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn6, tptp_rdn_neg(tptp_rdnn(tptp_n6))),
+    tptp_rdn_translate(tptp_n100, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn96, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn41, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn57, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn121, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn126, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n7, tptp_rdn_pos(tptp_rdnn(tptp_n7))),
+    tptp_rdn_translate(tptp_n24, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn32, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn113, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn83, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n87, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn44, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn81, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n125, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n123, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn5, tptp_rdn_neg(tptp_rdnn(tptp_n5))),
+    tptp_rdn_translate(tptp_nn54, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n60, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n115, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n61, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn89, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n47, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn43, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n27, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn119, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn102, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn101, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn118, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n69, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn76, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n99, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn39, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n75, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn60, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn92, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n29, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn93, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n45, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn128, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n83, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n104, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n41, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n30, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n102, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn125, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn69, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn23, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n50, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn34, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn117, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn18, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n110, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn11, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n26, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn106, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn3, tptp_rdn_neg(tptp_rdnn(tptp_n3))),
+    tptp_rdn_translate(tptp_nn104, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn37, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn45, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn123, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n20, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n9, tptp_rdn_pos(tptp_rdnn(tptp_n9))),
+    tptp_rdn_translate(tptp_nn2, tptp_rdn_neg(tptp_rdnn(tptp_n2))),
+    tptp_rdn_translate(tptp_nn72, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n25, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_nn99, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn56, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n59, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n101, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n85, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n67, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn85, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn30, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n15, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n62, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn35, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n32, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n18, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn1, tptp_rdn_neg(tptp_rdnn(tptp_n1))),
+    tptp_rdn_translate(tptp_nn16, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n103, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n119, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n5, tptp_rdn_pos(tptp_rdnn(tptp_n5))),
+    tptp_rdn_translate(tptp_nn55, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n48, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn36, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n88, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn27, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n53, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n97, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n34, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n65, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn65, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n113, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn66, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn48, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n49, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn124, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n120, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n95, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n73, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n78, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn107, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn122, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n51, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_n68, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn59, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn74, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n2, tptp_rdn_pos(tptp_rdnn(tptp_n2))),
+    tptp_rdn_translate(tptp_n76, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn61, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n64, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n66, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn87, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n4, tptp_rdn_pos(tptp_rdnn(tptp_n4))),
+    tptp_rdn_translate(tptp_nn64, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_nn40, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn103, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn46, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n19, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n10, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn71, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n116, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n57, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn38, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_n98, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n38, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn82, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n81, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n117, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n96, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n80, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn98, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn77, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_nn95, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n109, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n42, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n111, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn21, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n6, tptp_rdn_pos(tptp_rdnn(tptp_n6))),
+    tptp_rdn_translate(tptp_nn114, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n94, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_nn68, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n6)))),
+    tptp_rdn_translate(tptp_n79, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n91, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n9)))),
+    tptp_rdn_translate(tptp_n0, tptp_rdn_pos(tptp_rdnn(tptp_n0))),
+    tptp_rdn_translate(tptp_nn49, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_nn84, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_n46, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n4)))),
+    tptp_rdn_translate(tptp_n56, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn25, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n2)))),
+    tptp_rdn_translate(tptp_n13, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_nn70, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n39, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n3)))),
+    tptp_rdn_translate(tptp_nn100, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_nn105, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdn(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n3, tptp_rdn_pos(tptp_rdnn(tptp_n3))),
+    tptp_rdn_translate(tptp_n86, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n8)))),
+    tptp_rdn_translate(tptp_nn79, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n7)))),
+    tptp_rdn_translate(tptp_n54, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n5)))),
+    tptp_rdn_translate(tptp_nn19, tptp_rdn_neg(tptp_rdn(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n1)))),
+    tptp_rdn_translate(tptp_n114, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n4), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n112, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n2), tptp_rdn(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1))))),
+    tptp_rdn_translate(tptp_n35, tptp_rdn_pos(tptp_rdn(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n3)))),
+    \forall TPTP_i sv_0; (\forall TPTP_i sv_1; (\forall TPTP_i sv_2; ((tptp_rdn_non_zero(sv_2) -> tptp_rdn_positive_less(tptp_rdnn(sv_0), tptp_rdn(tptp_rdnn(sv_1), sv_2)))))),
+    \forall TPTP_i sv_3; (\forall TPTP_i sv_4; (\forall TPTP_i sv_5; (\forall TPTP_i sv_6; ((((tptp_rdn_positive_less(sv_5, sv_6) & tptp_rdn_translate(sv_4, tptp_rdn_pos(sv_6))) & tptp_rdn_translate(sv_3, tptp_rdn_pos(sv_5))) -> tptp_less(sv_3, sv_4)))))),
+    \forall TPTP_i sv_7; (\forall TPTP_i sv_8; (\forall TPTP_i sv_9; (\forall TPTP_i sv_10; ((tptp_rdn_positive_less(sv_8, sv_10) -> tptp_rdn_positive_less(tptp_rdn(tptp_rdnn(sv_7), sv_8), tptp_rdn(tptp_rdnn(sv_9), sv_10))))))),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n9)),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n8)),
+    \forall TPTP_i sv_11; ((tptp_rdn_non_zero_digit(tptp_rdnn(sv_11)) -> tptp_rdn_non_zero(tptp_rdnn(sv_11)))),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n2)),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n4)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n5)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n4)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n2)),
+    \forall TPTP_i sv_12; (\forall TPTP_i sv_13; ((tptp_rdn_non_zero(sv_13) -> tptp_rdn_non_zero(tptp_rdn(tptp_rdnn(sv_12), sv_13))))),
+    \forall TPTP_i sv_14; (\forall TPTP_i sv_15; (\forall TPTP_i sv_16; (\forall TPTP_i sv_17; (((tptp_rdn_translate(sv_15, tptp_rdn_pos(sv_17)) & tptp_rdn_translate(sv_14, tptp_rdn_neg(sv_16))) -> tptp_less(sv_14, sv_15)))))),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n5)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n7)),
+    \forall TPTP_i sv_18; (\forall TPTP_i sv_19; (\forall TPTP_i sv_20; (((tptp_rdn_positive_less(tptp_rdnn(sv_18), tptp_rdnn(sv_19)) & tptp_rdn_positive_less(tptp_rdnn(sv_19), tptp_rdnn(sv_20))) -> tptp_rdn_positive_less(tptp_rdnn(sv_18), tptp_rdnn(sv_20)))))),
+    \forall TPTP_i sv_21; (\forall TPTP_i sv_22; (((!(tptp_less(sv_22, sv_21)) & !(sv_21 = sv_22)) <-> tptp_less(sv_21, sv_22)))),
+    \forall TPTP_i sv_23; (\forall TPTP_i sv_24; (\forall TPTP_i sv_25; (\forall TPTP_i sv_26; ((((tptp_rdn_translate(sv_24, tptp_rdn_neg(sv_26)) & tptp_rdn_positive_less(sv_26, sv_25)) & tptp_rdn_translate(sv_23, tptp_rdn_neg(sv_25))) -> tptp_less(sv_23, sv_24)))))),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n1)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n8)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_27; (\forall TPTP_i sv_28; (\forall TPTP_i sv_29; (((tptp_less(sv_29, sv_28) & tptp_sum(sv_27, tptp_n1, sv_28)) -> tptp_less_or_equal(sv_29, sv_27))))),
+    \forall TPTP_i sv_30; (\forall TPTP_i sv_31; (\forall TPTP_i sv_32; (((tptp_rdn_positive_less(tptp_rdnn(sv_30), tptp_rdnn(sv_32)) & tptp_rdn_non_zero(sv_31)) -> tptp_rdn_positive_less(tptp_rdn(tptp_rdnn(sv_30), sv_31), tptp_rdn(tptp_rdnn(sv_32), sv_31)))))),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n7)),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n6)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n3)),
+    \forall TPTP_i sv_33; (\forall TPTP_i sv_34; (((tptp_less(sv_33, sv_34) | (sv_34 = sv_33)) <-> tptp_less_or_equal(sv_33, sv_34)))),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n3)),
+    tptp_rdn_positive_less(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n6)),
+    tptp_rdn_non_zero_digit(tptp_rdnn(tptp_n9)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_35; (\forall TPTP_i sv_36; (\forall TPTP_i sv_37; (\forall TPTP_i sv_38; (\forall TPTP_i sv_39; ((((tptp_rdn_translate(sv_35, tptp_rdn_neg(sv_38)) & tptp_sum(sv_36, sv_35, sv_37)) & tptp_rdn_translate(sv_36, tptp_rdn_pos(sv_39))) -> tptp_sum(sv_35, sv_36, sv_37))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_40; (\forall TPTP_i sv_41; (\forall TPTP_i sv_42; (\forall TPTP_i sv_43; (\forall TPTP_i sv_44; (\forall TPTP_i sv_45; (\forall TPTP_i sv_46; (\forall TPTP_i sv_47; (\forall TPTP_i sv_48; (\forall TPTP_i sv_49; (\forall TPTP_i sv_50; ((((((((tptp_rdn_add_with_carry(tptp_rdnn(sv_50), sv_42, sv_44, sv_46) & tptp_rdn_non_zero(sv_44)) & tptp_rdn_non_zero(sv_46)) & tptp_rdn_non_zero(sv_42)) & tptp_rdn_digit_add(tptp_rdnn(sv_48), tptp_rdnn(sv_49), tptp_rdnn(sv_50), tptp_rdnn(tptp_n0))) & tptp_rdn_digit_add(tptp_rdnn(sv_47), tptp_rdnn(sv_40), tptp_rdnn(sv_45), tptp_rdnn(sv_49))) & tptp_rdn_digit_add(tptp_rdnn(sv_41), tptp_rdnn(sv_43), tptp_rdnn(sv_47), tptp_rdnn(sv_48))) -> tptp_rdn_add_with_carry(tptp_rdnn(sv_40), tptp_rdn(tptp_rdnn(sv_41), sv_42), tptp_rdn(tptp_rdnn(sv_43), sv_44), tptp_rdn(tptp_rdnn(sv_45), sv_46)))))))))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_51; (\forall TPTP_i sv_52; (\forall TPTP_i sv_53; (\forall TPTP_i sv_54; (\forall TPTP_i sv_55; (\forall TPTP_i sv_56; ((((((tptp_rdn_translate(sv_52, tptp_rdn_neg(sv_55)) & tptp_rdn_translate(sv_53, tptp_rdn_pos(sv_56))) & tptp_rdn_add_with_carry(tptp_rdnn(tptp_n0), sv_55, sv_56, sv_54)) & tptp_rdn_positive_less(sv_55, sv_54)) & tptp_rdn_translate(sv_51, tptp_rdn_pos(sv_54))) -> tptp_sum(sv_51, sv_52, sv_53)))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_57; (\forall TPTP_i sv_58; (\forall TPTP_i sv_59; ((tptp_sum(sv_58, sv_59, sv_57) <-> tptp_difference(sv_57, sv_58, sv_59))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_60; (\forall TPTP_i sv_61; (\forall TPTP_i sv_62; (\forall TPTP_i sv_63; (\forall TPTP_i sv_64; (\forall TPTP_i sv_65; (\forall TPTP_i sv_66; ((((tptp_rdn_digit_add(tptp_rdnn(sv_61), tptp_rdnn(sv_62), tptp_rdnn(sv_63), tptp_rdnn(sv_65)) & tptp_rdn_digit_add(tptp_rdnn(sv_65), tptp_rdnn(sv_66), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n0))) & tptp_rdn_digit_add(tptp_rdnn(sv_63), tptp_rdnn(sv_60), tptp_rdnn(sv_64), tptp_rdnn(sv_66))) -> tptp_rdn_add_with_carry(tptp_rdnn(sv_60), tptp_rdnn(sv_61), tptp_rdnn(sv_62), tptp_rdn(tptp_rdnn(sv_64), tptp_rdnn(tptp_n1))))))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_67; (\forall TPTP_i sv_68; (\forall TPTP_i sv_69; (((tptp_rdn_translate(sv_68, tptp_rdn_neg(sv_69)) & tptp_rdn_translate(sv_67, tptp_rdn_pos(sv_69))) -> tptp_sum(sv_67, sv_68, tptp_n0))))),
+    \forall TPTP_i sv_70; (\forall TPTP_i sv_71; (\forall TPTP_i sv_72; (\forall TPTP_i sv_73; (\forall TPTP_i sv_74; (\forall TPTP_i sv_75; ((tptp_rdn_add_with_carry(tptp_rdnn(sv_70), tptp_rdnn(sv_73), tptp_rdn(tptp_rdnn(sv_71), sv_72), tptp_rdn(tptp_rdnn(sv_74), sv_75)) -> tptp_rdn_add_with_carry(tptp_rdnn(sv_70), tptp_rdn(tptp_rdnn(sv_71), sv_72), tptp_rdnn(sv_73), tptp_rdn(tptp_rdnn(sv_74), sv_75))))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_76; (\forall TPTP_i sv_77; (\forall TPTP_i sv_78; (\forall TPTP_i sv_79; (((tptp_sum(sv_76, sv_78, sv_79) & tptp_sum(sv_76, sv_77, sv_79)) -> (sv_77 = sv_78)))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_80; (\forall TPTP_i sv_81; (\forall TPTP_i sv_82; (\forall TPTP_i sv_83; (((tptp_sum(sv_80, sv_81, sv_82) & tptp_sum(sv_80, sv_81, sv_83)) -> (sv_83 = sv_82)))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_84; (\forall TPTP_i sv_85; (\forall TPTP_i sv_86; (\forall TPTP_i sv_87; (\forall TPTP_i sv_88; (\forall TPTP_i sv_89; (((((tptp_rdn_add_with_carry(tptp_rdnn(tptp_n0), sv_87, sv_88, sv_89) & tptp_rdn_translate(sv_86, tptp_rdn_neg(sv_89))) & tptp_rdn_translate(sv_85, tptp_rdn_neg(sv_88))) & tptp_rdn_translate(sv_84, tptp_rdn_neg(sv_87))) -> tptp_sum(sv_84, sv_85, sv_86)))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_90; (\forall TPTP_i sv_91; (\forall TPTP_i sv_92; (\forall TPTP_i sv_93; (\forall TPTP_i sv_94; (\forall TPTP_i sv_95; ((((((tptp_rdn_translate(sv_90, tptp_rdn_pos(sv_93)) & tptp_rdn_translate(sv_91, tptp_rdn_neg(sv_94))) & tptp_rdn_translate(sv_92, tptp_rdn_neg(sv_95))) & tptp_rdn_add_with_carry(tptp_rdnn(tptp_n0), sv_93, sv_95, sv_94)) & tptp_rdn_positive_less(sv_93, sv_94)) -> tptp_sum(sv_90, sv_91, sv_92)))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_96; (\forall TPTP_i sv_97; (\forall TPTP_i sv_98; (\forall TPTP_i sv_99; (\forall TPTP_i sv_100; (\forall TPTP_i sv_101; (\forall TPTP_i sv_102; (\forall TPTP_i sv_103; (\forall TPTP_i sv_104; (\forall TPTP_i sv_105; (((((((tptp_rdn_digit_add(tptp_rdnn(sv_97), tptp_rdnn(sv_98), tptp_rdnn(sv_102), tptp_rdnn(sv_103)) & tptp_rdn_digit_add(tptp_rdnn(sv_102), tptp_rdnn(sv_96), tptp_rdnn(sv_100), tptp_rdnn(sv_104))) & tptp_rdn_digit_add(tptp_rdnn(sv_103), tptp_rdnn(sv_104), tptp_rdnn(sv_105), tptp_rdnn(tptp_n0))) & tptp_rdn_non_zero(sv_99)) & tptp_rdn_non_zero(sv_101)) & tptp_rdn_add_with_carry(tptp_rdnn(sv_105), tptp_rdnn(tptp_n0), sv_99, sv_101)) -> tptp_rdn_add_with_carry(tptp_rdnn(sv_96), tptp_rdnn(sv_97), tptp_rdn(tptp_rdnn(sv_98), sv_99), tptp_rdn(tptp_rdnn(sv_100), sv_101))))))))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n2), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    \forall TPTP_i sv_106; (\forall TPTP_i sv_107; (\forall TPTP_i sv_108; (\forall TPTP_i sv_109; (\forall TPTP_i sv_110; (((tptp_rdn_digit_add(tptp_rdnn(sv_110), tptp_rdnn(sv_106), tptp_rdnn(sv_109), tptp_rdnn(tptp_n0)) & tptp_rdn_digit_add(tptp_rdnn(sv_107), tptp_rdnn(sv_108), tptp_rdnn(sv_110), tptp_rdnn(tptp_n0))) -> tptp_rdn_add_with_carry(tptp_rdnn(sv_106), tptp_rdnn(sv_107), tptp_rdnn(sv_108), tptp_rdnn(sv_109)))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_111; (\forall TPTP_i sv_112; (\forall TPTP_i sv_113; (\forall TPTP_i sv_114; (((tptp_sum(sv_112, sv_113, sv_114) & tptp_sum(sv_111, sv_113, sv_114)) -> (sv_112 = sv_111)))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n5), tptp_rdnn(tptp_n3), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n0)),
+    \forall TPTP_i sv_115; (\forall TPTP_i sv_116; (\forall TPTP_i sv_117; (\forall TPTP_i sv_118; (\forall TPTP_i sv_119; (\forall TPTP_i sv_120; (((((tptp_rdn_translate(sv_117, tptp_rdn_pos(sv_120)) & tptp_rdn_add_with_carry(tptp_rdnn(tptp_n0), sv_118, sv_119, sv_120)) & tptp_rdn_translate(sv_116, tptp_rdn_pos(sv_119))) & tptp_rdn_translate(sv_115, tptp_rdn_pos(sv_118))) -> tptp_sum(sv_115, sv_116, sv_117)))))))),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n7), tptp_rdnn(tptp_n4), tptp_rdnn(tptp_n1), tptp_rdnn(tptp_n1)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0), tptp_rdnn(tptp_n6), tptp_rdnn(tptp_n0)),
+    tptp_rdn_digit_add(tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n9), tptp_rdnn(tptp_n8), tptp_rdnn(tptp_n1))
+==>
+    \exists TPTP_i sv_121; (tptp_sum(sv_121, tptp_nn2, tptp_n3))
+}

--- a/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableMap.java
+++ b/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableMap.java
@@ -276,7 +276,8 @@ public final class DefaultImmutableMap<S, T> implements ImmutableMap<S, T> {
     public int hashCode() {
         int hashCode = 1;
         for (ImmutableMapEntry<S, T> stImmutableMapEntry : this) {
-            hashCode += 7 * stImmutableMapEntry.hashCode();
+            hashCode += (Objects.hashCode(stImmutableMapEntry.key()) ^
+                    Objects.hashCode(stImmutableMapEntry.value()));
         }
         return hashCode;
     }

--- a/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
+++ b/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
@@ -63,9 +63,12 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
     }
 
     public static <T> ImmutableSet<T> fromCollection(Collection<T> seq) {
-        // ensure set property, each element only once and order of collection maintained
-        // to avoid regression with previous behavior
-        return seq.isEmpty() ? nil() : fromSet(new LinkedHashSet<>(seq));
+        if (seq instanceof Set<T> set) {
+            return fromSet(set);
+        } else {
+            // ensure set property "each element only once"
+            return seq.isEmpty() ? nil() : fromImmutableList(ImmutableList.fromList(seq));
+        }
     }
 
     public static <T> ImmutableSet<T> fromSet(Set<T> set) {

--- a/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
+++ b/key.util/src/main/java/org/key_project/util/collection/DefaultImmutableSet.java
@@ -63,7 +63,14 @@ public class DefaultImmutableSet<T extends @Nullable Object> implements Immutabl
     }
 
     public static <T> ImmutableSet<T> fromCollection(Collection<T> seq) {
-        return new DefaultImmutableSet<>(ImmutableList.fromList(seq));
+        // ensure set property, each element only once and order of collection maintained
+        // to avoid regression with previous behavior
+        return seq.isEmpty() ? nil() : fromSet(new LinkedHashSet<>(seq));
+    }
+
+    public static <T> ImmutableSet<T> fromSet(Set<T> set) {
+        // we can rely on the set property here
+        return set.isEmpty() ? nil() : new DefaultImmutableSet<>(ImmutableList.fromList(set));
     }
 
     // private static HashSet<String> previousComplains = new HashSet<>();

--- a/key.util/src/main/java/org/key_project/util/collection/ImmutableList.java
+++ b/key.util/src/main/java/org/key_project/util/collection/ImmutableList.java
@@ -111,7 +111,9 @@ public interface ImmutableList<T extends @Nullable Object>
     /// @param list the list to wrap
     /// @return an ImmutableList containing the elements of the input list
     static <T extends @Nullable Object> ImmutableList<T> fromList(List<T> list) {
-        return new ImmutableListList<>(new ArrayList<>(list));
+        // Used constructor is public one which copies list into an ArrayList, so
+        // no copy needed here
+        return new ImmutableListList<>(list);
     }
 
     /// Creates an [ImmutableList] from an array.

--- a/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
+++ b/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.collection;
 
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -222,6 +224,14 @@ public class TestImmutables {
         assertTrue(result);
         result = l.exists(x -> x == 1_999_998);
         assertFalse(result);
+    }
+
+    @Test
+    public void testSetFromCollectionHasNoDuplicates() {
+        List<Integer> l = List.of(1, 2, 3, 2);
+        ImmutableSet<Integer> s = DefaultImmutableSet.fromCollection(l);
+        assertEquals(s.size(), l.size() - 1,
+            "Set size should be one less than list size as list contains one duplicate");
     }
 
 }

--- a/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
+++ b/key.util/src/test/java/org/key_project/util/collection/TestImmutables.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package org.key_project.util.collection;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -234,4 +235,22 @@ public class TestImmutables {
             "Set size should be one less than list size as list contains one duplicate");
     }
 
+    @Test
+    public void testListNotLeaked() {
+        // ensures that optimisation with less copying does not lead to a leak
+        List<Integer> original = List.of(1, 2, 3, 4);
+        List<Integer> mutableCopyOfOriginal = new ArrayList<>(original);
+        int size = mutableCopyOfOriginal.size();
+        ImmutableList<Integer> immList = ImmutableList.fromList(mutableCopyOfOriginal);
+        assertEquals(immList.toList(), original,
+            "ImmutableList size should be equal to original list");
+        mutableCopyOfOriginal.add(10);
+        assertEquals(mutableCopyOfOriginal.size(), size + 1, "List size should have increased");
+        assertEquals(immList.toList(), original, "ImmutableList should be equal to original list");
+        mutableCopyOfOriginal.removeLast();
+        mutableCopyOfOriginal.removeFirst();
+        assertEquals(mutableCopyOfOriginal.size(), size - 1,
+            "List size should be one less than original list");
+        assertEquals(immList.toList(), original, "ImmutableList should be equal to original list");
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

Minor tweaks to Immutable data structures:

- DefaultImmutableSet: ensure set property "no duplicates" maintained when constructing from a Collection
- ImmutableList: avoid unnecessary copying of list
- DefaultImmutableMap: 
       Use hashcode computation as by java.util.HashMap to reduce collision.
       Data from a 'pathological' case taken from TPTP:
       **Context**: The problem is in examples/standard_key/pred_log/tptp/NUM/NUM325+1.key 
       It cannot be solved at the moment by KeY as it leads after ~180 nodes to an OOM (that is part of another optimisation effort)
       **Results**:
         - New hashcode: OOM reached within 105s (187 nodes)
        - Old hashcode: OOM reached after 900s (187 nodes)
      So we reach an OOM faster :-) after same amount of work.

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->


## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Refactoring (behaviour should not change or only minimally change)
- There are changes to the (Java) code

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I added new test case(s) for new functionality.
- I have tested the feature as follows: standard CI tests 
- I have checked that runtime performance has not deteriorated.

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
