### PR TITLE
Do not generate query axioms for methods without a body

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/speclang/QueryAxiom.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/speclang/QueryAxiom.java
@@ -174,6 +174,13 @@ public final class QueryAxiom extends ClassAxiom {
         // get real implementation of program method
         final IProgramMethod targetImpl =
             services.getJavaInfo().getProgramMethod(kjt, target.getName(), sig, kjt);
+
+        if (targetImpl.getMethodDeclaration().getBody() == null) {
+            // no method implementation available so using a query axiom
+            // that requires inlining of the body is not sensible.
+            return DefaultImmutableSet.nil();
+        }
+
         final MethodBodyStatement mbs = new MethodBodyStatement(targetImpl, selfProgSV,
             resultProgSV, new ImmutableArray<>(paramProgSVs));
         final StatementBlock sb = new StatementBlock(mbs);


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Related Issue

<!-- Please remove if this PR is not related to an issue. -->
<!-- Please add number if it is in answer to an issue. -->
This pull request relates to #3917 

## Intended Change

The "Query_Axiom_..." rules allow to expand method bodies of local queries. 
Some queries do not have bodies (e.g. the equals in the record Point3d from the example in #3917) so 
the rule can be applied but we get then stuck with a modality that contains a non-reducible method body statement.
This also prevents the usage of a contract. 

This PR does not create such an axiom for bodyless queries and thus the only matching rule is the general "Evaluate Query rule" which uses contracts (if method treatment does).

## Type of pull request

<!--- What types of changes does your code introduce? 
      Delete those lines that do not apply.      
-->

- Bug fix (non-breaking change which fixes an issue)
- There are changes to the (Java) code
- There are changes to the taclet rule base: in some cases query taclets are no longer generated. This is by construction sound.

## Ensuring quality

<!--- How did you make sure that the proposed change improves the code base? 
      Delete those lines that do not apply.
      Please make an effort to delete as few lines as possible. :-)
-->
    
- I have tested the feature as follows: example of PR #3917 and checked that query axioms for other methods are still generated

## Additional information and contact(s)

<!-- Add further information to help the reviewer understand the request.
     Leave empty if you are sure the reviewer does not need more
     
     Who apart from yourself is involved in this pull request?
     Use @mentions to refer to them here.
     Use Co-Authored-By in your git commits if applicable. -->
     
<!-- DRAFT MODE: Please note that on the button to submit this pull
     request you can select between submitting a merge-ready request
     or one in draft mode (still evolving). 
     Please use the draft mode unless you think that your proposal
     should be brought onto master in the current form. -->

The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
